### PR TITLE
Avoid side effects from parsing of "version" option in jackd

### DIFF
--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -260,7 +260,7 @@ int main(int argc, char** argv)
     int replace_registry = 0;
 
     for(int a = 1; a < argc; ++a) {
-        if(strstr(argv[a], "--version") || strstr(argv[a], "-V")) {
+        if( !strcmp(argv[a], "--version") || !strcmp(argv[a], "-V") ) {
             print_version();
         }
     }

--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -264,7 +264,7 @@ int main(int argc, char** argv)
             print_version();
         }
     }
-    const char *options = "-d:X:I:P:uvshVrRL:STFl:t:mn:p:"
+    const char *options = "-d:X:I:P:uvshrRL:STFl:t:mn:p:"
         "a:"
 #ifdef __linux__
         "c:"
@@ -292,7 +292,6 @@ int main(int argc, char** argv)
                                        { "realtime-priority", 1, 0, 'P' },
                                        { "timeout", 1, 0, 't' },
                                        { "temporary", 0, 0, 'T' },
-                                       { "version", 0, 0, 'V' },
                                        { "silent", 0, 0, 's' },
                                        { "sync", 0, 0, 'S' },
                                        { "autoconnect", 1, 0, 'a' },
@@ -305,7 +304,6 @@ int main(int argc, char** argv)
     char** master_driver_args = NULL;
     int master_driver_nargs = 1;
     int loopback = 0;
-    bool show_version = false;
     jackctl_sigmask_t * sigmask;
     jackctl_parameter_t* param;
     union jackctl_parameter_value value;

--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -241,6 +241,15 @@ static void usage(FILE* file, jackctl_server_t *server, bool full = true)
 // Prototype to be found in libjackserver
 extern "C" void silent_jack_error_callback(const char *desc);
 
+void print_version()
+{
+    printf( "jackdmp version " VERSION " tmpdir "
+            jack_server_dir " protocol %d" "\n",
+            JACK_PROTOCOL_VERSION);
+    exit(-1);
+
+}
+
 int main(int argc, char** argv)
 {
     jackctl_server_t * server_ctl;
@@ -249,6 +258,12 @@ int main(int argc, char** argv)
     jackctl_driver_t * master_driver_ctl;
     jackctl_driver_t * loopback_driver_ctl = NULL;
     int replace_registry = 0;
+
+    for(int a = 1; a < argc; ++a) {
+        if(strstr(argv[a], "--version") || strstr(argv[a], "-V")) {
+            print_version();
+        }
+    }
     const char *options = "-d:X:I:P:uvshVrRL:STFl:t:mn:p:"
         "a:"
 #ifdef __linux__
@@ -470,6 +485,9 @@ int main(int argc, char** argv)
                 break;
 
             case 'V':
+                //TODO unreachable (refactoring needed)
+                fprintf(stderr, "should not be reachable.\n");
+                return -1;
                 show_version = true;
                 break;
 
@@ -491,11 +509,7 @@ int main(int argc, char** argv)
     }
 
     if (show_version) {
-        printf( "jackdmp version " VERSION
-                " tmpdir " jack_server_dir
-                " protocol %d"
-                "\n", JACK_PROTOCOL_VERSION);
-        return -1;
+        //TODO refactor unreachable
     }
 
     if (!master_driver_name) {

--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -484,13 +484,6 @@ int main(int argc, char** argv)
                 }
                 break;
 
-            case 'V':
-                //TODO unreachable (refactoring needed)
-                fprintf(stderr, "should not be reachable.\n");
-                return -1;
-                show_version = true;
-                break;
-
             default:
                 fprintf(stderr, "unknown option character %c\n", optopt);
                 /*fallthru*/
@@ -506,10 +499,6 @@ int main(int argc, char** argv)
     if (param != NULL) {
         value.b = replace_registry;
         jackctl_parameter_set_value(param, &value);
-    }
-
-    if (show_version) {
-        //TODO refactor unreachable
     }
 
     if (!master_driver_name) {


### PR DESCRIPTION
This avoids many side effects when the user just wants to see the version string of the application by passing "-V" OR "--version". This is achieved by adding an additional check for the version option before the actual option parsing begins.
Fixes #81 
Also the copyright header is not displayed in case the version option is supplied.