### PR TITLE
Fix detection of USB disconnect for ALSA devices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@ Lars-Peter Clausen
 Alexandru Tofan
 Kim Jeong Yeon
 Filipe Coelho
+Google LLC
 
 ---------------------------
   Jackdmp changes log

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -1401,6 +1401,12 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 				return 0;
 			}
 
+                        if (revents & POLLNVAL) {
+                                jack_error ("ALSA: playback device disconnected");
+                                *status = -7;
+                                return 0;
+                        }
+
 			if (revents & POLLERR) {
 				xrun_detected = TRUE;
 			}
@@ -1423,6 +1429,12 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 				*status = -6;
 				return 0;
 			}
+
+                        if (revents & POLLNVAL) {
+                                jack_error ("ALSA: capture device disconnected");
+                                *status = -7;
+                                return 0;
+                        }
 
 			if (revents & POLLERR) {
 				xrun_detected = TRUE;


### PR DESCRIPTION
Without this change, jack gets stuck in a tight poll() loop that it never recovers from. This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1416091.