### PR TITLE
jack_transport_reposition linkage fix

### DIFF
--- a/common/JackWeakAPI.c
+++ b/common/JackWeakAPI.c
@@ -254,7 +254,7 @@ DECL_FUNCTION(int, jack_set_timebase_callback, (jack_client_t *client,
 DECL_FUNCTION(int, jack_transport_locate, (jack_client_t *client, jack_nframes_t frame), (client, frame));
 DECL_FUNCTION(jack_transport_state_t, jack_transport_query, (const jack_client_t *client, jack_position_t *pos), (client, pos));
 DECL_FUNCTION(jack_nframes_t, jack_get_current_transport_frame, (const jack_client_t *client), (client));
-DECL_FUNCTION(int, jack_transport_reposition, (jack_client_t *client, jack_position_t *pos), (client, pos));
+DECL_FUNCTION(int, jack_transport_reposition, (jack_client_t *client, const jack_position_t *pos), (client, pos));
 DECL_VOID_FUNCTION(jack_transport_start, (jack_client_t *client), (client));
 DECL_VOID_FUNCTION(jack_transport_stop, (jack_client_t *client), (client));
 DECL_VOID_FUNCTION(jack_get_transport_info, (jack_client_t *client, jack_transport_info_t *tinfo), (client,tinfo));


### PR DESCRIPTION
The second argument should be const, see 
https://github.com/jackaudio/jack2/blob/ec8403050c11cf6447a2a2f082f46fec8dc886cd/common/jack/transport.h#L191
and
https://github.com/jackaudio/jack2/blob/97e0e80bba707bc59ea1e6894590c1be6ae5a74d/common/JackAPI.cpp#L226
