### PR TITLE
Mingw waf fixes

### DIFF
--- a/example-clients/transport.c
+++ b/example-clients/transport.c
@@ -459,9 +459,11 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+#ifndef WIN32
 	signal(SIGQUIT, signal_handler);
-	signal(SIGTERM, signal_handler);
 	signal(SIGHUP, signal_handler);
+#endif
+	signal(SIGTERM, signal_handler);
 	signal(SIGINT, signal_handler);
 
 	jack_on_shutdown(client, jack_shutdown, 0);

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -93,6 +93,8 @@ def build(bld):
             prog.use += ['RT', 'READLINE']
         if bld.env['IS_MACOSX']:
             prog.use += ['READLINE']
+        if bld.env['IS_WINDOWS']:
+            prog.use += ['READLINE']
         prog.target = 'jack_transport'
 
     if bld.env['BUILD_EXAMPLE_CLIENT_REC']:

--- a/wscript
+++ b/wscript
@@ -400,6 +400,21 @@ def check_for_readline(conf):
 def check_for_readline_error(conf):
     print_error('--readline requires the readline/readline.h header, but it cannot be found.')
 
+def check_for_mmsystem(conf):
+    try:
+        conf.check_cc(fragment='''
+                      #include <windows.h>
+                      #include <mmsystem.h>
+                      int main(void) { return 0; }''',
+                      execute=False,
+                      msg='Checking for header mmsystem.h')
+        return True
+    except conf.errors.ConfigurationError:
+        return False
+
+def check_for_mmsystem_error(conf):
+    print_error('--winmme requires the mmsystem.h header, but it cannot be found.')
+
 def options(opt):
     # options provided by the modules
     opt.tool_options('compiler_cxx')
@@ -440,8 +455,7 @@ def options(opt):
     portaudio.add_header('windows.h') # only build portaudio on windows
     portaudio.add_package('portaudio-2.0', uselib_store='PORTAUDIO', atleast_version='19')
     winmme = add_auto_option(opt, 'winmme', help='Enable WinMME driver', conf_dest='BUILD_DRIVER_WINMME')
-    winmme.add_header('mmsystem.h')
-    winmme.add_header('windows.h')
+    winmme.set_check_hook(check_for_mmsystem, check_for_mmsystem_error)
 
     celt = add_auto_option(opt, 'celt', help='Build with CELT')
     celt.set_check_hook(check_for_celt, check_for_celt_error)


### PR DESCRIPTION
These small fixes are necessary for successful build using waf with mingw-w64 when cross compiling on linux(tested with Fedora) and using MSYS2 environment on windows.