### PR TITLE
Fix svnversion.h generation

### DIFF
--- a/svnversion_regenerate.sh
+++ b/svnversion_regenerate.sh
@@ -16,8 +16,6 @@ TEMP_FILE="${OUTPUT_FILE}.tmp"
 #echo "$OUTPUT_FILE"
 #echo "$TEMP_FILE"
 
-OLDPWD=`pwd`
-
 # The script should reside in the toplevel source directory which sould contain
 # all version control files.
 cd `dirname ${0}`
@@ -65,8 +63,6 @@ else
     if test $? -ne 0; then exit 1; fi
   fi
 fi
-
-cd "${OLDPWD}"
 
 rm "${TEMP_FILE}"
 

--- a/svnversion_regenerate.sh
+++ b/svnversion_regenerate.sh
@@ -17,7 +17,10 @@ TEMP_FILE="${OUTPUT_FILE}.tmp"
 #echo "$TEMP_FILE"
 
 OLDPWD=`pwd`
-cd ..
+
+# The script should reside in the toplevel source directory which sould contain
+# all version control files.
+cd `dirname ${0}`
 
 if test $# -eq 2
 then

--- a/wscript
+++ b/wscript
@@ -710,8 +710,11 @@ def build(bld):
             #print sg.encode('hex')
             Build.bld.node_sigs[self.env.variant()][self.outputs[0].id] = sg
 
+        script = bld.path.find_resource('svnversion_regenerate.sh')
+        script = script.abspath()
+
         bld(
-                rule = '../svnversion_regenerate.sh ${TGT}',
+                rule = '%s ${TGT}' % script,
                 name = 'svnversion',
                 runnable_status = Task.RUN_ME,
                 before = 'c',

--- a/wscript
+++ b/wscript
@@ -621,11 +621,15 @@ def configure(conf):
     conf.write_config_header('config.h', remove=False)
 
     svnrev = None
-    if os.access('svnversion.h', os.R_OK):
-        data = file('svnversion.h').read()
+    try:
+        f = open('svnversion.h')
+        data = f.read()
         m = re.match(r'^#define SVN_VERSION "([^"]*)"$', data)
         if m != None:
             svnrev = m.group(1)
+        f.close()
+    except FileNotFoundError:
+        pass
 
     if Options.options.mixed == True:
         conf.setenv(lib32, env=conf.env.derive())

--- a/wscript
+++ b/wscript
@@ -809,6 +809,7 @@ def build(bld):
                 shutil.rmtree(html_build_dir)
                 Logs.pprint('CYAN', "Removing doxygen generated documentation done.")
 
-def dist_hook():
-    os.remove('svnversion_regenerate.sh')
-    os.system('../svnversion_regenerate.sh svnversion.h')
+def dist(ctx):
+    # This code blindly assumes it is working in the toplevel source directory.
+    if not os.path.exists('svnversion.h'):
+        os.system('./svnversion_regenerate.sh svnversion.h')

--- a/wscript
+++ b/wscript
@@ -714,8 +714,6 @@ def build(bld):
     print("make[1]: Entering directory `" + os.getcwd() + "/" + out2 + "'")
 
     if not bld.variant:
-        if not os.access('svnversion.h', os.R_OK):
-            create_svnversion_task(bld)
         if bld.env['BUILD_WITH_32_64'] == True:
             waflib.Options.commands.append(bld.cmd + '_' + lib32)
 
@@ -725,6 +723,9 @@ def build(bld):
     if bld.variant:
         # only the wscript in common/ knows how to handle variants
         return
+
+    if not os.access('svnversion.h', os.R_OK):
+        create_svnversion_task(bld)
 
     if bld.env['IS_LINUX']:
         bld.add_subdirs('linux')

--- a/wscript
+++ b/wscript
@@ -50,26 +50,6 @@ def display_feature(msg, build):
 def print_error(msg):
     print(Logs.colors.RED + msg + Logs.colors.NORMAL)
 
-def create_svnversion_task(bld, header='svnversion.h', define=None):
-    cmd = '../svnversion_regenerate.sh ${TGT}'
-    if define:
-        cmd += " " + define
-
-    def post_run(self):
-        sg = Utils.h_file(self.outputs[0].abspath(self.env))
-        #print sg.encode('hex')
-        Build.bld.node_sigs[self.env.variant()][self.outputs[0].id] = sg
-
-    bld(
-            rule = cmd,
-            name = 'svnversion',
-            runnable_status = Task.RUN_ME,
-            before = 'c',
-            color = 'BLUE',
-            post_run = post_run,
-            target = [bld.path.find_or_declare(header)]
-    )
-
 class AutoOption:
     """
     This class is the foundation for the auto options. It adds an option
@@ -725,7 +705,20 @@ def build(bld):
         return
 
     if not os.access('svnversion.h', os.R_OK):
-        create_svnversion_task(bld)
+        def post_run(self):
+            sg = Utils.h_file(self.outputs[0].abspath(self.env))
+            #print sg.encode('hex')
+            Build.bld.node_sigs[self.env.variant()][self.outputs[0].id] = sg
+
+        bld(
+                rule = '../svnversion_regenerate.sh ${TGT}',
+                name = 'svnversion',
+                runnable_status = Task.RUN_ME,
+                before = 'c',
+                color = 'BLUE',
+                post_run = post_run,
+                target = [bld.path.find_or_declare('svnversion.h')]
+        )
 
     if bld.env['IS_LINUX']:
         bld.add_subdirs('linux')

--- a/wscript
+++ b/wscript
@@ -720,6 +720,7 @@ def build(bld):
                 before = 'c cxx',
                 color = 'BLUE',
                 post_run = post_run,
+                source = ['svnversion_regenerate.sh'],
                 target = [bld.path.find_or_declare('svnversion.h')]
         )
 

--- a/wscript
+++ b/wscript
@@ -717,7 +717,7 @@ def build(bld):
                 rule = '%s ${TGT}' % script,
                 name = 'svnversion',
                 runnable_status = Task.RUN_ME,
-                before = 'c',
+                before = 'c cxx',
                 color = 'BLUE',
                 post_run = post_run,
                 target = [bld.path.find_or_declare('svnversion.h')]


### PR DESCRIPTION
The svnversion.h was broken since the dist_hook was never called. This resulted in SVN_REVISION being defined as "unknown" (since svnversion.h did not exist and not the .git directory either) in distributed tarballs. This pull request fixes that issue.

Also the svnersion_regenerate.sh script assumed ../ was the source directory. It has been fixed.

Another issue was the hardcoded path to the svnersion_regenerate.sh script which caused builds with a nonstandard out directory (--out was specified and was not build) to fail. This is also fixed.

There are a few very minor fixes too such as future-proofing so that cxx sources can use svnversion.h to.