### PR TITLE
Auto options and removed automagic dependencies

### DIFF
--- a/common/wscript
+++ b/common/wscript
@@ -6,8 +6,8 @@ import re
 import os
 
 def configure(conf):
-    conf.env['BUILD_NETLIB'] = conf.is_defined('HAVE_SAMPLERATE')
-    conf.env['BUILD_ADAPTER'] = conf.is_defined('HAVE_SAMPLERATE')
+    conf.env['BUILD_NETLIB'] = conf.env['SAMPLERATE']
+    conf.env['BUILD_ADAPTER'] = conf.env['SAMPLERATE']
 
     if conf.env['IS_WINDOWS']:
         try:

--- a/common/wscript
+++ b/common/wscript
@@ -6,11 +6,6 @@ import re
 import os
 
 def configure(conf):
-    conf.check_cc(header_name='samplerate.h', define_name="HAVE_SAMPLERATE")
-   
-    if conf.is_defined('HAVE_SAMPLERATE'):
-        conf.env['LIB_SAMPLERATE'] = ['samplerate']
-
     conf.env['BUILD_NETLIB'] = conf.is_defined('HAVE_SAMPLERATE')
     conf.env['BUILD_ADAPTER'] = conf.is_defined('HAVE_SAMPLERATE')
 

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -36,13 +36,7 @@ example_libs = {
     }
 
 def configure(conf):
-    e = conf.check_cc(lib='readline', define_name="HAVE_READLINE", mandatory=False)
-
-    # define_name="HAVE_READLINE" has no effect, LIB_READLINE is defined if readline is available
-    #if conf.is_defined('HAVE_READLINE'):
-    #    conf.env['LIB_READLINE'] = ['readline']
-
-    conf.env['BUILD_EXAMPLE_CLIENT_TRANSPORT'] = bool(conf.env['LIB_READLINE'])
+    conf.env['BUILD_EXAMPLE_CLIENT_TRANSPORT'] = conf.env['READLINE']
 
     conf.env['BUILD_EXAMPLE_CLIENT_REC'] = conf.env['SNDFILE']
 

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -36,8 +36,6 @@ example_libs = {
     }
 
 def configure(conf):
-    conf.check_cfg(package='sndfile', args='--cflags --libs', mandatory=False)
- 
     e = conf.check_cc(lib='readline', define_name="HAVE_READLINE", mandatory=False)
 
     # define_name="HAVE_READLINE" has no effect, LIB_READLINE is defined if readline is available
@@ -46,7 +44,7 @@ def configure(conf):
 
     conf.env['BUILD_EXAMPLE_CLIENT_TRANSPORT'] = bool(conf.env['LIB_READLINE'])
 
-    conf.env['BUILD_EXAMPLE_CLIENT_REC'] = conf.is_defined('HAVE_SNDFILE')
+    conf.env['BUILD_EXAMPLE_CLIENT_REC'] = conf.env['SNDFILE']
 
     conf.env['BUILD_EXAMPLE_ALSA_IO'] = conf.env['SAMPLERATE'] and conf.env['BUILD_DRIVER_ALSA']
 

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -36,7 +36,7 @@ example_libs = {
     }
 
 def configure(conf):
-    e = conf.check_cc(header_name='sndfile.h', define_name="HAVE_SNDFILE")
+    e = conf.check_cc(header_name='sndfile.h', define_name="HAVE_SNDFILE", mandatory=False)
  
     if conf.is_defined('HAVE_SNDFILE'):
         conf.env['LIB_SNDFILE'] = ['sndfile']

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -41,8 +41,6 @@ def configure(conf):
     if conf.is_defined('HAVE_SNDFILE'):
         conf.env['LIB_SNDFILE'] = ['sndfile']
 
-    conf.check_cfg(package='celt', atleast_version='0.5.0', args='--cflags --libs', mandatory=False)
-
     e = conf.check_cc(lib='readline', define_name="HAVE_READLINE", mandatory=False)
 
     # define_name="HAVE_READLINE" has no effect, LIB_READLINE is defined if readline is available

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -51,7 +51,7 @@ def configure(conf):
 
     conf.env['BUILD_EXAMPLE_CLIENT_REC'] = conf.is_defined('HAVE_SNDFILE')
 
-    conf.env['BUILD_EXAMPLE_ALSA_IO'] = conf.is_defined('HAVE_SAMPLERATE') and conf.env['BUILD_DRIVER_ALSA']
+    conf.env['BUILD_EXAMPLE_ALSA_IO'] = conf.env['SAMPLERATE'] and conf.env['BUILD_DRIVER_ALSA']
 
 def build(bld):
     if bld.env['IS_LINUX']:

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -36,11 +36,8 @@ example_libs = {
     }
 
 def configure(conf):
-    e = conf.check_cc(header_name='sndfile.h', define_name="HAVE_SNDFILE", mandatory=False)
+    conf.check_cfg(package='sndfile', args='--cflags --libs', mandatory=False)
  
-    if conf.is_defined('HAVE_SNDFILE'):
-        conf.env['LIB_SNDFILE'] = ['sndfile']
-
     e = conf.check_cc(lib='readline', define_name="HAVE_READLINE", mandatory=False)
 
     # define_name="HAVE_READLINE" has no effect, LIB_READLINE is defined if readline is available

--- a/linux/wscript
+++ b/linux/wscript
@@ -7,9 +7,6 @@ def configure(conf):
     conf. check_cfg(package='libfreebob', atleast_version='1.0.0', args='--cflags --libs', mandatory=False)
     conf.env['BUILD_DRIVER_FREEBOB'] = conf.is_defined('HAVE_LIBFREEBOB')
 
-    conf. check_cfg(package='libffado', atleast_version='1.999.17', args='--cflags --libs', mandatory=False)
-    conf.env['BUILD_DRIVER_FFADO'] = conf.is_defined('HAVE_LIBFFADO')
-
     conf.define('HAVE_PPOLL', 1 )
 
     conf.check_cfg(package='gtkIOStream', atleast_version='1.4.0', args='--cflags --libs', mandatory=False)

--- a/linux/wscript
+++ b/linux/wscript
@@ -4,9 +4,6 @@
 from waflib import Context
 
 def configure(conf):
-    conf. check_cfg(package='libfreebob', atleast_version='1.0.0', args='--cflags --libs', mandatory=False)
-    conf.env['BUILD_DRIVER_FREEBOB'] = conf.is_defined('HAVE_LIBFREEBOB')
-
     conf.define('HAVE_PPOLL', 1 )
 
     conf.check_cfg(package='gtkIOStream', atleast_version='1.4.0', args='--cflags --libs', mandatory=False)

--- a/linux/wscript
+++ b/linux/wscript
@@ -4,9 +4,6 @@
 from waflib import Context
 
 def configure(conf):
-    conf.check_cfg(package='alsa', atleast_version='1.0.18', args='--cflags --libs', mandatory=False)
-    conf.env['BUILD_DRIVER_ALSA'] = conf.is_defined('HAVE_ALSA')
-
     conf. check_cfg(package='libfreebob', atleast_version='1.0.0', args='--cflags --libs', mandatory=False)
     conf.env['BUILD_DRIVER_FREEBOB'] = conf.is_defined('HAVE_LIBFREEBOB')
 

--- a/linux/wscript
+++ b/linux/wscript
@@ -6,11 +6,6 @@ from waflib import Context
 def configure(conf):
     conf.define('HAVE_PPOLL', 1 )
 
-    conf.check_cfg(package='gtkIOStream', atleast_version='1.4.0', args='--cflags --libs', mandatory=False)
-    conf.env['BUILD_DRIVER_IIO'] = conf.is_defined('HAVE_GTKIOSTREAM')
-    conf.check_cfg(package='eigen3', atleast_version='3.1.2', args='--cflags --libs', mandatory=False)
-    conf.env['BUILD_DRIVER_IIO'] += conf.is_defined('HAVE_EIGEN3')
-
 def create_jack_driver_obj(bld, target, sources, uselib = None):
     driver = bld(features = ['c', 'cxx', 'cxxshlib', 'cshlib'])
     driver.env['cxxshlib_PATTERN'] = 'jack_%s.so'

--- a/windows/wscript
+++ b/windows/wscript
@@ -1,10 +1,6 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-def configure(conf):
-    conf.check_cfg(package='portaudio-2.0', uselib_store='PORTAUDIO', atleast_version='19', args='--cflags --libs')
-    conf.env['BUILD_DRIVER_PORTAUDIO'] = conf.is_defined('HAVE_PORTAUDIO')
-
 def create_jack_driver_obj(bld, target, sources, uselib = None):
     driver = bld(features = ['c', 'cxx', 'cxxshlib', 'cshlib'])
     driver.env['cxxshlib_PATTERN'] = 'jack_%s.dll'

--- a/wscript
+++ b/wscript
@@ -364,6 +364,24 @@ def display_auto_options_messages():
     for option in auto_options:
         option.display_message()
 
+def check_for_celt(conf):
+    found = False
+    for version in ['11', '8', '7', '5']:
+        define = 'HAVE_CELT_API_0_' + version
+        if not found:
+            try:
+                conf.check_cfg(package='celt', atleast_version='0.' + version + '.0', args='--cflags --libs')
+                found = True
+                conf.define(define, 1)
+                continue
+            except conf.errors.ConfigurationError:
+                pass
+        conf.define(define, 0)
+    return found
+
+def check_for_celt_error(conf):
+    print_error('--celt requires the package celt, but it could not be found.')
+
 def options(opt):
     # options provided by the modules
     opt.tool_options('compiler_cxx')
@@ -405,6 +423,9 @@ def options(opt):
     winmme = add_auto_option(opt, 'winmme', help='Enable WinMME driver', conf_dest='BUILD_DRIVER_WINMME')
     winmme.add_header('mmsystem.h')
     winmme.add_header('windows.h')
+
+    celt = add_auto_option(opt, 'celt', help='Build with CELT')
+    celt.set_check_hook(check_for_celt, check_for_celt_error)
 
     # dbus options
     opt.sub_options('dbus')
@@ -481,37 +502,6 @@ def configure(conf):
         conf.env['LIB_SAMPLERATE'] = ['samplerate']
 
     conf.sub_config('example-clients')
-
-    if conf.check_cfg(package='celt', atleast_version='0.11.0', args='--cflags --libs', mandatory=False):
-        conf.define('HAVE_CELT', 1)
-        conf.define('HAVE_CELT_API_0_11', 1)
-        conf.define('HAVE_CELT_API_0_8', 0)
-        conf.define('HAVE_CELT_API_0_7', 0)
-        conf.define('HAVE_CELT_API_0_5', 0)
-    elif conf.check_cfg(package='celt', atleast_version='0.8.0', args='--cflags --libs', mandatory=False):
-        conf.define('HAVE_CELT', 1)
-        conf.define('HAVE_CELT_API_0_11', 0)
-        conf.define('HAVE_CELT_API_0_8', 1)
-        conf.define('HAVE_CELT_API_0_7', 0)
-        conf.define('HAVE_CELT_API_0_5', 0)
-    elif conf.check_cfg(package='celt', atleast_version='0.7.0', args='--cflags --libs', mandatory=False):
-        conf.define('HAVE_CELT', 1)
-        conf.define('HAVE_CELT_API_0_11', 0)
-        conf.define('HAVE_CELT_API_0_8', 0)
-        conf.define('HAVE_CELT_API_0_7', 1)
-        conf.define('HAVE_CELT_API_0_5', 0)
-    elif conf.check_cfg(package='celt', atleast_version='0.5.0', args='--cflags --libs', mandatory=False):
-        conf.define('HAVE_CELT', 1)
-        conf.define('HAVE_CELT_API_0_11', 0)
-        conf.define('HAVE_CELT_API_0_8', 0)
-        conf.define('HAVE_CELT_API_0_7', 0)
-        conf.define('HAVE_CELT_API_0_5', 1)
-    else:
-        conf.define('HAVE_CELT', 0)
-        conf.define('HAVE_CELT_API_0_11', 0)
-        conf.define('HAVE_CELT_API_0_8', 0)
-        conf.define('HAVE_CELT_API_0_7', 0)
-        conf.define('HAVE_CELT_API_0_5', 0)
 
     conf.env['WITH_OPUS'] = False
     if conf.check_cfg(package='opus', atleast_version='0.9.0' , args='--cflags --libs', mandatory=False):

--- a/wscript
+++ b/wscript
@@ -396,7 +396,9 @@ def options(opt):
     firewire.add_package('libffado', atleast_version='1.999.17')
     freebob = add_auto_option(opt, 'freebob', help='Enable FreeBob driver')
     freebob.add_package('libfreebob', atleast_version='1.0.0')
-    opt.add_option('--iio', action='store_true', default=False, help='Enable IIO driver')
+    iio = add_auto_option(opt, 'iio', help='Enable IIO driver', conf_dest='BUILD_DRIVER_IIO')
+    iio.add_package('gtkIOStream', atleast_version='1.4.0')
+    iio.add_package('eigen3', atleast_version='3.1.2')
     opt.add_option('--portaudio', action='store_true', default=False, help='Enable Portaudio driver')
     opt.add_option('--winmme', action='store_true', default=False, help='Enable WinMME driver')
 
@@ -464,9 +466,6 @@ def configure(conf):
     conf.sub_config('common')
     if conf.env['IS_LINUX']:
         conf.sub_config('linux')
-        if Options.options.iio and not conf.env['BUILD_DRIVER_IIO']:
-            conf.fatal('IIO driver was explicitly requested but cannot be built')
-        conf.env['BUILD_DRIVER_IIO'] = Options.options.iio
     if conf.env['IS_WINDOWS']:
         conf.sub_config('windows')
         if Options.options.portaudio and not conf.env['BUILD_DRIVER_PORTAUDIO']:
@@ -661,9 +660,6 @@ def configure(conf):
 
     # display configuration result messages for auto options
     display_auto_options_messages()
-
-    if conf.env['IS_LINUX']:
-        display_feature('Build with IIO support', conf.env['BUILD_DRIVER_IIO'] == True)
 
     if conf.env['IS_WINDOWS']:
         display_feature('Build with WinMME support', conf.env['BUILD_DRIVER_WINMME'] == True)

--- a/wscript
+++ b/wscript
@@ -187,7 +187,7 @@ class AutoOption:
             var = program.upper().replace('-', '_')
         self.programs.append([program, var])
 
-    def check_hook(self, check_hook, check_hook_error):
+    def set_check_hook(self, check_hook, check_hook_error):
         """
         Add a check hook and a corresponding error printing function to the
         configure step. The check_hook argument is a function that should return

--- a/wscript
+++ b/wscript
@@ -495,6 +495,9 @@ def configure(conf):
 
     if conf.is_defined('HAVE_SAMPLERATE'):
         conf.env['LIB_SAMPLERATE'] = ['samplerate']
+        conf.env['SAMPLERATE'] = True
+    else:
+        conf.env['SAMPLERATE'] = False
 
     conf.sub_config('common')
     if conf.env['IS_LINUX']:

--- a/wscript
+++ b/wscript
@@ -390,7 +390,8 @@ def options(opt):
     # options with third party dependencies
     doxygen = add_auto_option(opt, 'doxygen', help='Build doxygen documentation', conf_dest='BUILD_DOXYGEN_DOCS')
     doxygen.add_program('doxygen')
-    opt.add_option('--alsa', action='store_true', default=False, help='Enable ALSA driver')
+    alsa = add_auto_option(opt, 'alsa', help='Enable ALSA driver', conf_dest='BUILD_DRIVER_ALSA')
+    alsa.add_package('alsa', atleast_version='1.0.18')
     opt.add_option('--firewire', action='store_true', default=False, help='Enable FireWire driver (FFADO)')
     opt.add_option('--freebob', action='store_true', default=False, help='Enable FreeBob driver')
     opt.add_option('--iio', action='store_true', default=False, help='Enable IIO driver')
@@ -461,15 +462,12 @@ def configure(conf):
     conf.sub_config('common')
     if conf.env['IS_LINUX']:
         conf.sub_config('linux')
-        if Options.options.alsa and not conf.env['BUILD_DRIVER_ALSA']:
-            conf.fatal('ALSA driver was explicitly requested but cannot be built')
         if Options.options.freebob and not conf.env['BUILD_DRIVER_FREEBOB']:
             conf.fatal('FreeBob driver was explicitly requested but cannot be built')
         if Options.options.firewire and not conf.env['BUILD_DRIVER_FFADO']:
             conf.fatal('FFADO driver was explicitly requested but cannot be built')
         if Options.options.iio and not conf.env['BUILD_DRIVER_IIO']:
             conf.fatal('IIO driver was explicitly requested but cannot be built')
-        conf.env['BUILD_DRIVER_ALSA'] = Options.options.alsa
         conf.env['BUILD_DRIVER_FFADO'] = Options.options.firewire
         conf.env['BUILD_DRIVER_FREEBOB'] = Options.options.freebob
         conf.env['BUILD_DRIVER_IIO'] = Options.options.iio
@@ -669,7 +667,6 @@ def configure(conf):
     display_auto_options_messages()
 
     if conf.env['IS_LINUX']:
-        display_feature('Build with ALSA support', conf.env['BUILD_DRIVER_ALSA'] == True)
         display_feature('Build with FireWire (FreeBob) support', conf.env['BUILD_DRIVER_FREEBOB'] == True)
         display_feature('Build with FireWire (FFADO) support', conf.env['BUILD_DRIVER_FFADO'] == True)
         display_feature('Build with IIO support', conf.env['BUILD_DRIVER_IIO'] == True)

--- a/wscript
+++ b/wscript
@@ -491,6 +491,11 @@ def configure(conf):
     # configure all auto options
     configure_auto_options(conf)
 
+    conf.check_cc(header_name='samplerate.h', define_name="HAVE_SAMPLERATE")
+
+    if conf.is_defined('HAVE_SAMPLERATE'):
+        conf.env['LIB_SAMPLERATE'] = ['samplerate']
+
     conf.sub_config('common')
     if conf.env['IS_LINUX']:
         conf.sub_config('linux')
@@ -498,11 +503,6 @@ def configure(conf):
         conf.sub_config('dbus')
         if conf.env['BUILD_JACKDBUS'] != True:
             conf.fatal('jackdbus was explicitly requested but cannot be built')
-
-    conf.check_cc(header_name='samplerate.h', define_name="HAVE_SAMPLERATE")
-
-    if conf.is_defined('HAVE_SAMPLERATE'):
-        conf.env['LIB_SAMPLERATE'] = ['samplerate']
 
     conf.sub_config('example-clients')
 

--- a/wscript
+++ b/wscript
@@ -774,7 +774,7 @@ def build(bld):
                 Logs.pprint('CYAN', "Removing doxygen generated documentation done.")
         elif bld.cmd =='build':
             if not os.access(html_docs_source_dir, os.R_OK):
-                os.popen("doxygen").read()
+                os.popen(bld.env.DOXYGEN).read()
             else:
                 Logs.pprint('CYAN', "doxygen documentation already built.")
 

--- a/wscript
+++ b/wscript
@@ -431,6 +431,8 @@ def options(opt):
     opus.add_package('opus', atleast_version='0.9.0')
     samplerate = add_auto_option(opt, 'samplerate', help='Build with libsamplerate')
     samplerate.add_package('samplerate')
+    sndfile = add_auto_option(opt, 'sndfile', help='Build with libsndfile')
+    sndfile.add_package('sndfile')
 
     # dbus options
     opt.sub_options('dbus')

--- a/wscript
+++ b/wscript
@@ -388,7 +388,8 @@ def options(opt):
     opt.add_option('--ports-per-application', default=768, type="int", dest="application_ports", help='Maximum number of ports per application')
 
     # options with third party dependencies
-    opt.add_option('--doxygen', action='store_true', default=False, help='Enable build of doxygen documentation')
+    doxygen = add_auto_option(opt, 'doxygen', help='Build doxygen documentation', conf_dest='BUILD_DOXYGEN_DOCS')
+    doxygen.add_program('doxygen')
     opt.add_option('--alsa', action='store_true', default=False, help='Enable ALSA driver')
     opt.add_option('--firewire', action='store_true', default=False, help='Enable FireWire driver (FFADO)')
     opt.add_option('--freebob', action='store_true', default=False, help='Enable FreeBob driver')
@@ -537,7 +538,6 @@ def configure(conf):
     conf.env['JACK_API_VERSION'] = JACK_API_VERSION
     conf.env['JACK_VERSION'] = VERSION
 
-    conf.env['BUILD_DOXYGEN_DOCS'] = Options.options.doxygen
     conf.env['BUILD_WITH_PROFILE'] = Options.options.profile
     conf.env['BUILD_WITH_32_64'] = Options.options.mixed
     conf.env['BUILD_CLASSIC'] = Options.options.classic
@@ -653,7 +653,6 @@ def configure(conf):
         display_msg('32-bit C compiler flags', repr(conf.all_envs[lib32]['CFLAGS']))
         display_msg('32-bit C++ compiler flags', repr(conf.all_envs[lib32]['CXXFLAGS']))
         display_msg('32-bit linker flags', repr(conf.all_envs[lib32]['LINKFLAGS']))
-    display_feature('Build doxygen documentation', conf.env['BUILD_DOXYGEN_DOCS'])
     display_feature('Build Opus netjack2', conf.env['WITH_OPUS'])
     display_feature('Build with engine profiling', conf.env['BUILD_WITH_PROFILE'])
     display_feature('Build with 32/64 bits mixed mode', conf.env['BUILD_WITH_32_64'])

--- a/wscript
+++ b/wscript
@@ -102,31 +102,31 @@ class AutoOption:
     __init__.
     """
 
-    # check hook to call upon configuration
-    check_hook = None
-    check_hook_error = None
-    check_hook_found = True
-
-    # required libraries
-    libs = [] # elements on the form [lib,uselib_store]
-    libs_not_found = [] # elements on the form lib
-
-    # required headers
-    headers = []
-    headers_not_found = []
-
-    # required packages (checked with pkg-config)
-    packages = [] # elements on the form [package,uselib_store,atleast_version]
-    packages_not_found = [] # elements on the form [package,atleast_version]
-
-    # required programs
-    programs = [] # elements on the form [program,var]
-    programs_not_found = [] # elements on the form program
-
-    # the result of the configuration (should the option be enabled or not?)
-    result = False
-
     def __init__(self, opt, name, help, conf_dest=None, define=None):
+        # check hook to call upon configuration
+        self.check_hook = None
+        self.check_hook_error = None
+        self.check_hook_found = True
+
+        # required libraries
+        self.libs = [] # elements on the form [lib,uselib_store]
+        self.libs_not_found = [] # elements on the form lib
+
+        # required headers
+        self.headers = []
+        self.headers_not_found = []
+
+        # required packages (checked with pkg-config)
+        self.packages = [] # elements on the form [package,uselib_store,atleast_version]
+        self.packages_not_found = [] # elements on the form [package,atleast_version]
+
+        # required programs
+        self.programs = [] # elements on the form [program,var]
+        self.programs_not_found = [] # elements on the form program
+
+        # the result of the configuration (should the option be enabled or not?)
+        self.result = False
+
         self.help = help
         self.option = '--' + name
         self.dest = 'auto_option_' + name

--- a/wscript
+++ b/wscript
@@ -392,7 +392,8 @@ def options(opt):
     doxygen.add_program('doxygen')
     alsa = add_auto_option(opt, 'alsa', help='Enable ALSA driver', conf_dest='BUILD_DRIVER_ALSA')
     alsa.add_package('alsa', atleast_version='1.0.18')
-    opt.add_option('--firewire', action='store_true', default=False, help='Enable FireWire driver (FFADO)')
+    firewire = add_auto_option(opt, 'firewire', help='Enable FireWire driver (FFADO)', conf_dest='BUILD_DRIVER_FFADO')
+    firewire.add_package('libffado', atleast_version='1.999.17')
     opt.add_option('--freebob', action='store_true', default=False, help='Enable FreeBob driver')
     opt.add_option('--iio', action='store_true', default=False, help='Enable IIO driver')
     opt.add_option('--portaudio', action='store_true', default=False, help='Enable Portaudio driver')
@@ -464,11 +465,8 @@ def configure(conf):
         conf.sub_config('linux')
         if Options.options.freebob and not conf.env['BUILD_DRIVER_FREEBOB']:
             conf.fatal('FreeBob driver was explicitly requested but cannot be built')
-        if Options.options.firewire and not conf.env['BUILD_DRIVER_FFADO']:
-            conf.fatal('FFADO driver was explicitly requested but cannot be built')
         if Options.options.iio and not conf.env['BUILD_DRIVER_IIO']:
             conf.fatal('IIO driver was explicitly requested but cannot be built')
-        conf.env['BUILD_DRIVER_FFADO'] = Options.options.firewire
         conf.env['BUILD_DRIVER_FREEBOB'] = Options.options.freebob
         conf.env['BUILD_DRIVER_IIO'] = Options.options.iio
     if conf.env['IS_WINDOWS']:
@@ -668,7 +666,6 @@ def configure(conf):
 
     if conf.env['IS_LINUX']:
         display_feature('Build with FireWire (FreeBob) support', conf.env['BUILD_DRIVER_FREEBOB'] == True)
-        display_feature('Build with FireWire (FFADO) support', conf.env['BUILD_DRIVER_FFADO'] == True)
         display_feature('Build with IIO support', conf.env['BUILD_DRIVER_IIO'] == True)
 
     if conf.env['IS_WINDOWS']:

--- a/wscript
+++ b/wscript
@@ -273,7 +273,7 @@ class AutoOption:
             print_error('%s requires the package %s, but it cannot be found.' % (self.option, string))
 
         for program in self.programs_not_found:
-            print_error('%s requires the %s program, but it cannot be found.', (self.option, program))
+            print_error('%s requires the %s program, but it cannot be found.' % (self.option, program))
 
         if not self.check_hook_found:
             self.check_hook_error(conf)

--- a/wscript
+++ b/wscript
@@ -394,7 +394,8 @@ def options(opt):
     alsa.add_package('alsa', atleast_version='1.0.18')
     firewire = add_auto_option(opt, 'firewire', help='Enable FireWire driver (FFADO)', conf_dest='BUILD_DRIVER_FFADO')
     firewire.add_package('libffado', atleast_version='1.999.17')
-    opt.add_option('--freebob', action='store_true', default=False, help='Enable FreeBob driver')
+    freebob = add_auto_option(opt, 'freebob', help='Enable FreeBob driver')
+    freebob.add_package('libfreebob', atleast_version='1.0.0')
     opt.add_option('--iio', action='store_true', default=False, help='Enable IIO driver')
     opt.add_option('--portaudio', action='store_true', default=False, help='Enable Portaudio driver')
     opt.add_option('--winmme', action='store_true', default=False, help='Enable WinMME driver')
@@ -463,11 +464,8 @@ def configure(conf):
     conf.sub_config('common')
     if conf.env['IS_LINUX']:
         conf.sub_config('linux')
-        if Options.options.freebob and not conf.env['BUILD_DRIVER_FREEBOB']:
-            conf.fatal('FreeBob driver was explicitly requested but cannot be built')
         if Options.options.iio and not conf.env['BUILD_DRIVER_IIO']:
             conf.fatal('IIO driver was explicitly requested but cannot be built')
-        conf.env['BUILD_DRIVER_FREEBOB'] = Options.options.freebob
         conf.env['BUILD_DRIVER_IIO'] = Options.options.iio
     if conf.env['IS_WINDOWS']:
         conf.sub_config('windows')
@@ -665,7 +663,6 @@ def configure(conf):
     display_auto_options_messages()
 
     if conf.env['IS_LINUX']:
-        display_feature('Build with FireWire (FreeBob) support', conf.env['BUILD_DRIVER_FREEBOB'] == True)
         display_feature('Build with IIO support', conf.env['BUILD_DRIVER_IIO'] == True)
 
     if conf.env['IS_WINDOWS']:

--- a/wscript
+++ b/wscript
@@ -426,6 +426,9 @@ def options(opt):
 
     celt = add_auto_option(opt, 'celt', help='Build with CELT')
     celt.set_check_hook(check_for_celt, check_for_celt_error)
+    opus = add_auto_option(opt, 'opus', help='Build Opus netjack2')
+    opus.add_header('opus/opus_custom.h')
+    opus.add_package('opus', atleast_version='0.9.0')
 
     # dbus options
     opt.sub_options('dbus')
@@ -502,15 +505,6 @@ def configure(conf):
         conf.env['LIB_SAMPLERATE'] = ['samplerate']
 
     conf.sub_config('example-clients')
-
-    conf.env['WITH_OPUS'] = False
-    if conf.check_cfg(package='opus', atleast_version='0.9.0' , args='--cflags --libs', mandatory=False):
-        if conf.check_cc(header_name='opus/opus_custom.h', mandatory=False):
-            conf.define('HAVE_OPUS', 1)
-            conf.env['WITH_OPUS'] = True
-        else:
-            conf.define('HAVE_OPUS', 0)
-
 
     conf.env['LIB_PTHREAD'] = ['pthread']
     conf.env['LIB_DL'] = ['dl']
@@ -635,7 +629,6 @@ def configure(conf):
         display_msg('32-bit C compiler flags', repr(conf.all_envs[lib32]['CFLAGS']))
         display_msg('32-bit C++ compiler flags', repr(conf.all_envs[lib32]['CXXFLAGS']))
         display_msg('32-bit linker flags', repr(conf.all_envs[lib32]['LINKFLAGS']))
-    display_feature('Build Opus netjack2', conf.env['WITH_OPUS'])
     display_feature('Build with engine profiling', conf.env['BUILD_WITH_PROFILE'])
     display_feature('Build with 32/64 bits mixed mode', conf.env['BUILD_WITH_32_64'])
 

--- a/wscript
+++ b/wscript
@@ -189,7 +189,7 @@ class AutoOption:
 
     def set_check_hook(self, check_hook, check_hook_error):
         """
-        Add a check hook and a corresponding error printing function to the
+        Set the check hook and the corresponding error printing function to the
         configure step. The check_hook argument is a function that should return
         True if the extra prerequisites were found and False if not. The
         check_hook_error argument is an error printing function that should

--- a/wscript
+++ b/wscript
@@ -433,6 +433,8 @@ def options(opt):
     samplerate.add_package('samplerate')
     sndfile = add_auto_option(opt, 'sndfile', help='Build with libsndfile')
     sndfile.add_package('sndfile')
+    readline = add_auto_option(opt, 'readline', help='Build with readline')
+    readline.add_library('readline')
 
     # dbus options
     opt.sub_options('dbus')

--- a/wscript
+++ b/wscript
@@ -382,6 +382,24 @@ def check_for_celt(conf):
 def check_for_celt_error(conf):
     print_error('--celt requires the package celt, but it could not be found.')
 
+# The readline/readline.h header does not work if stdio.h is not included
+# before. Thus a fragment with both stdio.h and readline/readline.h need to be
+# test-compiled to find out whether readline is available.
+def check_for_readline(conf):
+    try:
+        conf.check_cc(fragment='''
+                      #include <stdio.h>
+                      #include <readline/readline.h>
+                      int main(void) { return 0; }''',
+                      execute=False,
+                      msg='Checking for header readline/readline.h')
+        return True
+    except conf.errors.ConfigurationError:
+        return False
+
+def check_for_readline_error(conf):
+    print_error('--readline requires the readline/readline.h header, but it cannot be found.')
+
 def options(opt):
     # options provided by the modules
     opt.tool_options('compiler_cxx')
@@ -435,6 +453,7 @@ def options(opt):
     sndfile.add_package('sndfile')
     readline = add_auto_option(opt, 'readline', help='Build with readline')
     readline.add_library('readline')
+    readline.set_check_hook(check_for_readline, check_for_readline_error)
 
     # dbus options
     opt.sub_options('dbus')

--- a/wscript
+++ b/wscript
@@ -399,7 +399,9 @@ def options(opt):
     iio = add_auto_option(opt, 'iio', help='Enable IIO driver', conf_dest='BUILD_DRIVER_IIO')
     iio.add_package('gtkIOStream', atleast_version='1.4.0')
     iio.add_package('eigen3', atleast_version='3.1.2')
-    opt.add_option('--portaudio', action='store_true', default=False, help='Enable Portaudio driver')
+    portaudio = add_auto_option(opt, 'portaudio', help='Enable Portaudio driver', conf_dest='BUILD_DRIVER_PORTAUDIO')
+    portaudio.add_header('windows.h') # only build portaudio on windows
+    portaudio.add_package('portaudio-2.0', uselib_store='PORTAUDIO', atleast_version='19')
     opt.add_option('--winmme', action='store_true', default=False, help='Enable WinMME driver')
 
     # dbus options
@@ -467,10 +469,7 @@ def configure(conf):
     if conf.env['IS_LINUX']:
         conf.sub_config('linux')
     if conf.env['IS_WINDOWS']:
-        conf.sub_config('windows')
-        if Options.options.portaudio and not conf.env['BUILD_DRIVER_PORTAUDIO']:
-            conf.fatal('Portaudio driver was explicitly requested but cannot be built')
-        conf.env['BUILD_DRIVER_WINMME'] = Options.options.winmme
+         conf.env['BUILD_DRIVER_WINMME'] = Options.options.winmme
     if Options.options.dbus:
         conf.sub_config('dbus')
         if conf.env['BUILD_JACKDBUS'] != True:
@@ -663,7 +662,6 @@ def configure(conf):
 
     if conf.env['IS_WINDOWS']:
         display_feature('Build with WinMME support', conf.env['BUILD_DRIVER_WINMME'] == True)
-        display_feature('Build with Portaudio support', conf.env['BUILD_DRIVER_PORTAUDIO'] == True)
 
     if conf.env['BUILD_JACKDBUS'] == True:
         display_msg('D-Bus service install directory', conf.env['DBUS_SERVICES_DIR'], 'CYAN')

--- a/wscript
+++ b/wscript
@@ -402,7 +402,9 @@ def options(opt):
     portaudio = add_auto_option(opt, 'portaudio', help='Enable Portaudio driver', conf_dest='BUILD_DRIVER_PORTAUDIO')
     portaudio.add_header('windows.h') # only build portaudio on windows
     portaudio.add_package('portaudio-2.0', uselib_store='PORTAUDIO', atleast_version='19')
-    opt.add_option('--winmme', action='store_true', default=False, help='Enable WinMME driver')
+    winmme = add_auto_option(opt, 'winmme', help='Enable WinMME driver', conf_dest='BUILD_DRIVER_WINMME')
+    winmme.add_header('mmsystem.h')
+    winmme.add_header('windows.h')
 
     # dbus options
     opt.sub_options('dbus')
@@ -468,8 +470,6 @@ def configure(conf):
     conf.sub_config('common')
     if conf.env['IS_LINUX']:
         conf.sub_config('linux')
-    if conf.env['IS_WINDOWS']:
-         conf.env['BUILD_DRIVER_WINMME'] = Options.options.winmme
     if Options.options.dbus:
         conf.sub_config('dbus')
         if conf.env['BUILD_JACKDBUS'] != True:
@@ -659,9 +659,6 @@ def configure(conf):
 
     # display configuration result messages for auto options
     display_auto_options_messages()
-
-    if conf.env['IS_WINDOWS']:
-        display_feature('Build with WinMME support', conf.env['BUILD_DRIVER_WINMME'] == True)
 
     if conf.env['BUILD_JACKDBUS'] == True:
         display_msg('D-Bus service install directory', conf.env['DBUS_SERVICES_DIR'], 'CYAN')

--- a/wscript
+++ b/wscript
@@ -429,6 +429,8 @@ def options(opt):
     opus = add_auto_option(opt, 'opus', help='Build Opus netjack2')
     opus.add_header('opus/opus_custom.h')
     opus.add_package('opus', atleast_version='0.9.0')
+    samplerate = add_auto_option(opt, 'samplerate', help='Build with libsamplerate')
+    samplerate.add_package('samplerate')
 
     # dbus options
     opt.sub_options('dbus')
@@ -490,14 +492,6 @@ def configure(conf):
 
     # configure all auto options
     configure_auto_options(conf)
-
-    conf.check_cc(header_name='samplerate.h', define_name="HAVE_SAMPLERATE")
-
-    if conf.is_defined('HAVE_SAMPLERATE'):
-        conf.env['LIB_SAMPLERATE'] = ['samplerate']
-        conf.env['SAMPLERATE'] = True
-    else:
-        conf.env['SAMPLERATE'] = False
 
     conf.sub_config('common')
     if conf.env['IS_LINUX']:


### PR DESCRIPTION
After the previous pull request https://github.com/jackaudio/jack2/pull/110 we decided it would be good to have option in the build system that can have two states 'yes' and 'no'. That is implemented in this pull request. Some options can now be specified as --foo=yes or --foo=no to enable and disable foo respectively. The old form --foo is interpreted as --foo=yes. Together with other fixes and improvements. This pull includes the following:

1. Implementation of (and some fixes to) the AutoOptions class that is the logical backone for all options.
2. Move from old option to auto options where appropriate, i.e. an option can be enabled by default and has external dependencies.
3. Automagic depdendencies (see [1] for more info on these) on celt, opus, samplerate, sndfile and readline has been removed by letting their inclusion be controlled by the auto options --celt, --opus, --samplerate, --sndfile and --readline respectively.
4. Checks are performed using pkg-config where possible (since pkg-config is superior to header/library checks).
5. The check for readline now includes a custom header check on readline/readline.h. This is needed since stdio.h must be included before readline/readline.h. This fix makes sure the build system does not decide to build against readline if its developement files are missing (on distros with headers separated from libraries (binary distros, that is)).

[1] https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies