### PR TITLE
Opus Netjack fixes

### DIFF
--- a/common/JackNetOneDriver.cpp
+++ b/common/JackNetOneDriver.cpp
@@ -156,7 +156,6 @@ int JackNetOneDriver::AllocPorts()
 #if HAVE_OPUS
             OpusCustomMode *opus_mode = opus_custom_mode_create(netj.sample_rate, netj.period_size, NULL); // XXX free me in the end
             OpusCustomDecoder *decoder = opus_custom_decoder_create( opus_mode, 1, NULL );
-            opus_custom_decoder_init(decoder, opus_mode, 1);
             netj.capture_srcs = jack_slist_append(netj.capture_srcs, decoder);
 #endif
         } else {
@@ -217,7 +216,6 @@ int JackNetOneDriver::AllocPorts()
             opus_custom_encoder_ctl(oe, OPUS_SET_COMPLEXITY(10));
             opus_custom_encoder_ctl(oe, OPUS_SET_SIGNAL(OPUS_SIGNAL_MUSIC));
             opus_custom_encoder_ctl(oe, OPUS_SET_SIGNAL(OPUS_APPLICATION_RESTRICTED_LOWDELAY));
-            opus_custom_encoder_init(oe, opus_mode, 1);
             netj.playback_srcs = jack_slist_append(netj.playback_srcs, oe);
 #endif
         } else {

--- a/common/JackNetTool.cpp
+++ b/common/JackNetTool.cpp
@@ -749,10 +749,6 @@ namespace Jack
             opus_custom_encoder_ctl(fOpusEncoder[i], OPUS_SET_COMPLEXITY(10));
             opus_custom_encoder_ctl(fOpusEncoder[i], OPUS_SET_SIGNAL(OPUS_SIGNAL_MUSIC));
             opus_custom_encoder_ctl(fOpusEncoder[i], OPUS_SET_SIGNAL(OPUS_APPLICATION_RESTRICTED_LOWDELAY));
-
-            /* initilize decoders */
-            error = opus_custom_encoder_init(fOpusEncoder[i], fOpusMode[i], 1);
-            error = opus_custom_decoder_init(fOpusDecoder[i], fOpusMode[i], 1);
         }
 
         {

--- a/common/netjack.c
+++ b/common/netjack.c
@@ -406,7 +406,6 @@ void netjack_attach( netjack_driver_state_t *netj )
         } else if( netj->bitdepth == OPUS_MODE ) {
 #if HAVE_OPUS
             OpusCustomDecoder *decoder = opus_custom_decoder_create( netj->opus_mode, 1, NULL );
-            opus_custom_decoder_init(decoder, netj->opus_mode, 1);
             netj->capture_srcs = jack_slist_append(netj->capture_srcs, decoder );
 #endif
         } else {
@@ -471,7 +470,6 @@ void netjack_attach( netjack_driver_state_t *netj )
             opus_custom_encoder_ctl(oe, OPUS_SET_COMPLEXITY(10));
             opus_custom_encoder_ctl(oe, OPUS_SET_SIGNAL(OPUS_SIGNAL_MUSIC));
             opus_custom_encoder_ctl(oe, OPUS_SET_SIGNAL(OPUS_APPLICATION_RESTRICTED_LOWDELAY));
-            opus_custom_encoder_init(oe, opus_mode, 1);
             netj->playback_srcs = jack_slist_append(netj->playback_srcs, oe );
 #endif
         } else {


### PR DESCRIPTION
use the opus API correctly: `opus_*_create()` implies `opus_*_init()`.
