### PR TITLE
Release audio devices when alsa_driver_new fails

### DIFF
--- a/linux/alsa/JackAlsaDriver.cpp
+++ b/linux/alsa/JackAlsaDriver.cpp
@@ -346,7 +346,7 @@ int JackAlsaDriver::Open(jack_nframes_t nframes,
         fPlaybackChannels = ((alsa_driver_t *)fDriver)->playback_nchannels;
         return 0;
     } else {
-        JackAudioDriver::Close();
+        Close();
         return -1;
     }
 }
@@ -356,7 +356,9 @@ int JackAlsaDriver::Close()
     // Generic audio driver close
     int res = JackAudioDriver::Close();
 
-    alsa_driver_delete((alsa_driver_t*)fDriver);
+    if (fDriver) {
+        alsa_driver_delete((alsa_driver_t*)fDriver);
+    }
 
     if (JackServerGlobals::on_device_release != NULL)
     {


### PR DESCRIPTION
Call JackAlsaDriver::Close() when alsa_driver_new() fails, to
release devices acquired just before that call. Otherwise
JackAlsaDriver::Open() will never succeed again, as re-acquiring the
same device will fail with "A handler is already registered" DBus error.