### PR TITLE
wscript: replace deprecated use of check_cc by check

### DIFF
--- a/wscript
+++ b/wscript
@@ -106,11 +106,11 @@ class AutoOption:
     def add_library(self, library, uselib_store=None):
         """
         Add a required library that should be checked during configuration. The
-        library will be checked using the conf.check_cc function. If the
+        library will be checked using the conf.check function. If the
         uselib_store arugment is not given it defaults to LIBRARY (the uppercase
         of the library argument). The uselib_store argument will be passed to
-        check_cc which means LIB_LIBRARY, CFLAGS_LIBRARY and DEFINES_LIBRARY,
-        etc. will be defined if the option is enabled.
+        check which means LIB_LIBRARY, CFLAGS_LIBRARY and DEFINES_LIBRARY, etc.
+        will be defined if the option is enabled.
         """
         if not uselib_store:
             uselib_store = library.upper().replace('-', '_')
@@ -119,7 +119,7 @@ class AutoOption:
     def add_header(self, header):
         """
         Add a required header that should be checked during configuration. The
-        header will be checked using the conf.check_cc function which means
+        header will be checked using the conf.check function which means
         HAVE_HEADER_H will be defined if found.
         """
         self.headers.append(header)
@@ -192,7 +192,8 @@ class AutoOption:
         # check for libraries
         for lib,uselib_store in self.libs:
             try:
-                conf.check_cc(lib=lib, uselib_store=uselib_store, use=use)
+                conf.check(lib=lib, uselib_store=uselib_store, use=use,
+                           compiler='c')
             except conf.errors.ConfigurationError:
                 all_found = False
                 self.libs_not_found.append(lib)
@@ -200,7 +201,7 @@ class AutoOption:
         # check for headers
         for header in self.headers:
             try:
-                conf.check_cc(header_name=header, use=use)
+                conf.check(compiler='c', header_name=header, use=use)
             except conf.errors.ConfigurationError:
                 all_found = False
                 self.headers_not_found.append(header)
@@ -349,12 +350,13 @@ def check_for_celt_error(conf):
 # test-compiled to find out whether readline is available.
 def check_for_readline(conf):
     try:
-        conf.check_cc(fragment='''
-                      #include <stdio.h>
-                      #include <readline/readline.h>
-                      int main(void) { return 0; }''',
-                      execute=False,
-                      msg='Checking for header readline/readline.h')
+        conf.check(fragment='''
+                   #include <stdio.h>
+                   #include <readline/readline.h>
+                   int main(void) { return 0; }''',
+                   compiler='c',
+                   execute=False,
+                   msg='Checking for header readline/readline.h')
         return True
     except conf.errors.ConfigurationError:
         return False
@@ -364,12 +366,13 @@ def check_for_readline_error(conf):
 
 def check_for_mmsystem(conf):
     try:
-        conf.check_cc(fragment='''
-                      #include <windows.h>
-                      #include <mmsystem.h>
-                      int main(void) { return 0; }''',
-                      execute=False,
-                      msg='Checking for header mmsystem.h')
+        conf.check(fragment='''
+                   #include <windows.h>
+                   #include <mmsystem.h>
+                   int main(void) { return 0; }''',
+                   compiler='c',
+                   execute=False,
+                   msg='Checking for header mmsystem.h')
         return True
     except conf.errors.ConfigurationError:
         return False
@@ -477,7 +480,8 @@ def configure(conf):
     configure_auto_options(conf)
 
     # Check for functions.
-    conf.check_cc(
+    conf.check(
+        compiler='c',
         function_name='ppoll',
         header_name=['poll.h', 'signal.h'],
         defines=['_GNU_SOURCE'],


### PR DESCRIPTION
Using check_cc function is not recommended by the waf project [1], the
check function should be use instead.

So, replace all occurrences of:
  check_cc(...)
by:
  check(compiler='c', ...)

[1] https://github.com/waf-project/waf/blob/master/waflib/Tools/c_config.py#L762

Signed-off-by: Samuel Martin <s.martin49@gmail.com>