### PR TITLE
Add JackPortIsCV flag

### DIFF
--- a/common/jack/types.h
+++ b/common/jack/types.h
@@ -451,9 +451,9 @@ typedef void (*JackInfoShutdownCallback)(jack_status_t code, const char* reason,
 #define JACK_DEFAULT_MIDI_TYPE "8 bit raw midi"
 
 /**
- * Used to check if the current JACK version provides JackPortIsCV flag.
+ * Used to check if the current JACK version provides JackPortIsControlVoltage flag.
  */
-#define JACK_HAS_PORT_IS_CV_FLAG 1
+#define JACK_HAS_PORT_IS_CONTROL_VOLTAGE_FLAG 1
 
 /**
  * For convenience, use this typedef if you want to be able to change
@@ -520,10 +520,10 @@ enum JackPortFlags {
     JackPortIsTerminal = 0x10,
 
     /**
-     * if JackPortIsCV is set, then the audio port is used
+     * if JackPortIsControlVoltage is set, then the audio port is used
      * as control voltage audio signal.
      */
-    JackPortIsCV = 0x100,
+    JackPortIsControlVoltage = 0x20,
 
 };
 


### PR DESCRIPTION
This pull request adds a new JACK port flag, JackPortIsCV.

This is useful for applications that use JACK audio ports as CV.
As it's merely a hint, it won't hurt current JACK usage.
Patch-bays will welcome this change and may choose to represent these ports in a special way.

A new macro was also added, JACK_HAS_PORT_IS_CV_FLAG.
This allows new applications to safely check for this new flag existence.
