### PR TITLE
tests: define __STDC_LIMIT_MACROS

### DIFF
--- a/tests/iodelay.cpp
+++ b/tests/iodelay.cpp
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <math.h>
 #include <unistd.h>


### PR DESCRIPTION
With glibc 2.16, we get following build error when building jack2:

  [193/247] cxx: tests/iodelay.cpp -> build/tests/iodelay.cpp.4.o
  ../tests/iodelay.cpp:171:43: error: 'UINT32_MAX' was not declared in this scope
  ../tests/iodelay.cpp:171:55: error: 'UINT32_MAX' was not declared in this scope
  ../tests/iodelay.cpp:172:44: error: 'UINT32_MAX' was not declared in this scope
  ../tests/iodelay.cpp:172:56: error: 'UINT32_MAX' was not declared in this scope

In glibc 2.17 or older version, Header <stdint.h> defines these macros
for C++ only if explicitly requested by defining __STDC_LIMIT_MACROS.

We can't use <cstdint> since it requires C++11 standard.

This build issue found by Buildroot autobuilder.
http://autobuild.buildroot.net/results/369/369ce208ffea43dad75ba0a13469159b341e3bf5/

Signed-off-by: Rahul Bedarkar rahul.bedarkar@imgtec.com
