### PR TITLE
Add FreeBSD support

### DIFF
--- a/common/JackAudioAdapterFactory.cpp
+++ b/common/JackAudioAdapterFactory.cpp
@@ -35,7 +35,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #define JackPlatformAdapter JackAlsaAdapter
 #endif
 
-#if defined(__sun__) || defined(sun)
+#if defined(__sun__) || defined(sun) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #include "JackOSSAdapter.h"
 #define JackPlatformAdapter JackOSSAdapter
 #endif

--- a/common/wscript
+++ b/common/wscript
@@ -104,7 +104,7 @@ def build(bld):
             '../posix/JackPosixMutex.cpp',
             '../posix/JackPosixSemaphore.cpp',
             '../posix/JackSocket.cpp',
-            '../freebsd/JackFreeBSDTime.c',
+            '../posix/JackPosixTime.c',
             ]
         includes = ['../freebsd', '../posix'] + includes
 

--- a/common/wscript
+++ b/common/wscript
@@ -28,6 +28,8 @@ def create_jack_process_obj(bld, target, sources, uselib = None, framework = Non
         env_includes = ['../macosx', '../posix', '../macosx/coreaudio']
     if bld.env['IS_LINUX']:
         env_includes = ['../linux', '../posix', '../linux/alsa']
+    if bld.env['IS_FREEBSD']:
+        env_includes = ['../freebsd', '../posix', '../solaris/oss']
     if bld.env['IS_SUN']:
         env_includes = ['../solaris', '../posix', '../solaris/oss']
     if bld.env['IS_WINDOWS']:
@@ -36,7 +38,7 @@ def create_jack_process_obj(bld, target, sources, uselib = None, framework = Non
     process.name     = target
     process.target   = target
     process.source   = sources
-    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_FREEBSD'] or bld.env['IS_MACOSX']:
         process.env.append_value('CPPFLAGS', '-fvisibility=hidden')
     process.install_path = '${ADDON_DIR}/'
     process.use = [uselib.name]
@@ -91,6 +93,20 @@ def build(bld):
         includes = ['../linux', '../posix'] + includes
         uselib.append('RT')
         uselib.append('DL')
+
+    if bld.env['IS_FREEBSD']:
+        common_libsources += [
+            'JackDebugClient.cpp',
+            'timestamps.c',
+            'promiscuous.c',
+            '../posix/JackPosixThread.cpp',
+            '../posix/JackPosixProcessSync.cpp',
+            '../posix/JackPosixMutex.cpp',
+            '../posix/JackPosixSemaphore.cpp',
+            '../posix/JackSocket.cpp',
+            '../freebsd/JackFreeBSDTime.c',
+            ]
+        includes = ['../freebsd', '../posix'] + includes
 
     if bld.env['IS_SUN']:
         common_libsources += [
@@ -165,6 +181,12 @@ def build(bld):
             '../posix/JackPosixServerLaunch.cpp',
             ]
 
+    if bld.env['IS_FREEBSD']:
+        clientlib.source += [
+            '../posix/JackSocketClientChannel.cpp',
+            '../posix/JackPosixServerLaunch.cpp',
+            ]
+
     if bld.env['IS_SUN']:
         clientlib.source += [
             '../posix/JackSocketClientChannel.cpp',
@@ -188,6 +210,9 @@ def build(bld):
     clientlib.vnum = bld.env['JACK_API_VERSION']
 
     if bld.env['IS_LINUX']:
+        clientlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
+
+    if bld.env['IS_FREEBSD']:
         clientlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
     if bld.env['IS_MACOSX']:
@@ -254,6 +279,14 @@ def build(bld):
         ]
 
     if bld.env['IS_LINUX']:
+        serverlib.source += [
+            '../posix/JackSocketServerChannel.cpp',
+            '../posix/JackSocketNotifyChannel.cpp',
+            '../posix/JackSocketServerNotifyChannel.cpp',
+            '../posix/JackNetUnixSocket.cpp',
+            ]
+
+    if bld.env['IS_FREEBSD']:
         serverlib.source += [
             '../posix/JackSocketServerChannel.cpp',
             '../posix/JackSocketNotifyChannel.cpp',
@@ -332,6 +365,10 @@ def build(bld):
             netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../linux/JackLinuxTime.c']
             netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
+        if bld.env['IS_FREEBSD']:
+            netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../linux/JackLinuxTime.c']
+            netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
+
         if bld.env['IS_SUN']:
             netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../solaris/JackSolarisTime.c']
             netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
@@ -390,7 +427,7 @@ def build(bld):
          process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
          process.use = ['ALSA', 'SAMPLERATE']
 
-    if bld.env['BUILD_ADAPTER'] and bld.env['IS_SUN']:
+    if bld.env['BUILD_ADAPTER'] and (bld.env['IS_SUN'] or bld.env['IS_FREEBSD']):
          audio_adapter_sources += ['../solaris/oss/JackOSSAdapter.cpp', 'memops.c']
          process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
          process.use = 'SAMPLERATE'

--- a/dbus/wscript
+++ b/dbus/wscript
@@ -70,6 +70,9 @@ def build(bld):
         ]
         obj.use += ['PTHREAD', 'DL', 'RT', 'DBUS-1', 'EXPAT', 'STDC++']
     if bld.env['IS_FREEBSD']:
+        obj.source += [
+            '../linux/uptime.c',
+        ]
         obj.use += ['PTHREAD', 'EXECINFO', 'LIBSYSINFO', 'DBUS-1', 'EXPAT']
     if bld.env['IS_MACOSX']:
         obj.source += [

--- a/dbus/wscript
+++ b/dbus/wscript
@@ -39,6 +39,8 @@ def build(bld):
     obj = bld(features = ['c', 'cprogram'], idx=17)
     if bld.env['IS_LINUX']:
         sysdeps_dbus_include = ['../linux', '../posix']
+    if bld.env['IS_FREEBSD']:
+        sysdeps_dbus_include = ['../freebsd', '../posix']
     if bld.env['IS_MACOSX']:
         sysdeps_dbus_include = ['../macosx', '../posix']
 
@@ -67,6 +69,8 @@ def build(bld):
             '../linux/uptime.c',
         ]
         obj.use += ['PTHREAD', 'DL', 'RT', 'DBUS-1', 'EXPAT', 'STDC++']
+    if bld.env['IS_FREEBSD']:
+        obj.use += ['PTHREAD', 'EXECINFO', 'LIBSYSINFO', 'DBUS-1', 'EXPAT']
     if bld.env['IS_MACOSX']:
         obj.source += [
             '../macosx/uptime.c',

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -47,6 +47,8 @@ def configure(conf):
 def build(bld):
     if bld.env['IS_LINUX']:
         os_incdir = ['../linux', '../posix']
+    if bld.env['IS_FREEBSD']:
+        os_incdir = ['../freebsd', '../posix']
     if bld.env['IS_MACOSX']:
         os_incdir = ['../macosx', '../posix']
     if bld.env['IS_SUN']:
@@ -78,6 +80,8 @@ def build(bld):
             prog.use += ['RT', 'M']
         if bld.env['IS_SUN']:
             prog.use += ['M']
+        if bld.env['IS_FREEBSD']:
+            prog.use += ['M']
         #prog.cflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
         #prog.cxxflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
 
@@ -90,6 +94,8 @@ def build(bld):
         prog.use = ['clientlib']
         if bld.env['IS_LINUX']:
             prog.use += ['RT', 'READLINE']
+        if bld.env['IS_FREEBSD']:
+            prog.use += ['READLINE']
         if bld.env['IS_MACOSX']:
             prog.use += ['READLINE']
         if bld.env['IS_WINDOWS']:
@@ -105,13 +111,15 @@ def build(bld):
             prog.use += ['SNDFILE']
         if bld.env['IS_LINUX']:
             prog.use += ['RT', 'SNDFILE']
+        if bld.env['IS_FREEBSD']:
+            prog.use += ['SNDFILE']
         if bld.env['IS_SUN']:
             prog.use += ['RT', 'SNDFILE']
         if bld.env['IS_WINDOWS']:
             prog.uselib = ['SNDFILE']
         prog.target = 'jack_rec'
 
-    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX'] or bld.env['IS_FREEBSD']:
         prog = bld(features = 'c cprogram')
         prog.includes = os_incdir + ['.', '..', '../common/jack', '../common']
         prog.source = ['netsource.c', '../common/netjack_packet.c']

--- a/freebsd/JackAtomic_os.h
+++ b/freebsd/JackAtomic_os.h
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2004-2008 Grame
+Copyright (C) 2018 Greg V
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackAtomic_freebsd__
+#define __JackAtomic_freebsd__
+
+#include "JackTypes.h"
+#include <sys/types.h>
+#include <machine/atomic.h>
+
+static inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void* addr)
+{
+		 return atomic_cmpset_32((uint32_t*)addr, value, newvalue);
+}
+
+#endif
+

--- a/freebsd/JackFreeBSDTime.c
+++ b/freebsd/JackFreeBSDTime.c
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2001-2003 Paul Davis
+Copyright (C) 2005 Jussi Laako
+Copyright (C) 2004-2008 Grame
+Copyright (C) 2018 Greg V
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackConstants.h"
+#include "JackTime.h"
+#include "JackTypes.h"
+#include "JackError.h"
+
+#include <time.h>
+#include <unistd.h>
+
+jack_time_t (*_jack_get_microseconds)(void) = 0;
+
+static jack_time_t jack_get_microseconds_from_system (void)
+{
+	jack_time_t jackTime;
+	struct timespec time;
+
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	jackTime = (jack_time_t) time.tv_sec * 1e6 +
+		(jack_time_t) time.tv_nsec / 1e3;
+	return jackTime;
+}
+
+
+SERVER_EXPORT void JackSleep(long usec)
+{
+	usleep(usec);
+}
+
+SERVER_EXPORT void InitTime()
+{
+	/* nothing to do on a generic system - we use the system clock */
+}
+
+SERVER_EXPORT void EndTime()
+{}
+
+void SetClockSource(jack_timer_type_t source)
+{
+    jack_log("Clock source : %s", ClockSourceName(source));
+
+	switch (source)
+	{
+	case JACK_TIMER_SYSTEM_CLOCK:
+	    default:
+	    _jack_get_microseconds = jack_get_microseconds_from_system;
+	    break;
+	}
+}
+
+const char* ClockSourceName(jack_timer_type_t source)
+{
+	switch (source) {
+	case JACK_TIMER_SYSTEM_CLOCK:
+	    return "system clock via clock_gettime";
+	}
+
+	return "unknown";
+}
+
+SERVER_EXPORT jack_time_t GetMicroSeconds()
+{
+	return _jack_get_microseconds();
+}
+
+SERVER_EXPORT jack_time_t jack_get_microseconds()
+{
+	return _jack_get_microseconds();
+}
+

--- a/freebsd/JackPlatformPlug_os.h
+++ b/freebsd/JackPlatformPlug_os.h
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2004-2008 Grame
+Copyright (C) 2018 Greg V
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software 
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackPlatformPlug_freebsd__
+#define __JackPlatformPlug_freebsd__
+
+#define jack_server_dir "/tmp"
+#define jack_client_dir "/tmp"
+#define JACK_DEFAULT_DRIVER "oss"
+
+namespace Jack
+{
+		struct JackRequest;
+	struct JackResult;
+		
+		class JackPosixMutex;
+	class JackPosixThread;
+	class JackPosixSemaphore;
+
+	class JackSocketServerChannel;
+	class JackSocketClientChannel;
+	class JackSocketServerNotifyChannel;
+	class JackSocketNotifyChannel;
+	class JackClientSocket;
+	class JackNetUnixSocket;
+}
+
+/* __JackPlatformMutex__ */
+#include "JackPosixMutex.h"
+namespace Jack {typedef JackPosixMutex JackMutex; }
+
+/* __JackPlatformThread__ */
+#include "JackPosixThread.h"
+namespace Jack { typedef JackPosixThread JackThread; }
+
+/* __JackPlatformSynchro__  client activation */
+#include "JackPosixSemaphore.h"
+namespace Jack { typedef JackPosixSemaphore JackSynchro; }
+
+/* __JackPlatformChannelTransaction__ */
+#include "JackSocket.h"
+namespace Jack { typedef JackClientSocket JackChannelTransaction; }
+
+/* __JackPlatformProcessSync__ */
+#include "JackPosixProcessSync.h"
+namespace Jack { typedef JackPosixProcessSync JackProcessSync; }
+
+/* __JackPlatformServerChannel__ */ 
+#include "JackSocketServerChannel.h"
+namespace Jack { typedef JackSocketServerChannel JackServerChannel; }
+
+/* __JackPlatformClientChannel__ */
+#include "JackSocketClientChannel.h"
+namespace Jack { typedef JackSocketClientChannel JackClientChannel; }
+
+/* __JackPlatformServerNotifyChannel__ */
+#include "JackSocketServerNotifyChannel.h"
+namespace Jack { typedef JackSocketServerNotifyChannel JackServerNotifyChannel; }
+
+/* __JackPlatformNotifyChannel__ */
+#include "JackSocketNotifyChannel.h"
+namespace Jack { typedef JackSocketNotifyChannel JackNotifyChannel; }
+
+/* __JackPlatformNetSocket__ */
+#include "JackNetUnixSocket.h"
+namespace Jack { typedef JackNetUnixSocket JackNetSocket; }
+
+#endif

--- a/freebsd/driver.h
+++ b/freebsd/driver.h
@@ -1,0 +1,1 @@
+../linux/driver.h

--- a/freebsd/uptime.h
+++ b/freebsd/uptime.h
@@ -1,0 +1,1 @@
+../linux/uptime.h

--- a/posix/JackPosixSemaphore.cpp
+++ b/posix/JackPosixSemaphore.cpp
@@ -28,6 +28,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "promiscuous.h"
 #endif
 
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#define JACK_SEM_PREFIX "/jack_sem"
+#else
+#define JACK_SEM_PREFIX "jack_sem"
+#endif
+
 namespace Jack
 {
 
@@ -48,9 +54,9 @@ void JackPosixSemaphore::BuildName(const char* client_name, const char* server_n
     snprintf(res, 32, "js_%s", ext_client_name); 
 #else
     if (fPromiscuous) {
-        snprintf(res, size, "jack_sem.%s_%s", server_name, ext_client_name);
+        snprintf(res, size, JACK_SEM_PREFIX ".%s_%s", server_name, ext_client_name);
     } else {
-        snprintf(res, size, "jack_sem.%d_%s_%s", JackTools::GetUID(), server_name, ext_client_name);
+        snprintf(res, size, JACK_SEM_PREFIX ".%d_%s_%s", JackTools::GetUID(), server_name, ext_client_name);
     }
 #endif
 }

--- a/posix/JackPosixSemaphore.cpp
+++ b/posix/JackPosixSemaphore.cpp
@@ -30,8 +30,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #define JACK_SEM_PREFIX "/jack_sem"
+#define SEM_DEFAULT_O 0
 #else
 #define JACK_SEM_PREFIX "jack_sem"
+#define SEM_DEFAULT_O O_RDWR
 #endif
 
 namespace Jack
@@ -161,7 +163,7 @@ bool JackPosixSemaphore::Allocate(const char* name, const char* server_name, int
     BuildName(name, server_name, fName, sizeof(fName));
     jack_log("JackPosixSemaphore::Allocate name = %s val = %ld", fName, value);
 
-    if ((fSemaphore = sem_open(fName, O_CREAT | O_RDWR, 0777, value)) == (sem_t*)SEM_FAILED) {
+    if ((fSemaphore = sem_open(fName, O_CREAT | SEM_DEFAULT_O, 0777, value)) == (sem_t*)SEM_FAILED) {
         jack_error("Allocate: can't check in named semaphore name = %s err = %s", fName, strerror(errno));
         return false;
     } else {
@@ -189,7 +191,7 @@ bool JackPosixSemaphore::ConnectInput(const char* name, const char* server_name)
         return true;
     }
 
-    if ((fSemaphore = sem_open(fName, O_RDWR)) == (sem_t*)SEM_FAILED) {
+    if ((fSemaphore = sem_open(fName, SEM_DEFAULT_O)) == (sem_t*)SEM_FAILED) {
         jack_error("Connect: can't connect named semaphore name = %s err = %s", fName, strerror(errno));
         return false;
     } else if (fSemaphore) {

--- a/posix/JackPosixTime.c
+++ b/posix/JackPosixTime.c
@@ -57,25 +57,13 @@ SERVER_EXPORT void EndTime()
 
 void SetClockSource(jack_timer_type_t source)
 {
-    jack_log("Clock source : %s", ClockSourceName(source));
-
-	switch (source)
-	{
-	case JACK_TIMER_SYSTEM_CLOCK:
-	    default:
-	    _jack_get_microseconds = jack_get_microseconds_from_system;
-	    break;
-	}
+	jack_log("Clock source : %s", ClockSourceName(source));
+	_jack_get_microseconds = jack_get_microseconds_from_system;
 }
 
 const char* ClockSourceName(jack_timer_type_t source)
 {
-	switch (source) {
-	case JACK_TIMER_SYSTEM_CLOCK:
-	    return "system clock via clock_gettime";
-	}
-
-	return "unknown";
+	return "system clock via clock_gettime";
 }
 
 SERVER_EXPORT jack_time_t GetMicroSeconds()

--- a/tests/wscript
+++ b/tests/wscript
@@ -20,6 +20,8 @@ def build(bld):
             prog.includes = ['..','../macosx', '../posix', '../common/jack', '../common']
         if bld.env['IS_LINUX']:
             prog.includes = ['..','../linux', '../posix', '../common/jack', '../common']
+        if bld.env['IS_FREEBSD']:
+            prog.includes = ['..','../freebsd', '../posix', '../common/jack', '../common']
         if bld.env['IS_SUN']:
             prog.includes = ['..','../solaris', '../posix', '../common/jack', '../common']
         prog.source = test_program_sources

--- a/wscript
+++ b/wscript
@@ -673,7 +673,8 @@ def build_drivers(bld):
     create_driver_obj(
         bld,
         target = 'net',
-        source = net_src)
+        source = net_src,
+        use = ['CELT'])
 
     create_driver_obj(
         bld,


### PR DESCRIPTION
(re: #283)

- OSS backend works fine
- ALSA backend is crackling (probably resampling related; that happens other apps too), do not use (wasn't used in jack1 either)
- D-Bus works fine
- tested with Carla, Cadence, qjackctl
- using POSIX semaphores because I'm currently too lazy to write a thing for `umtx` (`futex` equivalent)
  - does any platform need `O_RDWR` in semaphores?
  - would any platform complain about beginning the semaphore path with `/`?
- also needs `-fPIC` to build the OSS adapter, I'm not sure where in waf I should enable PIC