### PR TITLE
Use _WIN32 instead of WIN32 in header files since WIN32 might not alw…

### DIFF
--- a/common/jack/systemdeps.h
+++ b/common/jack/systemdeps.h
@@ -58,7 +58,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(GNU_WIN32)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(GNU_WIN32)
 
     #include <windows.h>
 
@@ -101,7 +101,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
         typedef pthread_t jack_native_thread_t;
     #endif
 
-#endif /* WIN32 && !__CYGWIN__ && !GNU_WIN32 */
+#endif /* _WIN32 && !__CYGWIN__ && !GNU_WIN32 */
 
 #if defined(__APPLE__) || defined(__linux__) || defined(__sun__) || defined(sun) || defined(__unix__) || defined(__CYGWIN__) || defined(GNU_WIN32)
 

--- a/common/jack/thread.h
+++ b/common/jack/thread.h
@@ -122,7 +122,7 @@ int jack_client_stop_thread(jack_client_t* client, jack_native_thread_t thread) 
  */
  int jack_client_kill_thread(jack_client_t* client, jack_native_thread_t thread) JACK_OPTIONAL_WEAK_EXPORT;
 
-#ifndef WIN32
+#ifndef _WIN32
 
  typedef int (*jack_thread_creator_t)(pthread_t*,
 				     const pthread_attr_t*,

--- a/common/jack/weakmacros.h
+++ b/common/jack/weakmacros.h
@@ -47,7 +47,7 @@
    require linker arguments in the client as well.
 */
 
-#ifdef WIN32
+#ifdef _WIN32
     /*
         Not working with __declspec(dllexport) so normal linking
         Linking with JackWeakAPI.cpp will be the preferred way.
@@ -60,7 +60,7 @@
 #else
 /* Add other things here for non-gcc platforms */
 
-#ifdef WIN32
+#ifdef _WIN32
 #define JACK_WEAK_EXPORT
 #endif
 
@@ -81,7 +81,7 @@
 #else
 /* Add other things here for non-gcc platforms */
 
-#ifdef WIN32
+#ifdef _WIN32
 #define JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT
 #endif
 


### PR DESCRIPTION
…ays be defined

For instance, if compiling with gcc and the option --stc=c++11, WIN32 is not defined.
See http://webcache.googleusercontent.com/search?q=cache:amvfgAUCdsgJ:sourceforge.net/p/mingw-w64/mailman/message/31850993/+&cd=4&hl=en&ct=clnk&gl=no
http://sourceforge.net/p/mingw-w64/mailman/message/31850993/