### PR TITLE
jackdmp: Signal to systemd when ready

### DIFF
--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -43,6 +43,10 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "audio_reserve.h"
 #endif
 
+#if HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 /*
 This is a simple port of the old jackdmp.cpp file to use the new jack2 control API. Available options for the server
 are "hard-coded" in the source. A much better approach would be to use the control API to:
@@ -624,6 +628,10 @@ int main(int argc, char** argv)
     notify_sent = true;
     return_value = 0;
 
+#if HAVE_SYSTEMD
+    sd_notify(0, "READY=1");
+#endif
+
     // Waits for signal
 #ifdef __ANDROID__
     //reserve SIGUSR2 signal for switching master driver
@@ -637,6 +645,10 @@ int main(int argc, char** argv)
     }
 #else
     jackctl_wait_signals(sigmask);
+#endif
+
+#if HAVE_SYSTEMD
+    sd_notify(0, "STOPPING=1");
 #endif
 
  stop_server:

--- a/wscript
+++ b/wscript
@@ -439,6 +439,9 @@ def options(opt):
     readline = add_auto_option(opt, 'readline', help='Build with readline')
     readline.add_library('readline')
     readline.set_check_hook(check_for_readline, check_for_readline_error)
+    sd = add_auto_option(opt, 'systemd', help='Use systemd notify')
+    sd.add_header('systemd/sd-daemon.h')
+    sd.add_library('systemd')
 
     # dbus options
     opt.recurse('dbus')
@@ -728,7 +731,7 @@ def build_jackd(bld):
         includes = ['.', 'common', 'common/jack'],
         target = 'jackd',
         source = ['common/Jackdmp.cpp'],
-        use = ['serverlib']
+        use = ['serverlib', 'SYSTEMD']
     )
 
     if bld.env['BUILD_JACKDBUS']:


### PR DESCRIPTION
With this patch it is possibly to start the JACK daemon with a systemd
service file of type notify. The following provides an example service
file:

[Service]
Type=notify
ExecStart=/usr/bin/jackd -d alsa

[Install]
WantedBy=multi-user.target