### PR TITLE
float2int: Use right S24 format and full range S32 format

### DIFF
--- a/common/memops.c
+++ b/common/memops.c
@@ -137,17 +137,6 @@
 		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
 	}
 
-/* call this when "s" has already been scaled (e.g. when dithering)
- */
-
-#define float_24u32_scaled(s, d)\
-        if ((s) <= SAMPLE_24BIT_MIN_F) {\
-		(d) = SAMPLE_24BIT_MIN << 8;\
-	} else if ((s) >= SAMPLE_24BIT_MAX_F) {	\
-		(d) = SAMPLE_24BIT_MAX << 8;		\
-	} else {\
-		(d) = f_round ((s)) << 8; \
-	}
 
 #define float_24(s, d) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
@@ -156,18 +145,6 @@
 		(d) = SAMPLE_24BIT_MAX;\
 	} else {\
 		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
-	}
-
-/* call this when "s" has already been scaled (e.g. when dithering)
- */
-
-#define float_24_scaled(s, d)\
-        if ((s) <= SAMPLE_24BIT_MIN_F) {\
-		(d) = SAMPLE_24BIT_MIN;\
-	} else if ((s) >= SAMPLE_24BIT_MAX_F) {	\
-		(d) = SAMPLE_24BIT_MAX;		\
-	} else {\
-		(d) = f_round ((s)); \
 	}
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -73,6 +73,7 @@
    So, for now (October 2008) we use 2^(N-1)-1 as the scaling factor.
 */
 
+#define SAMPLE_32BIT_SCALING  0x7FFFFFFF
 #define SAMPLE_24BIT_SCALING  8388607
 #define SAMPLE_16BIT_SCALING  32767
 
@@ -240,6 +241,8 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
    
    S      - sample is a jack_default_audio_sample_t, currently (October 2008) a 32 bit floating point value
    Ss     - like S but reverse endian from the host CPU
+   32     - sample is an signed 32 bit integer value
+   32s    - like 32 but reverse endian from the host CPU
    32u24  - sample is an signed 32 bit integer value, but data is in lower 24 bits only
    32u24s - like 32u24 but reverse endian from the host CPU
    24     - sample is an signed 24 bit integer value
@@ -306,6 +309,11 @@ static inline void sample_move_d32scal_sSs (char *dst, jack_default_audio_sample
 void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {
 	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
+void sample_move_d32_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_32BIT_SCALING);
 }
 
 
@@ -396,6 +404,11 @@ static inline void sample_move_d32scal_sS (char *dst, jack_default_audio_sample_
 void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {
 	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
+void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_32BIT_SCALING);
 }
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -83,8 +83,6 @@
 
 #define SAMPLE_24BIT_MAX  8388607  
 #define SAMPLE_24BIT_MIN  -8388607 
-#define SAMPLE_24BIT_MAX_F  8388607.0f  
-#define SAMPLE_24BIT_MIN_F  -8388607.0f 
 
 #define SAMPLE_16BIT_MAX  32767
 #define SAMPLE_16BIT_MIN  -32767
@@ -128,13 +126,13 @@
 	        (d) = f_round ((s));\
 	}
 
-#define float_24u32(s, d) \
+#define float_32(s, d, scale) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
-		(d) = SAMPLE_24BIT_MIN;\
+		(d) = -scale;\
 	} else if ((s) >= NORMALIZED_FLOAT_MAX) {\
-		(d) = SAMPLE_24BIT_MAX;\
+		(d) = scale;\
 	} else {\
-		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
+		(d) = f_round ((s) * scale);\
 	}
 
 
@@ -182,13 +180,13 @@ static inline float32x4_t clip(float32x4_t s, float32x4_t min, float32x4_t max)
 	return vminq_f32(max, vmaxq_f32(s, min));
 }
 
-static inline int32x4_t float_24_neon(float32x4_t s)
+static inline int32x4_t float_32_neon(float32x4_t s, const int32_t scaling)
 {
 	const float32x4_t upper_bound = vdupq_n_f32(NORMALIZED_FLOAT_MAX);
 	const float32x4_t lower_bound = vdupq_n_f32(NORMALIZED_FLOAT_MIN);
 
 	float32x4_t clipped = clip(s, lower_bound, upper_bound);
-	float32x4_t scaled = vmulq_f32(clipped, vdupq_n_f32(SAMPLE_24BIT_SCALING));
+	float32x4_t scaled = vmulq_f32(clipped, vdupq_n_f32(scaling));
 	return vcvtq_s32_f32(scaled);
 }
 
@@ -256,7 +254,7 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
 
 /* functions for native integer sample data */
 
-void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+static inline void sample_move_d32scal_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state, const int32_t scaling)
 {
 #if defined (__ARM_NEON__) || defined (__ARM_NEON)
 	unsigned long unrolled = nsamples / 4;
@@ -264,7 +262,7 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, scaling);
 		converted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(converted)));
 
 		switch(dst_skip) {
@@ -287,7 +285,7 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 
 	while (nsamples--) {
 
-		float_24u32 (*src, z);
+		float_32 (*src, z, scaling);
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 		dst[0]=(char)(z>>24);
@@ -303,12 +301,18 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 		dst += dst_skip;
 		src++;
 	}
-}	
+}
 
-void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
+
+static inline void sample_move_d32scal_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state, const int32_t scaling)
 {
 #if defined (__SSE2__) && !defined (__sun__)
-	__m128 int_max = _mm_set1_ps(SAMPLE_24BIT_MAX_F);
+	__m128 int_max = _mm_set1_ps(scaling);
 	__m128 int_min = _mm_sub_ps(_mm_setzero_ps(), int_max);
 	__m128 factor = int_max;
 
@@ -361,7 +365,7 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, scaling);
 
 		switch(dst_skip) {
 			case 4:
@@ -382,12 +386,18 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 
 #if !defined (__SSE2__)
 	while (nsamples--) {
-		float_24u32 (*src, *((int32_t*) dst));
+		float_32 (*src, *((int32_t*) dst), scaling);
 		dst += dst_skip;
 		src++;
 	}
 #endif
-}	
+}
+
+void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
 
 void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
@@ -533,7 +543,7 @@ void sample_move_d24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned 
 		int i;
 		int32_t z[4];
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, SAMPLE_24BIT_SCALING);
 		converted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(converted)));
 		vst1q_s32(z, converted);
 
@@ -604,7 +614,7 @@ void sample_move_d24_sS (char *dst, jack_default_audio_sample_t *src, unsigned l
 		int i;
 		int32_t z[4];
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, SAMPLE_24BIT_SCALING);
 		vst1q_s32(z, converted);
 
 		for (i = 0; i != 4; ++i) {

--- a/common/memops.c
+++ b/common/memops.c
@@ -489,6 +489,11 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, true);
 }
 
+void sample_move_dS_s32s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+{
+	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, false);
+}
+
 
 static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
 {
@@ -572,6 +577,11 @@ static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst,
 void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
 	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, true);
+}
+
+void sample_move_dS_s32 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+{
+	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, false);
 }
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -29,6 +29,7 @@
 #include <memory.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <limits.h>
 #ifdef __linux__
 #include <endian.h>
@@ -412,9 +413,10 @@ void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src, unsigned l
 }
 
 
-void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+static inline void sample_move_dS_s32s_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
 {
-	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
+	const jack_default_audio_sample_t scaling_divisor = do_signext ? (SAMPLE_24BIT_SCALING << 8) : SAMPLE_32BIT_SCALING;
+	const jack_default_audio_sample_t scaling = 1.0 / scaling_divisor;
 
 #if defined (__ARM_NEON__) || defined (__ARM_NEON)
 	float32x4_t factor = vdupq_n_f32(scaling);
@@ -437,9 +439,11 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 				break;
 		}
 		src128 = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(src128)));
-		/* sign extension - left shift will be reverted by scaling */
-		int32x4_t shifted = vshlq_n_s32(src128, 8);
-		float32x4_t as_float = vcvtq_f32_s32(shifted);
+		if (do_signext) {
+			/* sign extension - left shift will be reverted by scaling */
+			src128 = vshlq_n_s32(src128, 8);
+		}
+		float32x4_t as_float = vcvtq_f32_s32(src128);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
 
@@ -470,16 +474,26 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 		x <<= 8;
 		x |= (unsigned char)(src[0]);
 #endif
-		/* sign extension - left shift will be reverted by scaling */
-		*dst = (x << 8) * scaling;
+		if (do_signext) {
+			/* sign extension - left shift will be reverted by scaling */
+			x <<= 8;
+		}
+		*dst = x * scaling;
 		dst++;
 		src += src_skip;
 	}
 }	
 
-void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
-	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
+	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, true);
+}
+
+
+static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
+{
+	const jack_default_audio_sample_t scaling_divisor = do_signext ? (SAMPLE_24BIT_SCALING << 8) : SAMPLE_32BIT_SCALING;
+	const jack_default_audio_sample_t scaling = 1.0 / scaling_divisor;
 
 #if defined (__SSE2__) && !defined (__sun__)
 	unsigned long unrolled = nsamples / 4;
@@ -495,11 +509,12 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 		int i4 = *((int *) src);
 		src+= src_skip;
 
-		__m128i src = _mm_set_epi32(i4, i3, i2, i1);
-		/* sign extension - left shift will be reverted by scaling */
-		__m128i shifted = _mm_slli_epi32(src, 8);
-
-		__m128 as_float = _mm_cvtepi32_ps(shifted);
+		__m128i src128 = _mm_set_epi32(i4, i3, i2, i1);
+		if (do_signext) {
+			/* sign extension - left shift will be reverted by scaling */
+			src128 = _mm_slli_epi32(src128, 8);
+		}
+		__m128 as_float = _mm_cvtepi32_ps(src128);
 		__m128 divided = _mm_mul_ps(as_float, factor);
 
 		_mm_storeu_ps(dst, divided);
@@ -526,9 +541,11 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 				src128 = vld1q_lane_s32((int32_t*)(src+3*src_skip), src128, 3);
 				break;
 		}
-		/* sign extension  - left shift will be reverted by scaling */
-		int32x4_t shifted = vshlq_n_s32(src128, 8);
-		float32x4_t as_float = vcvtq_f32_s32(shifted);
+		if (do_signext) {
+			/* sign extension  - left shift will be reverted by scaling */
+			src128 = vshlq_n_s32(src128, 8);
+		}
+		float32x4_t as_float = vcvtq_f32_s32(src128);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
 
@@ -541,12 +558,22 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 	/* ALERT: signed sign-extension portability !!! */
 
 	while (nsamples--) {
-		/* sign extension  - left shift will be reverted by scaling */
-		*dst = (*((int *) src) << 8) * scaling;
+		int src32 = *((int *) src);
+		if (do_signext) {
+			/* sign extension  - left shift will be reverted by scaling */
+			src32 <<= 8;
+		}
+		*dst = src32 * scaling;
 		dst++;
 		src += src_skip;
 	}
 }	
+
+void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+{
+	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, true);
+}
+
 
 void sample_move_d24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {

--- a/common/memops.c
+++ b/common/memops.c
@@ -130,11 +130,11 @@
 
 #define float_24u32(s, d) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
-		(d) = SAMPLE_24BIT_MIN << 8;\
+		(d) = SAMPLE_24BIT_MIN;\
 	} else if ((s) >= NORMALIZED_FLOAT_MAX) {\
-		(d) = SAMPLE_24BIT_MAX << 8;\
+		(d) = SAMPLE_24BIT_MAX;\
 	} else {\
-		(d) = f_round ((s) * SAMPLE_24BIT_SCALING) << 8;\
+		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
 	}
 
 /* call this when "s" has already been scaled (e.g. when dithering)
@@ -265,7 +265,7 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
    
    S      - sample is a jack_default_audio_sample_t, currently (October 2008) a 32 bit floating point value
    Ss     - like S but reverse endian from the host CPU
-   32u24  - sample is an signed 32 bit integer value, but data is in upper 24 bits only
+   32u24  - sample is an signed 32 bit integer value, but data is in lower 24 bits only
    32u24s - like 32u24 but reverse endian from the host CPU
    24     - sample is an signed 24 bit integer value
    24s    - like 24 but reverse endian from the host CPU
@@ -288,18 +288,17 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
 		int32x4_t converted = float_24_neon(samples);
-		int32x4_t shifted = vshlq_n_s32(converted, 8);
-		shifted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(shifted)));
+		converted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(converted)));
 
 		switch(dst_skip) {
 			case 4:
-				vst1q_s32((int32_t*)dst, shifted);
+				vst1q_s32((int32_t*)dst, converted);
 				break;
 			default:
-				vst1q_lane_s32((int32_t*)(dst),            shifted, 0);
-				vst1q_lane_s32((int32_t*)(dst+dst_skip),   shifted, 1);
-				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), shifted, 2);
-                vst1q_lane_s32((int32_t*)(dst+3*dst_skip), shifted, 3);
+				vst1q_lane_s32((int32_t*)(dst),            converted, 0);
+				vst1q_lane_s32((int32_t*)(dst+dst_skip),   converted, 1);
+				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), converted, 2);
+				vst1q_lane_s32((int32_t*)(dst+3*dst_skip), converted, 3);
 				break;
 		}
 		dst += 4*dst_skip;
@@ -345,19 +344,18 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 		__m128 clipped = clip(scaled, int_min, int_max);
 
 		__m128i y = _mm_cvttps_epi32(clipped);
-		__m128i shifted = _mm_slli_epi32(y, 8);
 
 #ifdef __SSE4_1__
-		*(int32_t*)dst              = _mm_extract_epi32(shifted, 0);
-		*(int32_t*)(dst+dst_skip)   = _mm_extract_epi32(shifted, 1);
-		*(int32_t*)(dst+2*dst_skip) = _mm_extract_epi32(shifted, 2);
-		*(int32_t*)(dst+3*dst_skip) = _mm_extract_epi32(shifted, 3);
+		*(int32_t*)dst              = _mm_extract_epi32(y, 0);
+		*(int32_t*)(dst+dst_skip)   = _mm_extract_epi32(y, 1);
+		*(int32_t*)(dst+2*dst_skip) = _mm_extract_epi32(y, 2);
+		*(int32_t*)(dst+3*dst_skip) = _mm_extract_epi32(y, 3);
 #else
-		__m128i shuffled1 = _mm_shuffle_epi32(shifted, _MM_SHUFFLE(0, 3, 2, 1));
-		__m128i shuffled2 = _mm_shuffle_epi32(shifted, _MM_SHUFFLE(1, 0, 3, 2));
-		__m128i shuffled3 = _mm_shuffle_epi32(shifted, _MM_SHUFFLE(2, 1, 0, 3));
+		__m128i shuffled1 = _mm_shuffle_epi32(y, _MM_SHUFFLE(0, 3, 2, 1));
+		__m128i shuffled2 = _mm_shuffle_epi32(y, _MM_SHUFFLE(1, 0, 3, 2));
+		__m128i shuffled3 = _mm_shuffle_epi32(y, _MM_SHUFFLE(2, 1, 0, 3));
 
-		_mm_store_ss((float*)dst, (__m128)shifted);
+		_mm_store_ss((float*)dst, (__m128)y);
 
 		_mm_store_ss((float*)(dst+dst_skip), (__m128)shuffled1);
 		_mm_store_ss((float*)(dst+2*dst_skip), (__m128)shuffled2);
@@ -374,7 +372,7 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 		__m128 clipped = _mm_min_ss(int_max, _mm_max_ss(scaled, int_min));
 
 		int y = _mm_cvttss_si32(clipped);
-		*((int *) dst) = y<<8;
+		*((int *) dst) = y;
 
 		dst += dst_skip;
 		src++;
@@ -387,17 +385,16 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
 		int32x4_t converted = float_24_neon(samples);
-		int32x4_t shifted = vshlq_n_s32(converted, 8);
 
 		switch(dst_skip) {
 			case 4:
-				vst1q_s32((int32_t*)dst, shifted);
+				vst1q_s32((int32_t*)dst, converted);
 				break;
 			default:
-				vst1q_lane_s32((int32_t*)(dst),            shifted, 0);
-				vst1q_lane_s32((int32_t*)(dst+dst_skip),   shifted, 1);
-				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), shifted, 2);
-                vst1q_lane_s32((int32_t*)(dst+3*dst_skip), shifted, 3);
+				vst1q_lane_s32((int32_t*)(dst),            converted, 0);
+				vst1q_lane_s32((int32_t*)(dst+dst_skip),   converted, 1);
+				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), converted, 2);
+				vst1q_lane_s32((int32_t*)(dst+3*dst_skip), converted, 3);
 				break;
 		}
 		dst += 4*dst_skip;

--- a/common/memops.h
+++ b/common/memops.h
@@ -53,6 +53,8 @@ void sample_move_floatLE_sSs (jack_default_audio_sample_t *dst, char *src, unsig
 void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 
 /* integer functions */
+void sample_move_d32_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
+void sample_move_d32_sS              (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sSs          (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sS           (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d24_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);

--- a/common/memops.h
+++ b/common/memops.h
@@ -81,6 +81,8 @@ void sample_move_dither_tri_d16_sS        (char *dst, jack_default_audio_sample_
 void sample_move_dither_shaped_d16_sSs    (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_dither_shaped_d16_sS     (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 
+void sample_move_dS_s32s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
+void sample_move_dS_s32              (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24s          (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24           (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s24s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);

--- a/example-clients/alsa_in.c
+++ b/example-clients/alsa_in.c
@@ -95,9 +95,9 @@ typedef struct alsa_format {
 
 alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
-	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
+	{ SND_PCM_FORMAT_S32, 4, sample_move_d32_sS, sample_move_dS_s32, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/example-clients/alsa_out.c
+++ b/example-clients/alsa_out.c
@@ -96,9 +96,9 @@ typedef struct alsa_format {
 
 alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
-	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
+	{ SND_PCM_FORMAT_S32, 4, sample_move_d32_sS, sample_move_dS_s32, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -312,9 +312,19 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 				break;
 
 			case 4: /* NO DITHER */
-				driver->write_via_copy = driver->quirk_bswap?
-					sample_move_d32u24_sSs:
-					sample_move_d32u24_sS;
+				switch (driver->playback_sample_format) {
+				case SND_PCM_FORMAT_S24_LE:
+				case SND_PCM_FORMAT_S24_BE:
+					driver->write_via_copy = driver->quirk_bswap?
+						sample_move_d32u24_sSs:
+						sample_move_d32u24_sS;
+					break;
+				default:
+					driver->write_via_copy = driver->quirk_bswap?
+						sample_move_d32_sSs:
+						sample_move_d32_sS;
+					break;
+				}
 				break;
 
 			default:
@@ -341,9 +351,20 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 					sample_move_dS_s24;
 				break;
 			case 4:
-				driver->read_via_copy = driver->quirk_bswap?
-					sample_move_dS_s32u24s:
-					sample_move_dS_s32u24;
+				switch (driver->playback_sample_format) {
+				case SND_PCM_FORMAT_S24_LE:
+				case SND_PCM_FORMAT_S24_BE:
+					driver->read_via_copy = driver->quirk_bswap?
+						sample_move_dS_s32u24s:
+						sample_move_dS_s32u24;
+					break;
+				default:
+					driver->read_via_copy = driver->quirk_bswap?
+						sample_move_dS_s32s:
+						sample_move_dS_s32;
+					break;
+				}
+
 				break;
 			}
 		}

--- a/solaris/oss/JackBoomerDriver.cpp
+++ b/solaris/oss/JackBoomerDriver.cpp
@@ -87,7 +87,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32u24(dst, (char*)s32src, nframes, byte_skip);
+            sample_move_dS_s32(dst, (char*)s32src, nframes, byte_skip);
 			break;
         }
 	}
@@ -112,7 +112,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32u24_sS((char*)s32dst, src, nframes, byte_skip, NULL);
+            sample_move_d32_sS((char*)s32dst, src, nframes, byte_skip, NULL);
 			break;
         }
 	}

--- a/solaris/oss/JackOSSAdapter.cpp
+++ b/solaris/oss/JackOSSAdapter.cpp
@@ -52,7 +52,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32u24(dst, (char*)s32src, nframes, chcount<<2);
+            sample_move_dS_s32(dst, (char*)s32src, nframes, chcount<<2);
 			break;
         }
 	}
@@ -77,7 +77,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32u24_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
+            sample_move_d32_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
 			break;
         }
 	}

--- a/solaris/oss/JackOSSDriver.cpp
+++ b/solaris/oss/JackOSSDriver.cpp
@@ -86,7 +86,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32u24(dst, (char*)s32src, nframes, chcount<<2);
+            sample_move_dS_s32(dst, (char*)s32src, nframes, chcount<<2);
 			break;
         }
 	}
@@ -111,7 +111,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32u24_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
+            sample_move_d32_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
 			break;
         }
 	}


### PR DESCRIPTION
ALSA expects right-aligned (0x00******) samples when using S24_LE and S24_BE but without this PR JACK converts into left-aligned samples (0x******00). This can result in clipping when the amplitude is higher than 0x7FFF.
In addition the same conversion was also used for S32_LE and S32_BE. Therefore the full range of S32_LE was not used. The maximal value of JACK was 0x7FFFFF00 but the maximal value accepted by ALSA is 0x7FFFFFFF. This PR provides separated conversion functions for S32 (inlining is used to reduce duplicates).

I have compiled it for ARM64 and x86_64.