### PR TITLE
Add support for nios2

### DIFF
--- a/dbus/sigsegv.c
+++ b/dbus/sigsegv.c
@@ -104,7 +104,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     jack_error("info.si_errno = %d", info->si_errno);
     jack_error("info.si_code  = %d (%s)", info->si_code, si_code_str);
     jack_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__)
+#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(nios2)
     for(i = 0; i < NGREG; i++)
         jack_error("reg[%02d]       = 0x" REGFORMAT, i, 
 #if defined(__powerpc64__)


### PR DESCRIPTION
When compiling jack on nios2, compilation fails because NGREGS is not
defined. Since this is only for debug output on segmentation faults, stub
the debug print out like it's been done for other platforms before.

Inspired by
https://github.com/jackaudio/jack2/commit/d11bb095291d8880508c87adfe625bf2bcab1456

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>