### PR TITLE
Fix unused{,-but-set}-variable compiler warnings.

### DIFF
--- a/common/JackNetOneDriver.cpp
+++ b/common/JackNetOneDriver.cpp
@@ -986,9 +986,6 @@ extern "C"
         unsigned int latency = 5;
         unsigned int redundancy = 1;
         unsigned int mtu = 1400;
-#if HAVE_SAMPLERATE
-        unsigned int resample_factor_up = 1;
-#endif
         int dont_htonl_floats = 0;
         int always_deadline = 0;
         int jitter_val = 0;
@@ -1029,15 +1026,6 @@ extern "C"
                 case 'f':
 #if HAVE_SAMPLERATE
                     resample_factor = param->value.ui;
-#else
-                    jack_error("not built with libsamplerate support");
-                    return NULL;
-#endif
-                    break;
-
-                case 'u':
-#if HAVE_SAMPLERATE
-                    resample_factor_up = param->value.ui;
 #else
                     jack_error("not built with libsamplerate support");
                     return NULL;

--- a/example-clients/metro.c
+++ b/example-clients/metro.c
@@ -135,7 +135,6 @@ main (int argc, char *argv[])
 	int attack_percent = 1, decay_percent = 10, dur_arg = 100;
 	char *client_name = 0;
 	char *bpm_string = "bpm";
-	int verbose = 0;
 	jack_status_t status;
 
 	const char *options = "f:A:D:a:d:b:n:thv";
@@ -150,7 +149,6 @@ main (int argc, char *argv[])
 		{"name", 1, 0, 'n'},
 		{"transport", 0, 0, 't'},
 		{"help", 0, 0, 'h'},
-		{"verbose", 0, 0, 'v'},
 		{0, 0, 0, 0}
 	};
 
@@ -197,9 +195,6 @@ main (int argc, char *argv[])
 		case 'n':
 			client_name = (char *) malloc ((strlen (optarg) + 1) * sizeof (char));
 			strcpy (client_name, optarg);
-			break;
-		case 'v':
-			verbose = 1;
 			break;
 		case 't':
 			transport_aware = 1;

--- a/example-clients/midiseq.c
+++ b/example-clients/midiseq.c
@@ -82,7 +82,6 @@ static int process(jack_nframes_t nframes, void *arg)
 int main(int narg, char **args)
 {
 	int i;
-	jack_nframes_t nframes;
 	if ((narg<6) || ((narg-3)%3 != 0)) {
 		usage();
 		exit(1);
@@ -93,7 +92,6 @@ int main(int narg, char **args)
 	}
 	jack_set_process_callback (client, process, 0);
 	output_port = jack_port_register (client, "out", JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0);
-	nframes = jack_get_buffer_size(client);
 	loop_index = 0;
 	num_notes = (narg - 3)/3;
 	note_frqs = malloc(num_notes*sizeof(unsigned char));

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -610,7 +610,6 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 	channel_t chn;
 	unsigned int pr = 0;
 	unsigned int cr = 0;
-	int err;
 
 	driver->frame_rate = rate;
 	driver->frames_per_cycle = frames_per_cycle;
@@ -702,14 +701,14 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 	if (driver->playback_handle) {
  		snd_pcm_access_t access;
 
- 		err = snd_pcm_hw_params_get_period_size (
- 			driver->playback_hw_params, &p_period_size, &dir);
- 		err = snd_pcm_hw_params_get_format (
- 			driver->playback_hw_params,
-			&(driver->playback_sample_format));
- 		err = snd_pcm_hw_params_get_access (driver->playback_hw_params,
+		snd_pcm_hw_params_get_period_size (
+			driver->playback_hw_params, &p_period_size, &dir);
+		snd_pcm_hw_params_get_format (
+			driver->playback_hw_params,
+			&(driver->playback_sample_format))
+		snd_pcm_hw_params_get_access (driver->playback_hw_params,
 						    &access);
- 		driver->playback_interleaved =
+		driver->playback_interleaved =
 			(access == SND_PCM_ACCESS_MMAP_INTERLEAVED)
 			|| (access == SND_PCM_ACCESS_MMAP_COMPLEX);
 
@@ -725,14 +724,14 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 	if (driver->capture_handle) {
  		snd_pcm_access_t access;
 
- 		err = snd_pcm_hw_params_get_period_size (
- 			driver->capture_hw_params, &c_period_size, &dir);
- 		err = snd_pcm_hw_params_get_format (
- 			driver->capture_hw_params,
+		snd_pcm_hw_params_get_period_size (
+			driver->capture_hw_params, &c_period_size, &dir);
+		snd_pcm_hw_params_get_format (
+			driver->capture_hw_params,
 			&(driver->capture_sample_format));
- 		err = snd_pcm_hw_params_get_access (driver->capture_hw_params,
+		snd_pcm_hw_params_get_access (driver->capture_hw_params,
 						    &access);
- 		driver->capture_interleaved =
+		driver->capture_interleaved =
 			(access == SND_PCM_ACCESS_MMAP_INTERLEAVED)
 			|| (access == SND_PCM_ACCESS_MMAP_COMPLEX);
 

--- a/linux/alsa/alsa_seqmidi.c
+++ b/linux/alsa/alsa_seqmidi.c
@@ -856,7 +856,6 @@ void do_jack_output(alsa_seqmidi_t *self, port_t *port, struct process_info* inf
 		int64_t frame_offset;
 		int64_t out_time;
 		snd_seq_real_time_t out_rt;
-		int err;
 
 		jack_midi_event_get(&jack_event, port->jack_buf, i);
 
@@ -896,7 +895,7 @@ void do_jack_output(alsa_seqmidi_t *self, port_t *port, struct process_info* inf
 		out_rt.tv_sec = out_time / NSEC_PER_SEC;
 		snd_seq_ev_schedule_real(&alsa_event, self->queue, 0, &out_rt);
 
-		err = snd_seq_event_output(self->seq, &alsa_event);
+		snd_seq_event_output(self->seq, &alsa_event);
 		debug_log("alsa_out: written %d bytes to %s at %+d (%lld): %d", (int)jack_event.size, port->name, (int)frame_offset, out_time, err);
 	}
 }

--- a/linux/alsa/hdsp.c
+++ b/linux/alsa/hdsp.c
@@ -39,9 +39,6 @@ static const int hdsp_num_input_channels = 52;
 static const int hdsp_physical_input_index[] = {
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
   12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
-static const int hdsp_audio_stream_index[] = {
-  26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-  38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
 
 /*
  * Use this array to choose the value of the output_channel 

--- a/posix/JackNetUnixSocket.cpp
+++ b/posix/JackNetUnixSocket.cpp
@@ -111,8 +111,6 @@ namespace Jack
             StrError(NET_ERROR_CODE);
         }
         
-        int tos = 0;       /* see <netinet/in.h> */
-        
         /*
         DSCP Field Hex/Bin/Dec	Layer 2 Prio	Traffic Type	Acronym	WMM Access Category
         0x38 / 111000 / 56	7	Network Control	NC	AC_VO

--- a/tests/cpu.c
+++ b/tests/cpu.c
@@ -78,10 +78,9 @@ int update_buffer_size(jack_nframes_t nframes, void *arg)
 
 int process(jack_nframes_t nframes, void *arg)
 {
-	jack_default_audio_sample_t *in, *out;
+	jack_default_audio_sample_t *out;
 	jack_nframes_t start_frame = jack_frame_time(client);
 
-	in = (jack_default_audio_sample_t *) jack_port_get_buffer (input_port, nframes);
 	out = (jack_default_audio_sample_t *) jack_port_get_buffer (output_port, nframes);
 	memset(out, 0, sizeof (jack_default_audio_sample_t) * nframes);
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -494,8 +494,6 @@ int process5(jack_nframes_t nframes, void *arg)
     static jack_nframes_t first_current_frames;
     static jack_time_t first_current_usecs;
     static jack_time_t first_next_usecs;
-    static float first_period_usecs;
-	static int res1 = jack_get_cycle_times(client, &first_current_frames, &first_current_usecs, &first_next_usecs, &first_period_usecs);
 	   
     jack_nframes_t current_frames;
     jack_time_t current_usecs;


### PR DESCRIPTION
Since I am mostly hacking in the build system I thought it would be a good idea to let you review these changes in a pull request before pushing to master.

This fixes some (I am not compiling all features so I assume not all) unused-variable and unused-but-set-variable compiler warnings. The fixes are naive, i.e. the variables have been dropped without further ado.