### PR TITLE
add libopus support to netjack2

### DIFF
--- a/common/JackNetAdapter.cpp
+++ b/common/JackNetAdapter.cpp
@@ -102,6 +102,14 @@ namespace Jack
                     }
                     break;
             #endif
+            #if HAVE_OPUS
+                case 'O':
+                    if (param->value.i > 0) {
+                        fParams.fSampleEncoder = JackOpusEncoder;
+                        fParams.fKBps = param->value.i;
+                    }
+                    break;
+            #endif
                 case 'l' :
                     fParams.fNetworkLatency = param->value.i;
                     if (fParams.fNetworkLatency > NETWORK_MAX_LATENCY) {
@@ -419,6 +427,11 @@ extern "C"
     #if HAVE_CELT
         value.i = -1;
         jack_driver_descriptor_add_parameter(desc, &filler, "celt", 'c', JackDriverParamInt, &value, NULL, "Set CELT encoding and number of kBits per channel", NULL);
+    #endif
+
+    #if HAVE_OPUS
+        value.i = -1;
+        jack_driver_descriptor_add_parameter(desc, &filler, "opus", 'O', JackDriverParamInt, &value, NULL, "Set Opus encoding and number of kBits per channel", NULL);
     #endif
 
         strcpy(value.str, "'hostname'");

--- a/common/JackNetDriver.h
+++ b/common/JackNetDriver.h
@@ -69,7 +69,7 @@ namespace Jack
 
             JackNetDriver(const char* name, const char* alias, JackLockedEngine* engine, JackSynchro* table,
                         const char* ip, int port, int mtu, int midi_input_ports, int midi_output_ports,
-                        char* net_name, uint transport_sync, int network_latency, int celt_encoding);
+                        char* net_name, uint transport_sync, int network_latency, int celt_encoding, int opus_encoding);
             virtual ~JackNetDriver();
 
             int Close();

--- a/common/JackNetInterface.cpp
+++ b/common/JackNetInterface.cpp
@@ -243,6 +243,10 @@ namespace Jack
             case JackCeltEncoder:
                 return new NetCeltAudioBuffer(&fParams, nports, buffer, fParams.fKBps);
             #endif
+            #if HAVE_OPUS
+            case JackOpusEncoder:
+                return new NetOpusAudioBuffer(&fParams, nports, buffer, fParams.fKBps);
+            #endif
         }
         return NULL;
     }

--- a/common/JackNetTool.h
+++ b/common/JackNetTool.h
@@ -62,6 +62,7 @@ namespace Jack
         JackFloatEncoder = 0,
         JackIntEncoder = 1,
         JackCeltEncoder = 2,
+        JackOpusEncoder = 3,
     };
 
 //session params ******************************************************************************
@@ -386,6 +387,50 @@ namespace Jack
 
             NetCeltAudioBuffer(session_params_t* params, uint32_t nports, char* net_buffer, int kbps);
             virtual ~NetCeltAudioBuffer();
+
+            // needed size in bytes for an entire cycle
+            size_t GetCycleSize();
+
+             // cycle duration in sec
+            float GetCycleDuration();
+            int GetNumPackets(int active_ports);
+
+            //jack<->buffer
+            int RenderFromJackPorts();
+            void RenderToJackPorts();
+
+            //network<->buffer
+            int RenderFromNetwork(int cycle, int sub_cycle, uint32_t port_num);
+            int RenderToNetwork(int sub_cycle, uint32_t  port_num);
+    };
+
+#endif
+
+#if HAVE_OPUS
+
+#include <opus/opus.h>
+#include <opus/opus_custom.h>
+
+    class SERVER_EXPORT NetOpusAudioBuffer : public NetAudioBuffer
+    {
+        private:
+
+            OpusCustomMode** fOpusMode;
+            OpusCustomEncoder** fOpusEncoder;
+            OpusCustomDecoder** fOpusDecoder;
+
+            int fCompressedSizeByte;
+            int fNumPackets;
+
+            size_t fLastSubPeriodBytesSize;
+
+            unsigned char** fCompressedBuffer;
+            void FreeOpus();
+
+        public:
+
+            NetOpusAudioBuffer(session_params_t* params, uint32_t nports, char* net_buffer, int kbps);
+            virtual ~NetOpusAudioBuffer();
 
             // needed size in bytes for an entire cycle
             size_t GetCycleSize();

--- a/common/jack/net.h
+++ b/common/jack/net.h
@@ -40,6 +40,7 @@ enum JackNetEncoder {
     JackFloatEncoder = 0,   // samples are transmitted as float
     JackIntEncoder = 1,     // samples are transmitted as 16 bits integer
     JackCeltEncoder = 2,    // samples are transmitted using CELT codec (http://www.celt-codec.org/)
+    JackOpusEncoder = 2,    // samples are transmitted using OPUS codec (http://www.opus-codec.org/)
 };
 
 typedef struct {

--- a/common/wscript
+++ b/common/wscript
@@ -68,7 +68,7 @@ def build(bld):
         ]
 
     includes = ['.', './jack', '..']
-    uselib = ["PTHREAD", "CELT"]
+    uselib = ["PTHREAD", "CELT", "OPUS"]
 
     if bld.env['IS_LINUX']:
         common_libsources += [
@@ -193,7 +193,7 @@ def build(bld):
         netlib.includes = includes
         netlib.name         = 'netlib'
         netlib.target       = 'jacknet'
-        netlib.use = ['SAMPLERATE', 'CELT', 'PTHREAD' , 'RT']
+        netlib.use = ['SAMPLERATE', 'CELT', 'OPUS', 'PTHREAD' , 'RT']
         netlib.install_path = '${LIBDIR}'
         netlib.source = [
             'JackNetAPI.cpp',

--- a/wscript
+++ b/wscript
@@ -173,6 +173,13 @@ def configure(conf):
         conf.define('HAVE_CELT_API_0_7', 0)
         conf.define('HAVE_CELT_API_0_5', 0)
 
+    conf.env['WITH_OPUS'] = False
+    if conf.check_cfg(package='opus', atleast_version='0.9.0' , args='--cflags --libs', mandatory=False):
+        if conf.check_cc(header_name='opus/opus_custom.h', mandatory=False):
+            conf.define('HAVE_OPUS', 1)
+            conf.env['WITH_OPUS'] = True
+
+
     conf.env['LIB_PTHREAD'] = ['pthread']
     conf.env['LIB_DL'] = ['dl']
     conf.env['LIB_RT'] = ['rt']
@@ -264,6 +271,7 @@ def configure(conf):
     display_msg('C++ compiler flags', repr(conf.env['CXXFLAGS']))
     display_msg('Linker flags', repr(conf.env['LINKFLAGS']))
     display_feature('Build doxygen documentation', conf.env['BUILD_DOXYGEN_DOCS'])
+    display_feature('Build Opus netjack2', conf.env['WITH_OPUS'])
     display_feature('Build with engine profiling', conf.env['BUILD_WITH_PROFILE'])
     display_feature('Build with 32/64 bits mixed mode', conf.env['BUILD_WITH_32_64'])
 


### PR DESCRIPTION
[Opus](http://www.opus-codec.org/) is the successor of CELT.
libcelt is being been removed from debian and other distributions.

This patch adds support for opus en/decoding of netjack2 audio packets.
