### PR TITLE
Fix CPU hogging of the midi_thread()

### DIFF
--- a/linux/alsa/alsa_rawmidi.c
+++ b/linux/alsa/alsa_rawmidi.c
@@ -43,7 +43,7 @@ enum {
 	NANOSLEEP_RESOLUTION = 7000
 };
 
-#define NFRAMES_INF INT_MAX
+#define NFRAMES_INF ULLONG_MAX
 
 enum {
 #ifndef JACK_MIDI_DEBUG


### PR DESCRIPTION
The midi thread was always late after 2^31-1 Samples (~13.5h at 44.1kHz), because when there's no time limit, a uint64_t sample counter was compared against a signed 32bit INT_MAX to determine lateness. Now the CPU lockup will occur only after ~3 million years (at 192kHz), and because of the overflow it will presumably fix itself after a few milliseconds. Fixes #150 