### PR TITLE
Preserving original status

### DIFF
--- a/common/JackGenericClientChannel.cpp
+++ b/common/JackGenericClientChannel.cpp
@@ -102,7 +102,7 @@ void JackGenericClientChannel::ClientCheck(const char* name, int uuid, char* nam
     JackClientCheckRequest req(name, protocol, options, uuid, open);
     JackClientCheckResult res;
     ServerSyncCall(&req, &res, result);
-    *status = res.fStatus;
+    *status |= res.fStatus;
     strcpy(name_res, res.fName);
 }
 


### PR DESCRIPTION
Overwriting causes the previous status to be lost. This results in an incorrect status returned to calls of jack_client_open.
This behavior can be reproduced by running the example client simple_client without a running jackd instance. It will not print the "JACK server started" message, while it does start the server. This is because of the status getting overwritten by the status of the ClientCheck call on JackEngine.