### PR TITLE
eliminate duplicated examples.

### DIFF
--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -13,7 +13,6 @@ example_programs = {
     'jack_zombie' : 'zombie.c',
     'jack_load' : 'ipload.c',
     'jack_unload' : 'ipunload.c',
-    'jack_showtime' : 'showtime.c',
     'jack_alias' : 'alias.c',
     'jack_bufsize' : 'bufsize.c',
     'jack_wait' : 'wait.c',


### PR DESCRIPTION
Dear all,

typo fixed:
jack_showtime application was duplicated in wscript.

Thanks,
KimJeongYeon