### PR TITLE
allow to use source date for man page generation

### DIFF
--- a/man/fill_template
+++ b/man/fill_template
@@ -1,5 +1,7 @@
 #!/bin/sh
+d=""
+[ -z "$SOURCE_DATE_EPOCH" ] || d=--date=@$SOURCE_DATE_EPOCH
 
 for i in *.0 ; do
-   sed -e "s/!VERSION!/${1}/g" -e "s/!DATE!/`date '+%B %Y'`/g" < ${i} > ${i%%0}1
+   sed -e "s/!VERSION!/${1}/g" -e "s/!DATE!/`date $d '+%B %Y'`/g" < ${i} > ${i%%0}1
 done


### PR DESCRIPTION
this enables making reproducible builds of this package

see also https://reproducible-builds.org/specs/source-date-epoch/
This change is tested.
Related to https://github.com/jackaudio/jack1/pull/38