### PR TITLE
Don't pack structures on MIPS where unaligned access is not allowed

### DIFF
--- a/common/jack/systemdeps.h
+++ b/common/jack/systemdeps.h
@@ -120,7 +120,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #endif /* __APPLE__ || __linux__ || __sun__ || sun */
 
-#if defined(__arm__) || defined(__aarch64__) || defined(__ppc__) || defined(__powerpc__)
+#if defined(__arm__) || defined(__aarch64__) || defined(__mips__) || defined(__ppc__) || defined(__powerpc__)
     #undef POST_PACKED_STRUCTURE
     #define POST_PACKED_STRUCTURE
 #endif /* __arm__ || __aarch64__ || __ppc__ || __powerpc__ */


### PR DESCRIPTION
This is an old bug from here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=728710

Not all MIPS processors support unaligned access (although some do) so using packed structures is not safe on this platform.