### PR TITLE
Fix Netjack crashes due to broken alignment

### DIFF
--- a/common/JackNetTool.h
+++ b/common/JackNetTool.h
@@ -38,7 +38,7 @@ using namespace std;
 #endif
 #endif
 
-#define NETWORK_PROTOCOL 8
+#define NETWORK_PROTOCOL 9
 
 #define NET_SYNCHING      0
 #define SYNC_PACKET_ERROR -2

--- a/common/JackNetTool.h
+++ b/common/JackNetTool.h
@@ -94,9 +94,9 @@ namespace Jack
         char fPacketType[8];                        //packet type ('param')
         uint32_t fProtocolVersion;                  //version
         int32_t fPacketID;                          //indicates the packet type
-        char fName[JACK_CLIENT_NAME_SIZE+1];          //slave's name
-        char fMasterNetName[JACK_SERVER_NAME_SIZE+1]; //master hostname (network)
-        char fSlaveNetName[JACK_SERVER_NAME_SIZE+1];  //slave hostname (network)
+        char fName[JACK_CLIENT_NAME_SIZE+8];        //slave's name
+        char fMasterNetName[JACK_SERVER_NAME_SIZE+8]; //master hostname (network)
+        char fSlaveNetName[JACK_SERVER_NAME_SIZE+8]; //slave hostname (network)
         uint32_t fMtu;                              //connection mtu
         uint32_t fID;                               //slave's ID
         uint32_t fTransportSync;                    //is the transport synced ?


### PR DESCRIPTION
Part of 02f74a659 touched the `_session_params` struct, breaking the alignment and causing both ends (driver and manager) to crash at negotiation. ~~This reverts the relevant change.~~