### PR TITLE
up-to-date jack2_android from OSRC(SM-G9008W_CHN).

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -1,12 +1,16 @@
 #
-# jack-1.9.9.5
+# jack-1.9.10
 #
 
 LOCAL_PATH := $(call my-dir)
 JACK_ROOT := $(call my-dir)/..
 SUPPORT_ALSA_IN_JACK := true
 SUPPORT_ANDROID_REALTIME_SCHED := false
+ifeq ($(TARGET_BOARD_PLATFORM),mrvl)
+ALSA_INCLUDES := vendor/marvell/external/alsa-lib/include
+else
 ALSA_INCLUDES := vendor/samsung/common/external/alsa-lib/include
+endif
 JACK_STL_LDFLAGS := -Lprebuilts/ndk/current/sources/cxx-stl/gnu-libstdc++/libs/$(TARGET_CPU_ABI) -lgnustl_static
 JACK_STL_INCLUDES := $(JACK_ROOT)/android/cxx-stl/gnu-libstdc++/libs/$(TARGET_CPU_ABI)/include \
                      prebuilts/ndk/current/sources/cxx-stl/gnu-libstdc++/libs/$(TARGET_CPU_ABI)/include \
@@ -20,6 +24,11 @@ common_cflags := -O0 -g -Wall -fexceptions -fvisibility=hidden -DHAVE_CONFIG_H
 common_cflags += -Wno-unused -Wno-sign-compare -Wno-deprecated-declarations -Wno-cpp
 common_cppflags := -frtti -Wno-sign-promo -fcheck-new
 common_shm_cflags := -O0 -g -Wall -fexceptions -DHAVE_CONFIG_H -Wno-unused
+ifeq ($(TARGET_BOARD_PLATFORM),clovertrail)
+common_ldflags := -ldl
+else
+common_ldflags :=
+endif
 common_c_includes := \
     $(JACK_ROOT) \
     $(JACK_ROOT)/common \
@@ -252,7 +261,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(common_libsource_server) $(server_libsource)
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libutils libjackshm
 LOCAL_MODULE_TAGS := eng optional
@@ -274,7 +283,7 @@ include $(BUILD_SHARED_LIBRARY)
 #LOCAL_SRC_FILES := $(net_libsource)
 #LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libsamplerate
 #LOCAL_MODULE_TAGS := eng optional
@@ -290,7 +299,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(common_libsource_client) $(client_libsource)
 LOCAL_CFLAGS := $(common_cflags)
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libutils libjackshm
 LOCAL_MODULE_TAGS := eng optional
@@ -312,7 +321,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := ../common/JackNetManager.cpp
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -329,7 +338,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := ../common/JackProfiler.cpp
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -346,7 +355,7 @@ include $(BUILD_SHARED_LIBRARY)
 #LOCAL_SRC_FILES := $(netadapter_libsource)
 #LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libsamplerate libjackserver
 #LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -364,7 +373,7 @@ include $(BUILD_SHARED_LIBRARY)
 #LOCAL_SRC_FILES := $(audioadapter_libsource)
 #LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE -D_POSIX_SOURCE
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include $(ALSA_INCLUDES)
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libasound libsamplerate libjackserver
 #LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -373,6 +382,40 @@ include $(BUILD_SHARED_LIBRARY)
 #
 #include $(BUILD_SHARED_LIBRARY)
 ##endif
+
+# ========================================================
+# in.so - sapaproxy internal client
+# ========================================================
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := JackSapaProxy.cpp JackSapaProxyIn.cpp
+LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
+LOCAL_CPPFLAGS := $(common_cppflags)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
+LOCAL_C_INCLUDES := $(common_c_includes)
+LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
+LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
+LOCAL_MODULE_TAGS := eng optional
+LOCAL_MODULE := in
+
+include $(BUILD_SHARED_LIBRARY)
+
+# ========================================================
+# out.so - sapaproxy internal client
+# ========================================================
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := JackSapaProxy.cpp JackSapaProxyOut.cpp
+LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
+LOCAL_CPPFLAGS := $(common_cppflags)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
+LOCAL_C_INCLUDES := $(common_c_includes)
+LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
+LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
+LOCAL_MODULE_TAGS := eng optional
+LOCAL_MODULE := out
+
+include $(BUILD_SHARED_LIBRARY)
 
 ##########################################################
 # linux
@@ -406,7 +449,7 @@ LOCAL_SRC_FILES := ../common/JackDummyDriver.cpp
 #'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -423,8 +466,6 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := \
     ../linux/alsa/JackAlsaDriver.cpp \
-    ../linux/alsa/alsa_rawmidi.c \
-    ../linux/alsa/alsa_seqmidi.c \
     ../linux/alsa/alsa_midi_jackmp.cpp \
     ../common/memops.c \
     ../linux/alsa/generic_hw.c \
@@ -432,10 +473,12 @@ LOCAL_SRC_FILES := \
     ../linux/alsa/alsa_driver.c \
     ../linux/alsa/hammerfall.c \
     ../linux/alsa/ice1712.c
+#    ../linux/alsa/alsa_rawmidi.c
+#    ../linux/alsa/alsa_seqmidi.c
 #'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE -D_POSIX_SOURCE -D_XOPEN_SOURCE=600
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes) $(ALSA_INCLUDES)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver libasound
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -461,7 +504,7 @@ endif
 ##'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 #LOCAL_CFLAGS := $(common_cflags) -D_POSIX_SOURCE -D__ALSA_RAWMIDI_H
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(ALSA_INCLUDES)
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver libasound
 #LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -480,7 +523,7 @@ endif
 ##'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 #LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes)
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 #LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -504,7 +547,7 @@ endif
 ##'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 #LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes)
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 #LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -522,7 +565,7 @@ LOCAL_SRC_FILES := ../common/JackNetDriver.cpp
 #'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -540,7 +583,7 @@ LOCAL_SRC_FILES := ../common/JackLoopbackDriver.cpp
 #'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -562,7 +605,7 @@ include $(BUILD_SHARED_LIBRARY)
 ##'HAVE_CONFIG_H','SERVER_SIDE', 'HAVE_PPOLL', 'HAVE_TIMERFD
 #LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 #LOCAL_CPPFLAGS := $(common_cppflags)
-#LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+#LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include
 #LOCAL_SHARED_LIBRARIES := libc libdl libcutils libsamplerate libjackserver
 #LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -582,7 +625,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := BnAndroidShm.cpp BpAndroidShm.cpp IAndroidShm.cpp AndroidShm.cpp Shm.cpp
 LOCAL_CFLAGS := $(common_shm_cflags) -DSERVER_SIDE
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libutils libbinder
 LOCAL_MODULE_TAGS := eng optional
@@ -598,7 +641,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := JackGoldfishDriver.cpp
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -615,7 +658,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := JackOpenSLESDriver.cpp opensl_io.c
 LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes) frameworks/wilhelm/include
 LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver libOpenSLES
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
@@ -636,7 +679,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := ./AndroidShmServer/main_androidshmservice.cpp
 LOCAL_CFLAGS := $(common_cflags)
 LOCAL_CPPFLAGS := $(common_cppflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libcutils libutils libbinder libjackshm
 LOCAL_MODULE_TAGS := eng optional
@@ -650,10 +693,13 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ./AndroidShmServer/test/shmservicetest.cpp
+LOCAL_CFLAGS := $(common_cflags) -DLOG_TAG=\"ShmServiceTest\"
+LOCAL_CPPFLAGS := $(common_cppflags)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
+LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libcutils libutils libjackshm libbinder
 LOCAL_MODULE_TAGS := eng optional
 LOCAL_MODULE := shmservicetest
-LOCAL_CFLAGS += -DLOG_TAG=\"ShmServiceTest\" 
 
 include $(BUILD_EXECUTABLE)
 
@@ -663,12 +709,13 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ./AndroidShmServer/test/shmservicedump.cpp
+LOCAL_CFLAGS := $(common_cflags) -DLOG_TAG=\"ShmServiceDump\"
+LOCAL_CPPFLAGS := $(common_cppflags)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_SHARED_LIBRARIES := libcutils libutils libjackshm libbinder
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_MODULE_TAGS := eng optional
 LOCAL_MODULE := shmservicedump
-LOCAL_CFLAGS += $(common_cflags) -DLOG_TAG=\"ShmServiceDump\"
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
 
 include $(BUILD_EXECUTABLE)
 
@@ -683,6 +730,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/freewheel.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -698,6 +746,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/connect.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -713,6 +762,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/connect.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -728,6 +778,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/lsp.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -743,6 +794,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/metro.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -758,6 +810,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/midiseq.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -773,6 +826,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/midisine.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -788,6 +842,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/showtime.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -803,6 +858,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/simple_client.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -818,6 +874,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/zombie.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -833,6 +890,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/ipload.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -848,6 +906,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/ipunload.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -863,6 +922,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/alias.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -878,6 +938,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/bufsize.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -893,6 +954,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/wait.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -908,6 +970,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/samplerate.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -923,6 +986,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/evmon.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -938,6 +1002,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/monitor_client.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -953,6 +1018,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/thru_client.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -968,6 +1034,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/cpu_load.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -983,6 +1050,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/simple_session_client.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -998,6 +1066,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/session_notify.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1013,7 +1082,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/server_control.cpp
 LOCAL_CFLAGS := $(common_cflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjackserver
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1029,6 +1098,7 @@ include $(BUILD_EXECUTABLE)
 #
 #LOCAL_SRC_FILES := ../example-clients/netslave.c
 #LOCAL_CFLAGS := $(common_cflags)
+#LOCAL_LDFLAGS := $(common_ldflags)
 #LOCAL_C_INCLUDES := $(common_c_includes)
 #LOCAL_SHARED_LIBRARIES := libjacknet
 #LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1044,6 +1114,7 @@ include $(BUILD_EXECUTABLE)
 #
 #LOCAL_SRC_FILES := ../example-clients/netmaster.c
 #LOCAL_CFLAGS := $(common_cflags)
+#LOCAL_LDFLAGS := $(common_ldflags)
 #LOCAL_C_INCLUDES := $(common_c_includes)
 #LOCAL_SHARED_LIBRARIES := libjacknet
 #LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1059,6 +1130,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/latent_client.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1074,6 +1146,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/midi_dump.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1089,6 +1162,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/midi_latency_test.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1104,6 +1178,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/transport.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1119,6 +1194,7 @@ include $(BUILD_EXECUTABLE)
 #
 #LOCAL_SRC_FILES := ../example-clients/capture_client.c
 #LOCAL_CFLAGS := $(common_cflags)
+#LOCAL_LDFLAGS := $(common_ldflags)
 #LOCAL_C_INCLUDES := $(common_c_includes)  $(JACK_ROOT)/../libsndfile/src
 #LOCAL_SHARED_LIBRARIES := libjack libsndfile
 #LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1134,6 +1210,7 @@ include $(BUILD_EXECUTABLE)
 #
 #LOCAL_SRC_FILES := ../example-clients/netsource.c  ../common/netjack_packet.c
 #LOCAL_CFLAGS := $(common_cflags) -DNO_JACK_ERROR
+#LOCAL_LDFLAGS := $(common_ldflags)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include
 #LOCAL_SHARED_LIBRARIES := libsamplerate libjack
 #LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1150,6 +1227,7 @@ include $(BUILD_EXECUTABLE)
 #
 #LOCAL_SRC_FILES := ../example-clients/alsa_in.c  ../common/memops.c
 #LOCAL_CFLAGS := $(common_cflags) -DNO_JACK_ERROR -D_POSIX_SOURCE -D_XOPEN_SOURCE=600
+#LOCAL_LDFLAGS := $(common_ldflags)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include $(ALSA_INCLUDES)
 #LOCAL_SHARED_LIBRARIES := libasound libsamplerate libjack
 #LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1167,6 +1245,7 @@ include $(BUILD_EXECUTABLE)
 #
 #LOCAL_SRC_FILES := ../example-clients/alsa_out.c  ../common/memops.c
 #LOCAL_CFLAGS := $(common_cflags) -DNO_JACK_ERROR -D_POSIX_SOURCE -D_XOPEN_SOURCE=600
+#LOCAL_LDFLAGS := $(common_ldflags)
 #LOCAL_C_INCLUDES := $(common_c_includes) $(JACK_ROOT)/../libsamplerate/include $(ALSA_INCLUDES)
 #LOCAL_SHARED_LIBRARIES := libasound libsamplerate libjack
 #LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1182,11 +1261,13 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../example-clients/inprocess.c
-LOCAL_CFLAGS := $(common_cflags)
+LOCAL_CFLAGS := $(common_cflags) -DSERVER_SIDE
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
-LOCAL_SHARED_LIBRARIES := libjackserver
+LOCAL_SHARED_LIBRARIES := libc libdl libcutils libjackserver
+LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/jack
 LOCAL_MODULE_TAGS := eng optional
-LOCAL_MODULE := example_lib
+LOCAL_MODULE := inprocess
 
 include $(BUILD_SHARED_LIBRARY)
 
@@ -1201,7 +1282,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../tests/test.cpp
 LOCAL_CFLAGS := $(common_cflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack libjackshm
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1217,6 +1298,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../tests/cpu.c
 LOCAL_CFLAGS := $(common_cflags)
+LOCAL_LDFLAGS := $(common_ldflags)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack libjackshm
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1233,7 +1315,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := ../tests/iodelay.cpp
 LOCAL_CFLAGS := $(common_cflags)
 LOCAL_CFLAGS += -Wno-narrowing
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack libjackshm
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1249,7 +1331,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := ../tests/external_metro.cpp
 LOCAL_CFLAGS := $(common_cflags)
-LOCAL_LDFLAGS := $(JACK_STL_LDFLAGS)
+LOCAL_LDFLAGS := $(common_ldflags) $(JACK_STL_LDFLAGS)
 LOCAL_C_INCLUDES := $(common_c_includes)
 LOCAL_SHARED_LIBRARIES := libjack libjackshm
 LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
@@ -1257,3 +1339,4 @@ LOCAL_MODULE_TAGS := eng optional
 LOCAL_MODULE := jack_multiple_metro
 
 include $(BUILD_EXECUTABLE)
+

--- a/android/CleanSpec.mk
+++ b/android/CleanSpec.mk
@@ -57,10 +57,12 @@ $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/jack_net_inter
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/jack_loopback_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/jack_netone_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/audioadapter_intermediates)
-$(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/example_lib_intermediates)
+$(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/inprocess_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/netadapter_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/netmanager_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/profiler_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/jack_goldfish_intermediates)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/jack_opensles_intermediates)
+$(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/in_intermediates)
+$(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/SHARED_LIBRARIES/out_intermediates)
 

--- a/android/JackAndroidThread.cpp
+++ b/android/JackAndroidThread.cpp
@@ -49,13 +49,6 @@ void* JackAndroidThread::ThreadHandler(void* arg)
     JackRunnableInterface* runnable = obj->fRunnable;
     int err;
 
-    struct sigaction actions;
-    memset(&actions, 0, sizeof(actions)); 
-    sigemptyset(&actions.sa_mask);
-    actions.sa_flags = 0; 
-    actions.sa_handler = thread_exit_handler;
-    sigaction(SIGUSR1,&actions,NULL);
-
     // Signal creation thread when started with StartSync
     jack_log("JackAndroidThread::ThreadHandler : start");
     obj->fStatus = kIniting;
@@ -114,6 +107,13 @@ int JackAndroidThread::StartImp(jack_native_thread_t* thread, int priority, int 
     struct sched_param rt_param;
     pthread_attr_init(&attributes);
     int res;
+
+    struct sigaction actions;
+    memset(&actions, 0, sizeof(actions));
+    sigemptyset(&actions.sa_mask);
+    actions.sa_flags = 0;
+    actions.sa_handler = thread_exit_handler;
+    sigaction(SIGUSR1,&actions,NULL);
 
     if ((res = pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_JOINABLE))) {
         jack_error("Cannot request joinable thread creation for thread res = %d", res);

--- a/android/JackOpenSLESDriver.cpp
+++ b/android/JackOpenSLESDriver.cpp
@@ -34,7 +34,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "opensl_io.h"
 
 #define JACK_OPENSLES_DEFAULT_SAMPLERATE   48000
-#define JACK_OPENSLES_DEFAULT_BUFFER_SIZE  1024
+#define JACK_OPENSLES_DEFAULT_BUFFER_SIZE  960
 
 namespace Jack
 {
@@ -59,8 +59,6 @@ int JackOpenSLESDriver::Open(jack_nframes_t buffer_size,
         capture_driver_uid, playback_driver_uid, capture_latency, playback_latency) != 0) {
         return -1;
     }
-    //JackAudioDriver::SetBufferSize(buffer_size);
-    //JackAudioDriver::SetSampleRate(samplerate);
 
     if (capturing) {
         inbuffer = (float *) malloc(sizeof(float) * buffer_size);  //mono input
@@ -102,7 +100,6 @@ int JackOpenSLESDriver::Read() {
 
     if (inbuffer) {
         int samps = android_AudioIn(pOpenSL_stream,inbuffer,fEngineControl->fBufferSize);
-        //jack_log("JackOpenSLESDriver::Read(%d)", samps);  //for debug
         for (int i = 0; i < samps; i++) {
             *(inputBuffer_1 + i) = *(inbuffer + i);
             *(inputBuffer_2 + i) = *(inbuffer + i);
@@ -175,7 +172,7 @@ extern "C"
     SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params) {
         jack_nframes_t sample_rate = JACK_OPENSLES_DEFAULT_SAMPLERATE;
         jack_nframes_t buffer_size = JACK_OPENSLES_DEFAULT_BUFFER_SIZE;
-        unsigned int capture_ports = 2;
+        unsigned int capture_ports = 0;
         unsigned int playback_ports = 2;
         int wait_time = 0;
         const JSList * node;

--- a/android/JackSapaProxy.cpp
+++ b/android/JackSapaProxy.cpp
@@ -1,0 +1,158 @@
+/*
+Copyright (C) 2014 Samsung Electronics
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackSapaProxy.h"
+#include "JackServerGlobals.h"
+#include "JackEngineControl.h"
+#include "JackLockedEngine.h"
+#include "JackArgParser.h"
+#include <assert.h>
+#include <string>
+
+// Example)
+//                                  sapaproxy
+//                                 .----------.
+// sapaproxy:__system_capture_1 -->|          |--> sapaproxy:capture_1
+// sapaproxy:__system_capture_2 -->|          |--> sapaproxy:capture_2
+// ...                             |          |    ...
+//                                 |          |
+// sapaproxy:playback_1 ---------->|          |--> sapaproxy:__system_playback_1
+// sapaproxy:playback_2 ---------->|          |--> sapaproxy:__system_playback_2
+// sapaproxy:playback_3 ---------->|          |--> sapaproxy:__system_playback_3
+// sapaproxy:playback_4 ---------->|          |--> sapaproxy:__system_playback_4
+// ...                             |          |    ...
+//                                 '----------'
+
+namespace Jack
+{
+
+    JackSapaProxy::JackSapaProxy(jack_client_t* client, const JSList* params)
+        :fClient(client)
+    {
+        jack_log("JackSapaProxy::JackSapaProxy");
+
+        fCapturePorts = fPlaybackPorts = 0;
+
+        const JSList* node;
+        const jack_driver_param_t* param;
+        for (node = params; node; node = jack_slist_next(node)) {
+            param = (const jack_driver_param_t*)node->data;
+
+            switch (param->character) {
+                case 'C':
+                    fCapturePorts = (param->value.ui > SAPAPROXY_PORT_NUM_FOR_CLIENT)? SAPAPROXY_PORT_NUM_FOR_CLIENT : param->value.ui;
+                    break;
+
+                case 'P':
+                    fPlaybackPorts = (param->value.ui > SAPAPROXY_PORT_NUM_FOR_CLIENT)? SAPAPROXY_PORT_NUM_FOR_CLIENT : param->value.ui;
+                    break;
+            }
+        }
+    }
+
+    JackSapaProxy::~JackSapaProxy()
+    {
+        jack_log("JackSapaProxy::~JackSapaProxy");
+    }
+
+    int JackSapaProxy::Setup(jack_client_t* client)
+    {
+        jack_log("JackSapaProxy::Setup");
+
+        //refer to system ports and create sapaproxy ports
+        unsigned int i = 0, j = 0;
+        const char **ports_system_capture;
+        const char **ports_system_playback;
+        unsigned int ports_system_capture_cnt = 0;
+        unsigned int ports_system_playback_cnt = 0;
+        char port_name[JACK_PORT_NAME_SIZE] = {0,};
+        ports_system_capture = jack_get_ports(client, "system:.*", NULL, JackPortIsPhysical | JackPortIsOutput);
+        if (ports_system_capture != NULL) {
+            for (i = 0; i < fCapturePorts && ports_system_capture[i]; i++) {
+                sprintf(port_name, "__system_capture_%d", i + 1);
+                fInputPorts[i] = jack_port_register(client, port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+                sprintf(port_name, "capture_%d", i + 1);
+                fOutputPorts[i] = jack_port_register(client, port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+                ports_system_capture_cnt++;
+            }
+            jack_free(ports_system_capture);
+        }
+
+        ports_system_playback = jack_get_ports(client, "system:.*", NULL, JackPortIsPhysical | JackPortIsInput);
+        if (ports_system_playback != NULL) {
+            for (j = 0; j < fPlaybackPorts && ports_system_playback[j]; j++, i++) {
+                sprintf(port_name, "playback_%d", j + 1);
+                fInputPorts[i] = jack_port_register(client, port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+                sprintf(port_name, "__system_playback_%d", j + 1);
+                fOutputPorts[i] = jack_port_register(client, port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+                ports_system_playback_cnt++;
+            }
+            jack_free(ports_system_playback);
+        }
+
+        //store actual number of system ports
+        fCapturePorts = ports_system_capture_cnt;
+        fPlaybackPorts = ports_system_playback_cnt;
+
+        jack_set_process_callback(client, Process, this);
+        jack_activate(client);
+
+        //conenct between sapaproxy and system ports
+        for (unsigned int i = 0; i < ports_system_capture_cnt; i++) {
+            sprintf(port_name, "system:capture_%d", i + 1);
+            jack_connect(client, port_name, jack_port_name(fInputPorts[i]));
+        }
+
+        for (unsigned int i = 0; i < ports_system_playback_cnt; i++) {
+            sprintf(port_name, "system:playback_%d", i + 1);
+            jack_connect(client, jack_port_name(fOutputPorts[ports_system_capture_cnt + i]), port_name);
+        }
+
+        return 0;
+    }
+
+    int JackSapaProxy::Process(jack_nframes_t nframes, void* arg)
+    {
+        JackSapaProxy* sapaproxy = static_cast<JackSapaProxy*>(arg);
+        jack_default_audio_sample_t *in, *out;
+
+        //for capture
+        for (unsigned int i = 0; i < sapaproxy->fCapturePorts; i++) {
+            in  = (jack_default_audio_sample_t*)jack_port_get_buffer(sapaproxy->fInputPorts[i] , nframes);
+            out = (jack_default_audio_sample_t*)jack_port_get_buffer(sapaproxy->fOutputPorts[i], nframes);
+
+            // TODO: adjust pcm gain each platform here
+
+            memcpy(out, in, sizeof(jack_default_audio_sample_t) * nframes);
+        }
+
+        //for playback
+        for (unsigned int i = sapaproxy->fCapturePorts; i < (sapaproxy->fCapturePorts + sapaproxy->fPlaybackPorts); i++) {
+            in  = (jack_default_audio_sample_t*)jack_port_get_buffer(sapaproxy->fInputPorts[i] , nframes);
+            out = (jack_default_audio_sample_t*)jack_port_get_buffer(sapaproxy->fOutputPorts[i], nframes);
+
+            // TODO: adjust pcm gain each platform here
+
+            memcpy(out, in, sizeof(jack_default_audio_sample_t) * nframes);
+        }
+
+        return 0;
+    }
+
+} // namespace Jack

--- a/android/JackSapaProxy.h
+++ b/android/JackSapaProxy.h
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2014 Samsung Electronics
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackSapaProxy__
+#define __JackSapaProxy__
+
+#include "JackConstants.h"
+#include "JackPlatformPlug.h"
+#include "jack.h"
+#include "jslist.h"
+#include <map>
+#include <string>
+
+#define SAPAPROXY_PORT_NUM_FOR_CLIENT  16
+
+namespace Jack
+{
+
+class JackSapaProxy
+{
+
+    private:
+
+        jack_client_t* fClient;
+        jack_port_t *fInputPorts[SAPAPROXY_PORT_NUM_FOR_CLIENT];
+        jack_port_t *fOutputPorts[SAPAPROXY_PORT_NUM_FOR_CLIENT];
+
+    public:
+
+        unsigned int fCapturePorts;
+        unsigned int fPlaybackPorts;
+
+        JackSapaProxy(jack_client_t* jack_client, const JSList* params);
+        ~JackSapaProxy();
+
+        int Setup(jack_client_t* jack_client);
+        static int Process(jack_nframes_t nframes, void* arg);
+
+};
+
+}
+
+#endif

--- a/android/JackSapaProxyIn.cpp
+++ b/android/JackSapaProxyIn.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2014 Samsung Electronics
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackSapaProxy.h"
+#include "JackServerGlobals.h"
+#include "JackEngineControl.h"
+#include "JackLockedEngine.h"
+#include "JackArgParser.h"
+#include <assert.h>
+#include <string>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "driver_interface.h"
+
+    using namespace Jack;
+
+    static Jack::JackSapaProxy* sapaproxy = NULL;
+
+    SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor()
+    {
+        jack_driver_desc_t * desc;
+        jack_driver_desc_filler_t filler;
+        jack_driver_param_value_t value;
+
+        desc = jack_driver_descriptor_construct("in", JackDriverNone, "sapaproxy client", &filler);
+
+        value.ui = 0U;
+        jack_driver_descriptor_add_parameter(desc, &filler, "capture", 'C', JackDriverParamUInt, &value, NULL, "Number of capture ports", NULL);
+        jack_driver_descriptor_add_parameter(desc, &filler, "playback", 'P', JackDriverParamUInt, &value, NULL, "Number of playback ports", NULL);
+
+        return desc;
+    }
+
+    SERVER_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
+    {
+        if (sapaproxy) {
+            jack_info("sapaproxy already loaded");
+            return 1;
+        }
+
+        jack_log("Loading sapaproxy");
+        sapaproxy = new Jack::JackSapaProxy(jack_client, params);
+        if (!params) {
+            sapaproxy->fCapturePorts  = 2U;
+            sapaproxy->fPlaybackPorts = 0U;
+        }
+        sapaproxy->Setup(jack_client);
+        assert(sapaproxy);
+        return 0;
+    }
+
+    SERVER_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
+    {
+        JSList* params = NULL;
+        bool parse_params = true;
+        int res = 1;
+        jack_driver_desc_t* desc = jack_get_descriptor();
+
+        Jack::JackArgParser parser(load_init);
+        if (parser.GetArgc() > 0)
+            parse_params = parser.ParseParams(desc, &params);
+
+        if (parse_params) {
+            res = jack_internal_initialize(jack_client, params);
+            parser.FreeParams(params);
+        }
+        return res;
+    }
+
+    SERVER_EXPORT void jack_finish(void* arg)
+    {
+        Jack::JackSapaProxy* sapaproxy = static_cast<Jack::JackSapaProxy*>(arg);
+
+        if (sapaproxy) {
+            jack_log("Unloading sapaproxy");
+            delete sapaproxy;
+        }
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/android/JackSapaProxyOut.cpp
+++ b/android/JackSapaProxyOut.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2014 Samsung Electronics
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackSapaProxy.h"
+#include "JackServerGlobals.h"
+#include "JackEngineControl.h"
+#include "JackLockedEngine.h"
+#include "JackArgParser.h"
+#include <assert.h>
+#include <string>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "driver_interface.h"
+
+    using namespace Jack;
+
+    static Jack::JackSapaProxy* sapaproxy = NULL;
+
+    SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor()
+    {
+        jack_driver_desc_t * desc;
+        jack_driver_desc_filler_t filler;
+        jack_driver_param_value_t value;
+
+        desc = jack_driver_descriptor_construct("out", JackDriverNone, "sapaproxy client", &filler);
+
+        value.ui = 0U;
+        jack_driver_descriptor_add_parameter(desc, &filler, "capture", 'C', JackDriverParamUInt, &value, NULL, "Number of capture ports", NULL);
+        jack_driver_descriptor_add_parameter(desc, &filler, "playback", 'P', JackDriverParamUInt, &value, NULL, "Number of playback ports", NULL);
+
+        return desc;
+    }
+
+    SERVER_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
+    {
+        if (sapaproxy) {
+            jack_info("sapaproxy already loaded");
+            return 1;
+        }
+
+        jack_log("Loading sapaproxy");
+        sapaproxy = new Jack::JackSapaProxy(jack_client, params);
+        if (!params) {
+            sapaproxy->fCapturePorts  = 0U;
+            sapaproxy->fPlaybackPorts = 2U;
+        }
+        sapaproxy->Setup(jack_client);
+        assert(sapaproxy);
+        return 0;
+    }
+
+    SERVER_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
+    {
+        JSList* params = NULL;
+        bool parse_params = true;
+        int res = 1;
+        jack_driver_desc_t* desc = jack_get_descriptor();
+
+        Jack::JackArgParser parser(load_init);
+        if (parser.GetArgc() > 0)
+            parse_params = parser.ParseParams(desc, &params);
+
+        if (parse_params) {
+            res = jack_internal_initialize(jack_client, params);
+            parser.FreeParams(params);
+        }
+        return res;
+    }
+
+    SERVER_EXPORT void jack_finish(void* arg)
+    {
+        Jack::JackSapaProxy* sapaproxy = static_cast<Jack::JackSapaProxy*>(arg);
+
+        if (sapaproxy) {
+            jack_log("Unloading sapaproxy");
+            delete sapaproxy;
+        }
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/android/config.h
+++ b/android/config.h
@@ -12,10 +12,10 @@
 /* #define HAVE_CELT_API_0_7 0 */
 /* #define HAVE_CELT_API_0_5 0 */
 /* #define HAVE_READLINE 0 */
-#define CLIENT_NUM 16
-#define PORT_NUM_FOR_CLIENT 16
-#define PORT_NUM 128
-#define PORT_NUM_MAX 256
+#define CLIENT_NUM 32
+#define PORT_NUM_FOR_CLIENT 24
+#define PORT_NUM 256
+#define PORT_NUM_MAX 512
 #define ADDON_DIR "/system/lib/jack"
 #define JACK_LOCATION "/system/bin"
 #define JACKMP 1

--- a/common/JackControlAPI.cpp
+++ b/common/JackControlAPI.cpp
@@ -640,7 +640,12 @@ jackctl_setup_signals(
     sigaddset(&sigmask.signals, SIGQUIT);
     sigaddset(&sigmask.signals, SIGPIPE);
     sigaddset(&sigmask.signals, SIGTERM);
+#ifndef __ANDROID__
+    /* android's bionic c doesn't provide pthread_cancel() and related functions.
+     * to solve this issue, use pthread_kill() & SIGUSR1 instead.
+     */
     sigaddset(&sigmask.signals, SIGUSR1);
+#endif
     sigaddset(&sigmask.signals, SIGUSR2);
 
     /* all child threads will inherit this mask unless they

--- a/linux/alsa/JackAlsaDriver.cpp
+++ b/linux/alsa/JackAlsaDriver.cpp
@@ -289,10 +289,12 @@ int JackAlsaDriver::Open(jack_nframes_t nframes,
     }
 
     alsa_midi_t *midi = 0;
+#ifndef __ANDROID__
     if (strcmp(midi_driver_name, "seq") == 0)
         midi = alsa_seqmidi_new((jack_client_t*)this, 0);
     else if (strcmp(midi_driver_name, "raw") == 0)
         midi = alsa_rawmidi_new((jack_client_t*)this);
+#endif
 
     if (JackServerGlobals::on_device_acquire != NULL) {
         int capture_card = card_to_num(capture_driver_name);

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -2092,9 +2092,7 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 			case EBUSY:
 #ifdef __ANDROID__
                 jack_error ("\n\nATTENTION: The capture (recording) device \"%s\" is "
-                            "already in use. Please stop the"
-                            " application using it and "
-                            "run JACK again",
+                            "already in use",
                             capture_alsa_device);
 #else
                 current_apps = discover_alsa_using_apps ();
@@ -2114,9 +2112,9 @@ alsa_driver_new (char *name, char *playback_alsa_device,
                                     "run JACK again",
                                     capture_alsa_device);
                 }
-#endif
 				alsa_driver_delete (driver);
 				return NULL;
+#endif
 				break;
 
 			case EPERM:


### PR DESCRIPTION
Dear all,

I have several patches for android's support.
These patches are applied to android's domain only.
- fixed freezing issue when load/unload jack internal clients.
- fixed build error at android's X86 platform.
- do not stop jackd when busy error occurs at alsa's capture device.
- increase default allowance number of ports & clients.
- add internal clients for experiment.
- fix typos & clean-up.
- support latest Android 4.4.3.
- build successed at https://travis-ci.org/KimJeongYeon/jack2/builds/27956460 and my local android's build system(KiKat 4.4.2).

These patches retrieved from http://opensource.samsung.com/reception/receptionSub.do?method=sub&sub=F&searchValue=SM-G9008W.

Regards,
KimJeongYeon
