### PR TITLE
Add support for archs xtensa & arc

### DIFF
--- a/dbus/sigsegv.c
+++ b/dbus/sigsegv.c
@@ -104,7 +104,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     jack_error("info.si_errno = %d", info->si_errno);
     jack_error("info.si_code  = %d (%s)", info->si_code, si_code_str);
     jack_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(nios2) && !defined(__XTENSA__)
+#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(nios2) && !defined(__XTENSA__) && !defined(__arc__)
     for(i = 0; i < NGREG; i++)
         jack_error("reg[%02d]       = 0x" REGFORMAT, i, 
 #if defined(__powerpc64__)

--- a/dbus/sigsegv.c
+++ b/dbus/sigsegv.c
@@ -104,7 +104,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     jack_error("info.si_errno = %d", info->si_errno);
     jack_error("info.si_code  = %d (%s)", info->si_code, si_code_str);
     jack_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(nios2)
+#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(nios2) && !defined(__XTENSA__)
     for(i = 0; i < NGREG; i++)
         jack_error("reg[%02d]       = 0x" REGFORMAT, i, 
 #if defined(__powerpc64__)


### PR DESCRIPTION
This fixes buildroot compile errors on both arcs:
http://autobuild.buildroot.net/results/1ee/1ee48356d8da5e0ebf3e5b61b02fed81704a01dd/
http://autobuild.buildroot.net/results/483/48367bdc5e2f466ea12eb573ba9f5265887a62f4/
