### PR TITLE
firewire: compile with FFADO versions < 9 again

### DIFF
--- a/linux/firewire/JackFFADODriver.cpp
+++ b/linux/firewire/JackFFADODriver.cpp
@@ -46,6 +46,13 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackCompilerDeps.h"
 #include "JackLockedEngine.h"
 
+// FFADO_API_VERSION was first defined with API_VERSION 9, so all previous
+// headers do not provide this define.
+#ifndef FFADO_API_VERSION
+extern "C" int ffado_streaming_set_period_size(ffado_device_t *dev,
+		unsigned int period) __attribute__((__weak__));
+#endif
+
 namespace Jack
 {
 


### PR DESCRIPTION
ffado_streaming_set_period_size() is exposed starting r2078 of FFADO.
To avoid a build dependency on ffado-svn in jack, we copy the prototype
declaration.

Since the symbol is defined as weak, no problems arise at runtime.
