### PR TITLE
alsa_in/out: Convert between sample rates when necessary

### DIFF
--- a/example-clients/alsa_in.c
+++ b/example-clients/alsa_in.c
@@ -353,7 +353,7 @@ int process (jack_nframes_t nframes, void *arg) {
 
     delay = snd_pcm_avail( alsa_handle );
 
-    delay -= jack_frames_since_cycle_start( client );
+    delay -= round( jack_frames_since_cycle_start( client ) / static_resample_factor );
     // Do it the hard way.
     // this is for compensating xruns etc...
 
@@ -510,7 +510,7 @@ latency_cb (jack_latency_callback_mode_t mode, void *arg)
 	jack_latency_range_t range;
 	JSList *node;
 
-	range.min = range.max = target_delay;
+	range.min = range.max = round(target_delay * static_resample_factor);
 
 	if (mode == JackCaptureLatency) {
 		for (node = capture_ports; node; node = jack_slist_next (node)) {

--- a/example-clients/alsa_out.c
+++ b/example-clients/alsa_out.c
@@ -357,7 +357,7 @@ int process (jack_nframes_t nframes, void *arg) {
 
     delay = (num_periods*period_size)-snd_pcm_avail( alsa_handle ) ;
 
-    delay -= jack_frames_since_cycle_start( client );
+    delay -= round( jack_frames_since_cycle_start( client ) * static_resample_factor );
     // Do it the hard way.
     // this is for compensating xruns etc...
 
@@ -513,7 +513,7 @@ latency_cb (jack_latency_callback_mode_t mode, void *arg)
 	jack_latency_range_t range;
 	JSList *node;
 
-	range.min = range.max = target_delay;
+	range.min = range.max = round(target_delay / static_resample_factor);
 
 	if (mode == JackCaptureLatency) {
 		for (node = capture_ports; node; node = jack_slist_next (node)) {


### PR DESCRIPTION
`alsa_in` and `alsa_out` set the playback latency of their ports to the target delay. The problem is the target delay is in terms of the _ALSA sample rate_, so it should be converted to JACK's sample rate.

Example: Imagine JACK is running at 48 kHz, and `alsa_out` is invoked like:

```
alsa_out -r 96000 -t 512
```

Currently, `alsa_out` will report 512 frames of playback latency. After the fix, it converts to 48kHz and correctly reports 256.

Also converts the result of `jack_frames_since_cycle_start` to ALSA sample rate.
