### PR TITLE
typecast input parameter to int for abs() to fix build with gcc7

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -479,7 +479,7 @@ int process4(jack_nframes_t nframes, void *arg)
 	jack_nframes_t delta_time = cur_time - last_time;
 
 	Log("calling process4 callback : jack_frame_time = %ld delta_time = %ld\n", cur_time, delta_time);
-	if (delta_time > 0  && (jack_nframes_t)abs(delta_time - cur_buffer_size) > tolerance) {
+	if (delta_time > 0  && (jack_nframes_t)abs(int(delta_time - cur_buffer_size)) > tolerance) {
 		printf("!!! ERROR !!! jack_frame_time seems to return incorrect values cur_buffer_size = %d, delta_time = %d tolerance %d\n", cur_buffer_size, delta_time, tolerance);
 	}
 


### PR DESCRIPTION
Fixes
../tests/test.cpp:482:73: error: call of overloaded 'abs(jack_nframes_t)' is ambiguous

because the signature is int abs(int) and its passing
unsigned int to it.

Signed-off-by: Khem Raj <raj.khem@gmail.com>
Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>