### PR TITLE
Set ToS on Netjack2 packets

### DIFF
--- a/posix/JackNetUnixSocket.cpp
+++ b/posix/JackNetUnixSocket.cpp
@@ -125,21 +125,13 @@ namespace Jack
         0x00 / 000000 / 0	0	Best Effort	BE	AC_BE
         */
         
-        /*
         socklen_t len = sizeof(tos);
         
         res = getsockopt(fSockfd, IPPROTO_IP, IP_TOS, &tos, &len);
-        printf("getsockopt IPPROTO_IP res = %d  tos = %d\n", res, tos);
         
         tos = 46 * 4;       // see <netinet/in.h> 
         res = setsockopt(fSockfd, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
-        
-        printf("setsockopt IPPROTO_IP res = %d  tos = %d\n", res, tos );
-        
-        res = getsockopt(fSockfd, IPPROTO_IP, IP_TOS, &tos, &len);
-        printf("getsockopt IPPROTO_IP res = %d  tos = %d\n", res, tos);
-        */
-  
+
         return fSockfd;
     }
 


### PR DESCRIPTION
Set the ToS/DS field on the packets sent over the network (the code was commented out for some reason).

This should make most network hops prioritize Netjack2 packets over other kinds of traffic.