### PR TITLE
[jack_bufsize] Fix off by 10 error

### DIFF
--- a/example-clients/bufsize.c
+++ b/example-clients/bufsize.c
@@ -76,7 +76,7 @@ void parse_arguments(int argc, char *argv[])
 		exit(2);
 	}
 
-    if (nframes < 1 || nframes > 8182) {
+    if (nframes < 1 || nframes > 8192) {
 		fprintf(stderr, "%s: invalid buffer size: %s (range is 1-8192)\n",
 			package, argv[1]);
 		exit(3);


### PR DESCRIPTION
Since help and error messages suggest, that 8192 samples is a valid
buffer size, this fixes the value in the check to 8192 instead of 8182.