### PR TITLE
Fix compiler warning about unused label on non Win32

### DIFF
--- a/common/JackMessageBuffer.cpp
+++ b/common/JackMessageBuffer.cpp
@@ -189,9 +189,10 @@ int JackMessageBuffer::SetInitCallback(JackThreadInitCallback callback, void *ar
             fGuard.Signal();
             JackSleep(1000);
         }
-        if (count == 1000)
+        if (count == 1000) {
             jack_error("JackMessageBuffer::SetInitCallback : signal lost");
             return -1;
+	}
     #endif
         return 0;
     }


### PR DESCRIPTION
- fixed warning
- seperated both error conditions
- removed a "goto" and the corresponding label
- more descriptive error messages
