### PR TITLE
Improve build on Windows with MSVC

### DIFF
--- a/common/JackAudioAdapterFactory.cpp
+++ b/common/JackAudioAdapterFactory.cpp
@@ -52,7 +52,7 @@ extern "C"
 
     using namespace Jack;
 
-    SERVER_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
+    LIB_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
     {
         jack_log("Loading audioadapter");
 
@@ -78,7 +78,7 @@ extern "C"
         }
     }
 
-    SERVER_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
+    LIB_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
     {
         JSList* params = NULL;
         bool parse_params = true;
@@ -97,7 +97,7 @@ extern "C"
         return res;
     }
 
-    SERVER_EXPORT void jack_finish(void* arg)
+    LIB_EXPORT void jack_finish(void* arg)
     {
         Jack::JackAudioAdapter* adapter = static_cast<Jack::JackAudioAdapter*>(arg);
 

--- a/common/JackDriverLoader.cpp
+++ b/common/JackDriverLoader.cpp
@@ -32,6 +32,10 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <dirent.h>
 #endif
 
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#endif
+
 #ifdef WIN32
 
 static char* locate_dll_driver_dir()

--- a/common/JackDummyDriver.cpp
+++ b/common/JackDummyDriver.cpp
@@ -23,7 +23,9 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackThreadedDriver.h"
 #include "JackCompilerDeps.h"
 #include <iostream>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <math.h>
 
 

--- a/common/JackDummyDriver.cpp
+++ b/common/JackDummyDriver.cpp
@@ -34,7 +34,7 @@ extern "C"
 {
 #endif
 
-    SERVER_EXPORT jack_driver_desc_t * driver_get_descriptor () {
+    LIB_EXPORT jack_driver_desc_t * driver_get_descriptor () {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
         jack_driver_param_value_t value;
@@ -60,7 +60,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params) {
+    LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params) {
         jack_nframes_t sample_rate = 48000;
         jack_nframes_t buffer_size = 1024;
         unsigned int capture_ports = 2;

--- a/common/JackLoopbackDriver.cpp
+++ b/common/JackLoopbackDriver.cpp
@@ -90,7 +90,7 @@ extern "C"
 {
 #endif
 
-    SERVER_EXPORT jack_driver_desc_t * driver_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t * driver_get_descriptor()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
@@ -104,7 +104,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
+    LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
     {
         const JSList * node;
         const jack_driver_param_t * param;

--- a/common/JackMidiBufferReadQueue.cpp
+++ b/common/JackMidiBufferReadQueue.cpp
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackMidiUtil.h"
 #include "JackError.h"
 
+using Jack::JackMidiBuffer;
 using Jack::JackMidiBufferReadQueue;
 
 JackMidiBufferReadQueue::JackMidiBufferReadQueue()

--- a/common/JackMidiBufferWriteQueue.cpp
+++ b/common/JackMidiBufferWriteQueue.cpp
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackMidiUtil.h"
 #include "JackError.h"
 
+using Jack::JackMidiBuffer;
 using Jack::JackMidiBufferWriteQueue;
 
 JackMidiBufferWriteQueue::JackMidiBufferWriteQueue()

--- a/common/JackMidiPort.cpp
+++ b/common/JackMidiPort.cpp
@@ -99,7 +99,11 @@ static void MidiBufferMixdown(void* mixbuffer, void** src_buffers, int src_count
     }
     mix->Reset(nframes);
 
+#if _MSC_VER
+    uint32_t* mix_index = (uint32_t*)_alloca(sizeof(uint32_t) * src_count);
+#else
     uint32_t mix_index[src_count];
+#endif
     int event_count = 0;
     for (int i = 0; i < src_count; ++i) {
         JackMidiBuffer* buf = static_cast<JackMidiBuffer*>(src_buffers[i]);

--- a/common/JackMidiRawOutputWriteQueue.cpp
+++ b/common/JackMidiRawOutputWriteQueue.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackMidiRawOutputWriteQueue.h"
 #include "JackMidiUtil.h"
 
+using Jack::JackMidiSendQueue;
 using Jack::JackMidiRawOutputWriteQueue;
 
 #define STILL_TIME(c, b) ((! (b)) || ((c) < (b)))

--- a/common/JackNetAdapter.cpp
+++ b/common/JackNetAdapter.cpp
@@ -413,7 +413,7 @@ extern "C"
 
     using namespace Jack;
 
-    SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t* jack_get_descriptor()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
@@ -465,7 +465,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT int jack_internal_initialize(jack_client_t* client, const JSList* params)
+    LIB_EXPORT int jack_internal_initialize(jack_client_t* client, const JSList* params)
     {
         jack_log("Loading netadapter");
 
@@ -491,7 +491,7 @@ extern "C"
         }
     }
 
-    SERVER_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
+    LIB_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
     {
         JSList* params = NULL;
         bool parse_params = true;
@@ -510,7 +510,7 @@ extern "C"
         return res;
     }
 
-    SERVER_EXPORT void jack_finish(void* arg)
+    LIB_EXPORT void jack_finish(void* arg)
     {
         Jack::JackAudioAdapter* adapter = static_cast<Jack::JackAudioAdapter*>(arg);
 

--- a/common/JackNetDriver.cpp
+++ b/common/JackNetDriver.cpp
@@ -665,7 +665,7 @@ namespace Jack
     {
 #endif
 
-        SERVER_EXPORT jack_driver_desc_t* driver_get_descriptor()
+        LIB_EXPORT jack_driver_desc_t* driver_get_descriptor()
         {
             jack_driver_desc_t * desc;
             jack_driver_desc_filler_t filler;
@@ -717,7 +717,7 @@ Deactivated for now..
             return desc;
         }
 
-        SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
+        LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
         {
             char multicast_ip[32];
             char net_name[JACK_CLIENT_NAME_SIZE+1] = {0};

--- a/common/JackNetManager.cpp
+++ b/common/JackNetManager.cpp
@@ -938,7 +938,7 @@ extern "C"
 {
 #endif
 
-    SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t* jack_get_descriptor()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
@@ -961,7 +961,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
+    LIB_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
     {
         if (master_manager) {
             jack_error("Master Manager already loaded");
@@ -973,7 +973,7 @@ extern "C"
         }
     }
 
-    SERVER_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
+    LIB_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
     {
         JSList* params = NULL;
         bool parse_params = true;
@@ -992,7 +992,7 @@ extern "C"
         return res;
     }
 
-    SERVER_EXPORT void jack_finish(void* arg)
+    LIB_EXPORT void jack_finish(void* arg)
     {
         if (master_manager) {
             jack_log("Unloading Master Manager");

--- a/common/JackNetOneDriver.cpp
+++ b/common/JackNetOneDriver.cpp
@@ -908,7 +908,7 @@ extern "C"
 {
 #endif
 
-    SERVER_EXPORT jack_driver_desc_t* driver_get_descriptor ()
+    LIB_EXPORT jack_driver_desc_t* driver_get_descriptor ()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
@@ -974,7 +974,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
+    LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
     {
         jack_nframes_t sample_rate = 48000;
         jack_nframes_t resample_factor = 1;

--- a/common/JackNetOneDriver.cpp
+++ b/common/JackNetOneDriver.cpp
@@ -44,6 +44,10 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <opus/opus_custom.h>
 #endif
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 #define MIN(x,y) ((x)<(y) ? (x) : (y))
 
 using namespace std;

--- a/common/JackProfiler.cpp
+++ b/common/JackProfiler.cpp
@@ -204,7 +204,7 @@ extern "C"
     
     static Jack::JackProfiler* profiler = NULL;
 
-    SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t* jack_get_descriptor()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
@@ -220,7 +220,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
+    LIB_EXPORT int jack_internal_initialize(jack_client_t* jack_client, const JSList* params)
     {
         if (profiler) {
             jack_info("profiler already loaded");
@@ -237,7 +237,7 @@ extern "C"
         }
     }
 
-    SERVER_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
+    LIB_EXPORT int jack_initialize(jack_client_t* jack_client, const char* load_init)
     {
         JSList* params = NULL;
         bool parse_params = true;
@@ -255,7 +255,7 @@ extern "C"
         return res;
     }
 
-    SERVER_EXPORT void jack_finish(void* arg)
+    LIB_EXPORT void jack_finish(void* arg)
     {
         Jack::JackProfiler* profiler = static_cast<Jack::JackProfiler*>(arg);
 

--- a/common/JackProxyDriver.cpp
+++ b/common/JackProxyDriver.cpp
@@ -483,7 +483,7 @@ namespace Jack
     {
 #endif
 
-        SERVER_EXPORT jack_driver_desc_t* driver_get_descriptor()
+        LIB_EXPORT jack_driver_desc_t* driver_get_descriptor()
         {
             jack_driver_desc_t * desc;
             jack_driver_desc_filler_t filler;
@@ -516,7 +516,7 @@ namespace Jack
             return desc;
         }
 
-        SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
+        LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
         {
             char upstream[JACK_CLIENT_NAME_SIZE + 1];
             char promiscuous[JACK_CLIENT_NAME_SIZE + 1] = {0};

--- a/common/JackTimedDriver.cpp
+++ b/common/JackTimedDriver.cpp
@@ -23,7 +23,9 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackTime.h"
 #include "JackCompilerDeps.h"
 #include <iostream>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <math.h>
 
 namespace Jack

--- a/common/jack/systemdeps.h
+++ b/common/jack/systemdeps.h
@@ -68,7 +68,10 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
     #ifdef _MSC_VER     /* Microsoft compiler */
         #define __inline__ inline
-        #if (!defined(int8_t) && !defined(_STDINT_H))
+        #if _MSC_VER >= 1600
+            #include <stdint.h>
+            #include <sys/types.h>
+        #elif (!defined(int8_t) && !defined(_STDINT_H))
             #define __int8_t_defined
             typedef char int8_t;
             typedef unsigned char uint8_t;

--- a/common/netjack.c
+++ b/common/netjack.c
@@ -63,6 +63,10 @@ $Id: net_driver.c,v 1.17 2006/04/16 20:16:10 torbenh Exp $
 
 #define MIN(x,y) ((x)<(y) ? (x) : (y))
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 static int sync_state = 1;
 static jack_transport_state_t last_transport_state;
 

--- a/common/netjack.c
+++ b/common/netjack.c
@@ -41,7 +41,7 @@ $Id: net_driver.c,v 1.17 2006/04/16 20:16:10 torbenh Exp $
 #include <sys/types.h>
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #include <malloc.h>
 #define socklen_t int
 #else

--- a/common/netjack.c
+++ b/common/netjack.c
@@ -28,7 +28,9 @@ $Id: net_driver.c,v 1.17 2006/04/16 20:16:10 torbenh Exp $
 #include <math.h>
 #include <stdio.h>
 #include <memory.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <errno.h>
 #include <stdarg.h>

--- a/common/netjack.h
+++ b/common/netjack.h
@@ -21,7 +21,9 @@
 #ifndef __NETJACK_H__
 #define __NETJACK_H__
 
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 #include <jack/types.h>
 #include <jack/jack.h>

--- a/common/netjack_packet.c
+++ b/common/netjack_packet.c
@@ -41,7 +41,9 @@
 #include <math.h>
 #include <stdio.h>
 #include <memory.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <errno.h>
 #include <stdarg.h>

--- a/common/netjack_packet.c
+++ b/common/netjack_packet.c
@@ -54,7 +54,6 @@
 
 #ifdef WIN32
 #include <winsock2.h>
-#define socklen_t int
 #include <malloc.h>
 #define socklen_t int
 #else

--- a/common/netjack_packet.c
+++ b/common/netjack_packet.c
@@ -86,6 +86,10 @@
 #define jack_error printf
 #endif
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 int fraggo = 0;
 
 void

--- a/common/ringbuffer.c
+++ b/common/ringbuffer.c
@@ -58,8 +58,8 @@ LIB_EXPORT void jack_ringbuffer_reset(jack_ringbuffer_t *rb);
 LIB_EXPORT void jack_ringbuffer_reset_size (jack_ringbuffer_t * rb, size_t sz);
 LIB_EXPORT size_t jack_ringbuffer_write(jack_ringbuffer_t *rb, const char *src,
                                  size_t cnt);
-void jack_ringbuffer_write_advance(jack_ringbuffer_t *rb, size_t cnt);
-size_t jack_ringbuffer_write_space(const jack_ringbuffer_t *rb);
+LIB_EXPORT void jack_ringbuffer_write_advance(jack_ringbuffer_t *rb, size_t cnt);
+LIB_EXPORT size_t jack_ringbuffer_write_space(const jack_ringbuffer_t *rb);
 
 /* Create a new ringbuffer to hold at least `sz' bytes of data. The
    actual buffer size is rounded up to the next power of two.  */

--- a/example-clients/alias.c
+++ b/example-clients/alias.c
@@ -16,7 +16,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <getopt.h>
 #include <jack/jack.h>

--- a/example-clients/bufsize.c
+++ b/example-clients/bufsize.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example-clients/freewheel.c
+++ b/example-clients/freewheel.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example-clients/latent_client.c
+++ b/example-clients/latent_client.c
@@ -6,7 +6,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>

--- a/example-clients/midi_dump.c
+++ b/example-clients/midi_dump.c
@@ -2,7 +2,9 @@
 
 #include <stdio.h>
 #include <string.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <assert.h>
 #include <inttypes.h>
 #include <jack/jack.h>

--- a/example-clients/midi_latency_test.c
+++ b/example-clients/midi_latency_test.c
@@ -62,7 +62,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #ifdef WIN32
 #include <windows.h>
-#include <unistd.h>
 #else
 #include <semaphore.h>
 #endif

--- a/example-clients/midiseq.c
+++ b/example-clients/midiseq.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <signal.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 jack_client_t *client;
 jack_port_t *output_port;

--- a/example-clients/midisine.c
+++ b/example-clients/midisine.c
@@ -18,7 +18,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>

--- a/example-clients/monitor_client.c
+++ b/example-clients/monitor_client.c
@@ -15,7 +15,9 @@
 */
 
 #include <stdio.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 

--- a/example-clients/netmaster.c
+++ b/example-clients/netmaster.c
@@ -31,6 +31,10 @@
 
 #include <jack/net.h>
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 jack_net_master_t* net;
 
 #define BUFFER_SIZE 512

--- a/example-clients/samplerate.c
+++ b/example-clients/samplerate.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example-clients/server_control.cpp
+++ b/example-clients/server_control.cpp
@@ -27,6 +27,10 @@
 #include <jack/jack.h>
 #include <jack/control.h>
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 static jackctl_driver_t * jackctl_server_get_driver(jackctl_server_t *server, const char *driver_name)
 {
     const JSList * node_ptr = jackctl_server_get_drivers_list(server);

--- a/example-clients/server_control.cpp
+++ b/example-clients/server_control.cpp
@@ -18,7 +18,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>

--- a/example-clients/session_notify.c
+++ b/example-clients/session_notify.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>

--- a/example-clients/session_notify.c
+++ b/example-clients/session_notify.c
@@ -31,6 +31,10 @@
 #include <jack/transport.h>
 #include <jack/session.h>
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 char *package;				/* program name */
 jack_client_t *client;
 

--- a/example-clients/showtime.c
+++ b/example-clients/showtime.c
@@ -26,6 +26,10 @@
 #include <jack/jack.h>
 #include <jack/transport.h>
 
+#ifdef _MSC_VER
+#define alloca _alloca
+#endif
+
 jack_client_t *client;
 
 static void

--- a/example-clients/showtime.c
+++ b/example-clients/showtime.c
@@ -16,7 +16,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <signal.h>
 #include <stdlib.h>
 #include <inttypes.h>

--- a/example-clients/simple_session_client.c
+++ b/example-clients/simple_session_client.c
@@ -7,7 +7,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>

--- a/example-clients/wait.c
+++ b/example-clients/wait.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <getopt.h>
 

--- a/example-clients/zombie.c
+++ b/example-clients/zombie.c
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 #include <errno.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <jack/jack.h>

--- a/windows/JackNetWinSocket.h
+++ b/windows/JackNetWinSocket.h
@@ -21,7 +21,7 @@
 #define __JackNetWinSocket__
 
 #include "JackNetSocket.h"
-#ifdef __MINGW32__
+#ifdef WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <stdint.h>

--- a/windows/JackSystemDeps_os.h
+++ b/windows/JackSystemDeps_os.h
@@ -28,7 +28,9 @@
 #define PATH_MAX   512
 #endif
 
+#if _MSC_VER < 1600
 #define UINT32_MAX 4294967295U
+#endif
 
 #define DRIVER_HANDLE HINSTANCE
 #define LoadDriverModule(name) LoadLibrary((name))

--- a/windows/portaudio/JackPortAudioAdapter.cpp
+++ b/windows/portaudio/JackPortAudioAdapter.cpp
@@ -202,7 +202,7 @@ extern "C"
 {
 #endif
 
-    SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t* jack_get_descriptor()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;

--- a/windows/portaudio/JackPortAudioAdapter.h
+++ b/windows/portaudio/JackPortAudioAdapter.h
@@ -71,7 +71,7 @@ extern "C"
 #include "JackCompilerDeps.h"
 #include "driver_interface.h"
 
-SERVER_EXPORT jack_driver_desc_t* jack_get_descriptor();
+LIB_EXPORT jack_driver_desc_t* jack_get_descriptor();
 
 #ifdef __cplusplus
 }

--- a/windows/portaudio/JackPortAudioDriver.cpp
+++ b/windows/portaudio/JackPortAudioDriver.cpp
@@ -361,7 +361,7 @@ extern "C"
 
 #include "JackCompilerDeps.h"
 
-    SERVER_EXPORT jack_driver_desc_t* driver_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t* driver_get_descriptor()
     {
         jack_driver_desc_t * desc;
         jack_driver_desc_filler_t filler;
@@ -402,7 +402,7 @@ extern "C"
         return desc;
     }
 
-    SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
+    LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
     {
         jack_nframes_t srate = 44100;
         jack_nframes_t frames_per_interrupt = 512;

--- a/windows/winmme/JackWinMMEDriver.cpp
+++ b/windows/winmme/JackWinMMEDriver.cpp
@@ -360,12 +360,12 @@ extern "C"
     // singleton kind of driver
     static Jack::JackWinMMEDriver* driver = NULL;
 
-    SERVER_EXPORT jack_driver_desc_t * driver_get_descriptor()
+    LIB_EXPORT jack_driver_desc_t * driver_get_descriptor()
     {
         return jack_driver_descriptor_construct("winmme", JackDriverSlave, "WinMME API based MIDI backend", NULL);
     }
 
-    SERVER_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
+    LIB_EXPORT Jack::JackDriverClientInterface* driver_initialize(Jack::JackLockedEngine* engine, Jack::JackSynchro* table, const JSList* params)
     {
         /*
         unsigned int capture_ports = 2;

--- a/windows/winmme/JackWinMMEDriver.cpp
+++ b/windows/winmme/JackWinMMEDriver.cpp
@@ -24,6 +24,8 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackWinMMEDriver.h"
 #include "driver_interface.h"
 
+using Jack::JackLockedEngine;
+using Jack::JackSynchro;
 using Jack::JackWinMMEDriver;
 
 JackWinMMEDriver::JackWinMMEDriver(const char *name, const char *alias,

--- a/windows/winmme/JackWinMMEInputPort.cpp
+++ b/windows/winmme/JackWinMMEInputPort.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackWinMMEInputPort.h"
 #include "JackMidiWriteQueue.h"
 
+using Jack::JackMidiBuffer;
 using Jack::JackWinMMEInputPort;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/windows/winmme/JackWinMMEOutputPort.cpp
+++ b/windows/winmme/JackWinMMEOutputPort.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackGlobals.h"
 #include "JackEngineControl.h"
 
+using Jack::JackMidiBuffer;
 using Jack::JackWinMMEOutputPort;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/wscript
+++ b/wscript
@@ -477,6 +477,7 @@ def configure(conf):
     if conf.env['IS_WINDOWS']:
         conf.env.append_unique('CCDEFINES', '_POSIX')
         conf.env.append_unique('CXXDEFINES', '_POSIX')
+        conf.env.append_unique('DEFINES', ['_WINSOCKAPI_'])
 
     conf.env.append_unique('CXXFLAGS', '-Wall')
     conf.env.append_unique('CFLAGS', '-Wall')


### PR DESCRIPTION
Greetings!

These are a series of fixes to eliminate most build errors encountered so far on Windows without any major intrusions. 

I have built almost everything in the repo with Visual Studio 2017 using the "msvc" tool in waf on my machine, but there is some remaining work that may be appropriate to hold off a bit:

### TODO
I'm still building tre myself, and using vcpkg to get the other dependencies (pthreads, portaudio, custom libsamplerate port). And using a custom pkg-config.bat to provide linker arguments to waf. Still sorting out how to improve and document this.

I intend to introduce a new SERVER_STATIC flag in *\JackCompilerDeps_os.h for when building libjack.dll, and changing + fixing the semantics of the SERVER_SIDE flag to properly link drivers against libjackserver.dll.

The `jack_info_callback` and `jack_error_callback` data exports defined in jack.h are not compatible with the definitions in JackError.h. They are not exported from the latest Windows dlls, and so I intend to put these inside an `#ifndef WIN32` guard.

I intend to update the wscripts to handle getopt, SERVER_SIDE/SERVER_STATIC fixme's, linking shell32+advapi, M_PI, min, max.

example-clients/showtime and netmaster need usleep(). May just drop a win32 implementation into each of them. inprocess.c needs declspec(dllexport).

Haven't looked into building 64bit binaries at all yet.

Regards
Anders
