### PR TITLE
jack_free() should be used to free memory returned by jack_return_ports()

### DIFF
--- a/example-clients/simple_client.c
+++ b/example-clients/simple_client.c
@@ -191,7 +191,7 @@ main (int argc, char *argv[])
 		fprintf (stderr, "cannot connect output ports\n");
 	}
 
-	free (ports);
+	jack_free (ports);
     
     /* install a signal handler to properly quits jack client */
 #ifdef WIN32


### PR DESCRIPTION
modified simple_client.c to use `jack_free()` instead of `free()` when appropriate
http://jackaudio.org/files/docs/html/jack_8h.html#a437010097629ac8124a56c752c02f299

> ```
> void jack_free (void * ptr)
> ```
> 
> The free function to be used on memory returned by jack_port_get_connections, jack_port_get_all_connections and jack_get_ports functions. This is MANDATORY on Windows when otherwise all nasty runtime version related crashes can occur. Developers are strongly encouraged to use this function instead of the standard "free" function in new code.
