### PR TITLE
Make backtrace support depends on execinfo.h existence

### DIFF
--- a/dbus/sigsegv.c
+++ b/dbus/sigsegv.c
@@ -27,7 +27,9 @@
 #include <stdio.h>
 #include <signal.h>
 #include <dlfcn.h>
-#include <execinfo.h>
+#ifdef HAVE_EXECINFO_H
+# include <execinfo.h>
+#endif
 #include <errno.h>
 #ifndef NO_CPP_DEMANGLE
 char * __cxa_demangle(const char * __mangled_name, char * __output_buffer, size_t * __length, int * __status);
@@ -161,12 +163,16 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
         bp = (void**)bp[0];
     }
 #else
+# ifdef HAVE_EXECINFO_H
     jack_error("Stack trace (non-dedicated):");
     sz = backtrace(bt, 20);
     strings = backtrace_symbols(bt, sz);
 
     for(i = 0; i < sz; ++i)
         jack_error("%s", strings[i]);
+# else
+    jack_error("Stack trace not available");
+# endif
 #endif
     jack_error("End of stack trace");
     exit (-1);

--- a/wscript
+++ b/wscript
@@ -483,6 +483,12 @@ def configure(conf):
         defines=['_GNU_SOURCE'],
         mandatory=False)
 
+    # Check for backtrace support
+    conf.check(
+        header_name='execinfo.h',
+        define_name='HAVE_EXECINFO_H',
+        mandatory=False)
+
     conf.recurse('common')
     if Options.options.dbus:
         conf.recurse('dbus')


### PR DESCRIPTION
In some C-libraries (like uclibc), backtrace support is optional, so the
execinfo.h may not exist.

This change adds the check for execinfo.h header and conditionaly enable
backtrace support.

This issue has been triggered by Buildroot farms:
  http://autobuild.buildroot.org/results/391/391e71a988250ea66ec4dbee6f60fdce9eaf2766/build-end.log

Signed-off-by: Samuel Martin s.martin49@gmail.com
