### PR TITLE
Allow for effective UID of binaries

### DIFF
--- a/android/Shm.cpp
+++ b/android/Shm.cpp
@@ -283,7 +283,7 @@ namespace android {
     }
 
     int Shm::GetUID() {
-        return getuid();
+        return geteuid();
     }
 
     int Shm::GetPID() {

--- a/common/JackTools.cpp
+++ b/common/JackTools.cpp
@@ -76,7 +76,7 @@ namespace Jack {
         return  _getpid();
         //#error "No getuid function available"
 #else
-        return getuid();
+        return geteuid();
 #endif
     }
 

--- a/common/shm.c
+++ b/common/shm.c
@@ -64,7 +64,7 @@ static int GetUID()
     return  _getpid();
     //#error "No getuid function available"
 #else
-    return getuid();
+    return geteuid();
 #endif
 }
 


### PR DESCRIPTION
I was trying to use a setuid jack_lsp and it didn't work, presumably because of this - maybe not the most common use case, but I think its helpful to support.