### PR TITLE
Add a --no-samplerate build option

### DIFF
--- a/common/wscript
+++ b/common/wscript
@@ -6,11 +6,6 @@ import re
 import os
 
 def configure(conf):
-    conf.check_cc(header_name='samplerate.h', define_name="HAVE_SAMPLERATE")
-   
-    if conf.is_defined('HAVE_SAMPLERATE'):
-        conf.env['LIB_SAMPLERATE'] = ['samplerate']
-
     conf.env['BUILD_NETLIB'] = conf.is_defined('HAVE_SAMPLERATE')
     conf.env['BUILD_ADAPTER'] = conf.is_defined('HAVE_SAMPLERATE')
 


### PR DESCRIPTION
The build option --no-samplerate can be used to not build against libsamplerate even if it is available. This is necessary to avoid an automagic dependency which is bad, see [1]. Also pkg-config is used to find libsamplerate instead of the header check. Note that the default behaviour is not changed; if --no-samplerate is not given (default) waf will detect samplerate and build against it conditionally, as usual.

If this change is welcome I will also fix the automagic dependencies on celt, opus sndfile and readline. All these changes are required to fulfill quality assurance in Gentoo, so it would be great if you merged this request to ease my undertaking as maintainer of jack2 in the Pro-Audio Gentoo Overlay [2].

[1] https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies
[2] http://proaudio.tuxfamily.org/wiki/index.php?title=Main_Page

Thanks in advance,
Karl