### PR TITLE
Doxygen fixes, less hardcoding and --htmldir

### DIFF
--- a/doxyfile.in
+++ b/doxyfile.in
@@ -31,7 +31,7 @@ PROJECT_NAME           = "Jack2"
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 1.9.11
+PROJECT_NUMBER         = @VERSION@
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/doxyfile.in
+++ b/doxyfile.in
@@ -574,22 +574,22 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = common \
-                         posix \
-                         macosx \
-                         macosx/coreaudio/ \
-			 macosx/coremidi/ \
-                         linux \
-                         linux/alsa \
-			 linux/alsarawmidi \
-			 linux/firewire \
-			 linux/freebob \
-                         windows \
-                         windows/portaudio \
-                         windows/winmme \
-                         solaris \
-			 solaris/oss \
-                         common/jack/
+INPUT                  = @SRCDIR@/common \
+                         @SRCDIR@/posix \
+                         @SRCDIR@/macosx \
+                         @SRCDIR@/macosx/coreaudio/ \
+                         @SRCDIR@/macosx/coremidi/ \
+                         @SRCDIR@/linux \
+                         @SRCDIR@/linux/alsa \
+                         @SRCDIR@/linux/alsarawmidi \
+                         @SRCDIR@/linux/firewire \
+                         @SRCDIR@/linux/freebob \
+                         @SRCDIR@/windows \
+                         @SRCDIR@/windows/portaudio \
+                         @SRCDIR@/windows/winmme \
+                         @SRCDIR@/solaris \
+                         @SRCDIR@/solaris/oss \
+                         @SRCDIR@/common/jack/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -789,7 +789,7 @@ GENERATE_HTML          = YES
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be
 # put in front of it. If left blank `html' will be used as the default path.
 
-HTML_OUTPUT            =
+HTML_OUTPUT            = @HTML_BUILD_DIR@
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for
 # each generated HTML page (for example: .htm,.php,.asp). If it is left blank

--- a/wscript
+++ b/wscript
@@ -736,7 +736,7 @@ def build(bld):
         #bld.add_subdirs('tests')
 
     if bld.env['BUILD_DOXYGEN_DOCS'] == True:
-        html_source_dir = "build/default/html"
+        html_build_dir = "build/default/html"
         if bld.cmd == 'install':
             share_dir = bld.options.destdir + bld.env['PREFIX'] + '/share/jack-audio-connection-kit'
             html_install_dir = share_dir + '/reference/html/'
@@ -745,7 +745,7 @@ def build(bld):
                 shutil.rmtree(html_install_dir)
                 Logs.pprint('CYAN', "Removing old doxygen documentation installation done.")
             Logs.pprint('CYAN', "Installing doxygen documentation...")
-            shutil.copytree(html_source_dir, html_install_dir)
+            shutil.copytree(html_build_dir, html_install_dir)
             Logs.pprint('CYAN', "Installing doxygen documentation done.")
         elif bld.cmd =='uninstall':
             Logs.pprint('CYAN', "Uninstalling doxygen documentation...")
@@ -753,12 +753,12 @@ def build(bld):
                 shutil.rmtree(share_dir)
             Logs.pprint('CYAN', "Uninstalling doxygen documentation done.")
         elif bld.cmd =='clean':
-            if os.access(html_source_dir, os.R_OK):
+            if os.access(html_build_dir, os.R_OK):
                 Logs.pprint('CYAN', "Removing doxygen generated documentation...")
-                shutil.rmtree(html_source_dir)
+                shutil.rmtree(html_build_dir)
                 Logs.pprint('CYAN', "Removing doxygen generated documentation done.")
         elif bld.cmd =='build':
-            if not os.access(html_source_dir, os.R_OK):
+            if not os.access(html_build_dir, os.R_OK):
                 os.popen(bld.env.DOXYGEN).read()
             else:
                 Logs.pprint('CYAN', "doxygen documentation already built.")

--- a/wscript
+++ b/wscript
@@ -765,9 +765,9 @@ def build(bld):
             target = 'doxygen.log'
         )
 
+        share_dir = bld.options.destdir + bld.env['PREFIX'] + '/share/jack-audio-connection-kit'
+        html_install_dir = share_dir + '/reference/html/'
         if bld.cmd == 'install':
-            share_dir = bld.options.destdir + bld.env['PREFIX'] + '/share/jack-audio-connection-kit'
-            html_install_dir = share_dir + '/reference/html/'
             if os.path.isdir(html_install_dir):
                 Logs.pprint('CYAN', "Removing old doxygen documentation installation...")
                 shutil.rmtree(html_install_dir)

--- a/wscript
+++ b/wscript
@@ -736,16 +736,16 @@ def build(bld):
         #bld.add_subdirs('tests')
 
     if bld.env['BUILD_DOXYGEN_DOCS'] == True:
-        html_docs_source_dir = "build/default/html"
+        html_source_dir = "build/default/html"
         if bld.cmd == 'install':
             share_dir = bld.options.destdir + bld.env['PREFIX'] + '/share/jack-audio-connection-kit'
-            html_docs_install_dir = share_dir + '/reference/html/'
-            if os.path.isdir(html_docs_install_dir):
+            html_install_dir = share_dir + '/reference/html/'
+            if os.path.isdir(html_install_dir):
                 Logs.pprint('CYAN', "Removing old doxygen documentation installation...")
-                shutil.rmtree(html_docs_install_dir)
+                shutil.rmtree(html_install_dir)
                 Logs.pprint('CYAN', "Removing old doxygen documentation installation done.")
             Logs.pprint('CYAN', "Installing doxygen documentation...")
-            shutil.copytree(html_docs_source_dir, html_docs_install_dir)
+            shutil.copytree(html_source_dir, html_install_dir)
             Logs.pprint('CYAN', "Installing doxygen documentation done.")
         elif bld.cmd =='uninstall':
             Logs.pprint('CYAN', "Uninstalling doxygen documentation...")
@@ -753,12 +753,12 @@ def build(bld):
                 shutil.rmtree(share_dir)
             Logs.pprint('CYAN', "Uninstalling doxygen documentation done.")
         elif bld.cmd =='clean':
-            if os.access(html_docs_source_dir, os.R_OK):
+            if os.access(html_source_dir, os.R_OK):
                 Logs.pprint('CYAN', "Removing doxygen generated documentation...")
-                shutil.rmtree(html_docs_source_dir)
+                shutil.rmtree(html_source_dir)
                 Logs.pprint('CYAN', "Removing doxygen generated documentation done.")
         elif bld.cmd =='build':
-            if not os.access(html_docs_source_dir, os.R_OK):
+            if not os.access(html_source_dir, os.R_OK):
                 os.popen(bld.env.DOXYGEN).read()
             else:
                 Logs.pprint('CYAN', "doxygen documentation already built.")

--- a/wscript
+++ b/wscript
@@ -743,7 +743,8 @@ def build(bld):
             source = 'doxyfile.in',
             target = 'doxyfile',
             HTML_BUILD_DIR = html_build_dir,
-            SRCDIR = bld.srcnode.abspath()
+            SRCDIR = bld.srcnode.abspath(),
+            VERSION = VERSION
         )
 
         # There are two reasons for logging to doxygen.log and using it as

--- a/wscript
+++ b/wscript
@@ -406,6 +406,7 @@ def options(opt):
     opt.tool_options('compiler_cc')
 
     # install directories
+    opt.add_option('--htmldir', type='string', default=None, help="HTML documentation directory [Default: <prefix>/share/jack-audio-connection-kit/reference/html/")
     opt.add_option('--libdir', type='string', help="Library directory [Default: <prefix>/lib]")
     opt.add_option('--libdir32', type='string', help="32bit Library directory [Default: <prefix>/lib32]")
     opt.add_option('--mandir', type='string', help="Manpage directory [Default: <prefix>/share/man/man1]")
@@ -545,6 +546,13 @@ def configure(conf):
         conf.env['BUILD_JACKD'] = True
 
     conf.env['BINDIR'] = conf.env['PREFIX'] + '/bin'
+
+    if Options.options.htmldir:
+        conf.env['HTMLDIR'] = Options.options.htmldir
+    else:
+        # set to None here so that the doxygen code can find out the highest
+        # directory to remove upon install
+        conf.env['HTMLDIR'] = None
 
     if Options.options.libdir:
         conf.env['LIBDIR'] = Options.options.libdir
@@ -765,8 +773,17 @@ def build(bld):
             target = 'doxygen.log'
         )
 
-        share_dir = bld.options.destdir + bld.env['PREFIX'] + '/share/jack-audio-connection-kit'
-        html_install_dir = share_dir + '/reference/html/'
+        # Determine where to install HTML documentation. Since share_dir is the
+        # highest directory the uninstall routine should remove, there is no
+        # better candidate for share_dir, but the requested HTML directory if
+        # --htmldir is given.
+        if bld.env['HTMLDIR']:
+            html_install_dir = bld.options.destdir + bld.env['HTMLDIR']
+            share_dir = html_install_dir
+        else:
+            share_dir = bld.options.destdir + bld.env['PREFIX'] + '/share/jack-audio-connection-kit'
+            html_install_dir = share_dir + '/reference/html/'
+
         if bld.cmd == 'install':
             if os.path.isdir(html_install_dir):
                 Logs.pprint('CYAN', "Removing old doxygen documentation installation...")


### PR DESCRIPTION
The install phase fails with doxygen enabled since doxygen generates html to the html directory directly under the top source directory. Not only is this bad (build files in source directory!), but it made installation fail when waf thought that html docs reside in build/default/html. This pull request fixes this issue by generating the doxyfile from a template, doxyfile.in. This makes it possible for wscript to subst correct directories into doxyfile. The manual invokation of doxygen was removed in favour of a waf rule (which is necessary since it now must depend on doxyfile). Also doxygen output has been piped into a log file for various reasons.

There was an other fault that made the uninstall phase fail (because share_dir was defined on the wrong place). This is fixed too.

As a goodie the previously hardcoded version in doxyfile could be replaced with a version tag that the wscript can substitute for the real version when building (it follows the version specified in wscript). Less manual work, great! This has been applied in this pull request.

Another important thing is the --htmldir option that this pull request adds. It is necessary for us in Gentoo downstream to make sure documentation goes into the correct directories (standardized file system structure, you know). I guess it is beneficial to other packagers aswell. No default behaviour is changed.

Over and out.