### PR TITLE
Fix crash in JackPosixSemaphore::Wait

### DIFF
--- a/posix/JackPosixSemaphore.cpp
+++ b/posix/JackPosixSemaphore.cpp
@@ -102,6 +102,11 @@ bool JackPosixSemaphore::Wait()
 {
     int res;
 
+    if (!fSemaphore) {
+        jack_error("JackPosixSemaphore::Wait name = %s already deallocated!!", fName);
+        return false;
+    }
+
     while ((res = sem_wait(fSemaphore) < 0)) {
         jack_error("JackPosixSemaphore::Wait name = %s err = %s", fName, strerror(errno));
         if (errno != EINTR) {

--- a/posix/JackPosixSemaphore.cpp
+++ b/posix/JackPosixSemaphore.cpp
@@ -81,23 +81,6 @@ bool JackPosixSemaphore::SignalAll()
     return (res == 0);
 }
 
-/*
-bool JackPosixSemaphore::Wait()
-{
-    int res;
-
-    if (!fSemaphore) {
-        jack_error("JackPosixSemaphore::Wait name = %s already deallocated!!", fName);
-        return false;
-    }
-
-    if ((res = sem_wait(fSemaphore)) != 0) {
-        jack_error("JackPosixSemaphore::Wait name = %s err = %s", fName, strerror(errno));
-    }
-    return (res == 0);
-}
-*/
-
 bool JackPosixSemaphore::Wait()
 {
     int res;


### PR DESCRIPTION
Observed a crash in JackPosixSemaphore::Wait where fSemaphore was null yet sem_wait() was still being called.

These patches add the null pointer check from the commented wait function, as well as performing some code clean up by removing said commented function.