### PR TITLE
Fix some issues on Windows.

### DIFF
--- a/common/JackDriverLoader.cpp
+++ b/common/JackDriverLoader.cpp
@@ -36,11 +36,9 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 static char* locate_dll_driver_dir()
 {
-#ifdef _WIN64
-    HMODULE libjack_handle = LoadLibrary("libjackserver64.dll");
-#else
-    HMODULE libjack_handle = LoadLibrary("libjackserver.dll");
-#endif
+    HMODULE libjack_handle = NULL;
+    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                      reinterpret_cast<LPCSTR>(locate_dll_driver_dir), &libjack_handle);
 
     // For WIN32 ADDON_DIR is defined in JackConstants.h as relative path
     char driver_dir_storage[512];
@@ -52,11 +50,9 @@ static char* locate_dll_driver_dir()
         jack_info("Drivers/internals found in : %s", driver_dir_storage);
         strcat(driver_dir_storage, "/");
         strcat(driver_dir_storage, ADDON_DIR);
-        FreeLibrary(libjack_handle);
         return strdup(driver_dir_storage);
     } else {
         jack_error("Cannot get JACK dll directory : %d", GetLastError());
-        FreeLibrary(libjack_handle);
         return NULL;
     }
 }

--- a/common/wscript
+++ b/common/wscript
@@ -142,6 +142,7 @@ def build(bld):
     clientlib.defines = 'HAVE_CONFIG_H'
     clientlib.use = uselib
     if bld.env['IS_WINDOWS']:
+         clientlib.env['cxxshlib_PATTERN'] = 'lib%s.dll'
          clientlib.install_path = '${BINDIR}'
     else:
          clientlib.install_path = '${LIBDIR}'
@@ -208,6 +209,7 @@ def build(bld):
     serverlib.target       = 'jackserver'
     serverlib.use = uselib
     if bld.env['IS_WINDOWS']:
+         serverlib.env['cxxshlib_PATTERN'] = 'lib%s.dll'
          serverlib.install_path = '${BINDIR}'
     else:
          serverlib.install_path = '${LIBDIR}'
@@ -303,6 +305,7 @@ def build(bld):
         netlib.target       = 'jacknet'
         netlib.use = ['SAMPLERATE', 'CELT', 'OPUS', 'PTHREAD']
         if bld.env['IS_WINDOWS']:
+             netlib.env['cxxshlib_PATTERN'] = 'lib%s.dll'
              netlib.install_path = '${BINDIR}'
              netlib.use += ['WS2_32', 'WINMM']
         elif bld.env['IS_MACOSX']:

--- a/windows/JackCompilerDeps_os.h
+++ b/windows/JackCompilerDeps_os.h
@@ -40,9 +40,29 @@
 #endif
 
 #if defined(_MSC_VER) /* Added by JE - 31-01-2012 */
-#define vsnprintf _vsnprintf
-#define snprintf _snprintf
 #define strdup _strdup
+#if _MSC_VER < 1900
+// This wrapper is not fully standard-compliant.  _snprintf() does not
+// distinguish whether a result is truncated or a format error occurs.
+inline int vsnprintf(char* buf, size_t buf_len, const char* fmt, va_list args)
+{
+	int str_len = _vsnprintf(buf, buf_len - 1, fmt, args);
+	if (str_len == buf_len - 1 || str_len < 0) {
+		buf[buf_len - 1] = '\0';
+		return buf_len - 1;
+	}
+	return str_len;
+}
+
+inline int snprintf(char* buf, size_t buf_len, const char* fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	int str_len = vsnprintf(buf, buf_len, fmt, args);
+	va_end(args);
+	return str_len;
+}
+#endif
 #endif
 
 #endif

--- a/windows/JackSystemDeps_os.h
+++ b/windows/JackSystemDeps_os.h
@@ -53,5 +53,18 @@
 #define snprintf _snprintf
 #endif
 
+inline int setenv(const char* name, const char* value, int overwrite)
+{
+	if (overwrite == 0 && getenv(name) != NULL) {
+		return 0;
+	}
+	return _putenv_s(name, value);
+}
+
+inline int unsetenv(const char* name)
+{
+	return _putenv_s(name, "");
+}
+
 #endif
 

--- a/windows/JackSystemDeps_os.h
+++ b/windows/JackSystemDeps_os.h
@@ -22,6 +22,7 @@
 #define __JackSystemDeps_WIN32__
 
 #include <windows.h>
+#include "JackCompilerDeps.h"
 
 #ifndef PATH_MAX
 #define PATH_MAX   512
@@ -47,10 +48,6 @@
 #define JACK_DEBUG true
 #else
 #define JACK_DEBUG false
-#endif
-
-#if defined(_MSC_VER)
-#define snprintf _snprintf
 #endif
 
 inline int setenv(const char* name, const char* value, int overwrite)

--- a/windows/portaudio/JackPortAudioDriver.cpp
+++ b/windows/portaudio/JackPortAudioDriver.cpp
@@ -196,8 +196,12 @@ int JackPortAudioDriver::Open(jack_nframes_t buffer_size,
     }
 
     // Generic JackAudioDriver Open
+    char capture_driver_name[JACK_CLIENT_NAME_SIZE];
+    char playback_driver_name[JACK_CLIENT_NAME_SIZE];
+    snprintf(capture_driver_name, sizeof(capture_driver_name), "%s", capture_driver_uid);
+    snprintf(playback_driver_name, sizeof(playback_driver_name), "%s", playback_driver_uid);
     if (JackAudioDriver::Open(buffer_size, samplerate, capturing, playing, inchannels, outchannels, monitor,
-        capture_driver_uid, playback_driver_uid, capture_latency, playback_latency) != 0) {
+        capture_driver_name, playback_driver_name, capture_latency, playback_latency) != 0) {
         return -1;
     }
 
@@ -238,12 +242,6 @@ int JackPortAudioDriver::Open(jack_nframes_t buffer_size,
     fEngineControl->fComputation = JackTools::ComputationMicroSec(fEngineControl->fBufferSize) * 1000;
     fEngineControl->fConstraint = fEngineControl->fPeriodUsecs * 1000;
 #endif
-
-    assert(strlen(capture_driver_uid) < JACK_CLIENT_NAME_SIZE);
-    assert(strlen(playback_driver_uid) < JACK_CLIENT_NAME_SIZE);
-
-    strcpy(fCaptureDriverName, capture_driver_uid);
-    strcpy(fPlaybackDriverName, playback_driver_uid);
 
     return 0;
 

--- a/wscript
+++ b/wscript
@@ -453,7 +453,7 @@ def detect_platform(conf):
         ('IS_LINUX',   'Linux',   ['gnu0', 'gnukfreebsd', 'linux', 'posix']),
         ('IS_MACOSX',  'MacOS X', ['darwin']),
         ('IS_SUN',     'SunOS',   ['sunos']),
-        ('IS_WINDOWS', 'Windows', ['cygwin', 'win32'])
+        ('IS_WINDOWS', 'Windows', ['cygwin', 'msys', 'win32'])
     ]
 
     for key,name,strings in platforms:
@@ -872,7 +872,7 @@ def build_drivers(bld):
         'windows/portaudio/JackPortAudioDriver.cpp',
     ]
 
-    winmme_driver_src = [
+    winmme_src = [
         'windows/winmme/JackWinMMEDriver.cpp',
         'windows/winmme/JackWinMMEInputPort.cpp',
         'windows/winmme/JackWinMMEOutputPort.cpp',


### PR DESCRIPTION
- Make locate_dll_driver_dir() independent from the dll file name.
- Add setenv() and unsetenv(), which are used in JackProxyDriver.cpp (Windows does not have them).
- Miscellaneous fixes.

I've tested this patch on MSYS2, with prebuilt PortAudio MSYS2 package, which supports WASAPI.

The PortAudio MSYS2 package seems to use these patches:
<https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-portaudio>