### PR TITLE
Secure promiscuous mode

### DIFF
--- a/common/promiscuous.c
+++ b/common/promiscuous.c
@@ -1,0 +1,95 @@
+/*
+ Copyright (C) 2014-2017 Cédric Schieli
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+#ifndef WIN32
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <grp.h>
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+#include "JackError.h"
+#endif
+
+
+int
+jack_group2gid(const char* group)
+{
+#ifdef WIN32
+    return -1;
+#else
+    size_t buflen;
+    char *buf;
+    int ret;
+    struct group grp;
+    struct group *result;
+
+    if (!group || !*group)
+        return -1;
+
+    ret = strtol(group, &buf, 10);
+    if (!*buf)
+        return ret;
+
+/* MacOSX only defines _SC_GETGR_R_SIZE_MAX starting from 10.4 */
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_4
+    buflen = 4096;
+#else
+    buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
+    if (buflen == -1)
+        buflen = 4096;
+#endif
+    buf = (char*)malloc(buflen);
+
+    while (buf && ((ret = getgrnam_r(group, &grp, buf, buflen, &result)) == ERANGE)) {
+        buflen *= 2;
+        buf = (char*)realloc(buf, buflen);
+    }
+    if (!buf)
+        return -1;
+    free(buf);
+    if (ret || !result)
+        return -1;
+    return grp.gr_gid;
+#endif
+}
+
+#ifndef WIN32
+int
+jack_promiscuous_perms(int fd, const char* path, gid_t gid)
+{
+	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+	if (gid >= 0) {
+		if (((fd < 0) ? chown(path, -1, gid) : fchown(fd, -1, gid)) < 0) {
+			jack_log("Cannot chgrp %s: %s. Falling back to permissive perms.", path, strerror(errno));
+		} else {
+			mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+		}
+	}
+	if (((fd < 0) ? chmod(path, mode) : fchmod(fd, mode)) < 0) {
+		jack_log("Cannot chmod %s: %s. Falling back to default (umask) perms.", path, strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+#endif

--- a/common/promiscuous.h
+++ b/common/promiscuous.h
@@ -1,0 +1,39 @@
+/*
+ Copyright (C) 2014-2017 Cédric Schieli
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+#ifndef __jack_gid_h__
+#define __jack_gid_h__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int jack_group2gid (const char *group); /*!< Lookup gid for a UNIX group in a thread-safe way */
+#ifndef WIN32
+int jack_promiscuous_perms (int fd, const char *path, gid_t gid); /*!< Set promiscuous permissions on object referenced by fd and/or path */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __jack_gid_h__ */
+
+

--- a/common/shm.c
+++ b/common/shm.c
@@ -52,6 +52,7 @@
 #include <sys/shm.h>
 #include <sys/sem.h>
 #include <stdlib.h>
+#include "promiscuous.h"
 
 #endif
 
@@ -837,6 +838,7 @@ jack_shmalloc (const char *shm_name, jack_shmsize_t size, jack_shm_info_t* si)
 	int shm_fd;
 	int rc = -1;
 	char name[SHM_NAME_MAX+1];
+	const char* promiscuous;
 
 	if (jack_shm_lock_registry () < 0) {
         jack_error ("jack_shm_lock_registry fails...");
@@ -876,6 +878,10 @@ jack_shmalloc (const char *shm_name, jack_shmsize_t size, jack_shm_info_t* si)
 		close (shm_fd);
 		goto unlock;
 	}
+
+	promiscuous = getenv("JACK_PROMISCUOUS_SERVER");
+	if ((promiscuous != NULL) && (jack_promiscuous_perms(shm_fd, name, jack_group2gid(promiscuous)) < 0))
+		goto unlock;
 
 	close (shm_fd);
 	registry->size = size;

--- a/common/wscript
+++ b/common/wscript
@@ -82,6 +82,7 @@ def build(bld):
         common_libsources += [
             'JackDebugClient.cpp',
             'timestamps.c',
+            'promiscuous.c',
             '../posix/JackPosixThread.cpp',
             '../posix/JackPosixProcessSync.cpp',
             '../posix/JackPosixMutex.cpp',
@@ -97,6 +98,7 @@ def build(bld):
         common_libsources += [
             'JackDebugClient.cpp',
             'timestamps.c',
+            'promiscuous.c',
            '../posix/JackPosixThread.cpp',
            '../posix/JackFifo.cpp',
            '../posix/JackPosixProcessSync.cpp',
@@ -111,6 +113,7 @@ def build(bld):
         common_libsources += [
             'JackDebugClient.cpp',
             'timestamps.c',
+            'promiscuous.c',
             '../posix/JackPosixProcessSync.cpp',
             '../posix/JackPosixThread.cpp',
             '../posix/JackPosixMutex.cpp',

--- a/linux/JackLinuxFutex.h
+++ b/linux/JackLinuxFutex.h
@@ -53,6 +53,8 @@ class SERVER_EXPORT JackLinuxFutex : public detail::JackSynchro
         int fSharedMem;
         FutexData* fFutex;
         bool fPrivate;
+        bool fPromiscuous;
+        int fPromiscuousGid;
 
     protected:
 
@@ -60,8 +62,7 @@ class SERVER_EXPORT JackLinuxFutex : public detail::JackSynchro
 
     public:
 
-        JackLinuxFutex():JackSynchro(), fSharedMem(-1), fFutex(NULL), fPrivate(false)
-        {}
+        JackLinuxFutex();
 
         bool Signal();
         bool SignalAll();

--- a/posix/JackPosixSemaphore.h
+++ b/posix/JackPosixSemaphore.h
@@ -39,6 +39,10 @@ class SERVER_EXPORT JackPosixSemaphore : public detail::JackSynchro
     private:
 
         sem_t* fSemaphore;
+        bool fPromiscuous;
+#ifdef __linux__
+        int fPromiscuousGid;
+#endif
 
     protected:
 
@@ -46,8 +50,7 @@ class SERVER_EXPORT JackPosixSemaphore : public detail::JackSynchro
 
     public:
 
-        JackPosixSemaphore():JackSynchro(), fSemaphore(NULL)
-        {}
+        JackPosixSemaphore();
 
         bool Signal();
         bool SignalAll();

--- a/posix/JackSocket.h
+++ b/posix/JackSocket.h
@@ -45,11 +45,12 @@ class JackClientSocket : public detail::JackClientRequestInterface
 
         int fSocket;
         int fTimeOut;
+        bool fPromiscuous;
+        int fPromiscuousGid;
 
     public:
 
-        JackClientSocket():JackClientRequestInterface(), fSocket(-1), fTimeOut(0)
-        {}
+        JackClientSocket();
         JackClientSocket(int socket);
 
         int Connect(const char* dir, const char* name, int which);
@@ -80,11 +81,12 @@ class JackServerSocket
 
         int fSocket;
         char fName[SOCKET_MAX_NAME_SIZE];
+        bool fPromiscuous;
+        int fPromiscuousGid;
 
     public:
 
-        JackServerSocket(): fSocket( -1)
-        {}
+        JackServerSocket();
         ~JackServerSocket()
         {}
 


### PR DESCRIPTION
This is a rework of PR #77 

Promiscuous mode requires that all clients are launched with a way too permissive 0000 umask.

With this PR, permissions are explicitly set on various shared resources so it is unnecessary to temper with the umask.
Moreover, it is possible to pass a group name or a gid in the JACK_PROMISCUOUS_SERVER environment variable so that the permissions on those resources are restricted to the members of a specific group.