### PR TITLE
Include inttypes.h.

### DIFF
--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -27,6 +27,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackTime.h"
 #include "JackPortType.h"
 #include <math.h>
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
 
 using namespace Jack;
 


### PR DESCRIPTION
When building with MXE, the macro expansion of PRIu64 fails:

../common/JackAPI.cpp: In function 'int jack_uuid_parse(const char*, jack_uuid_t*)':
../common/JackAPI.cpp:2119:24: error: expected ')' before 'PRIu64'
     if (sscanf (b, "%" PRIu64, u) == 1) {
                        ^
../common/JackAPI.cpp:2119:33: warning: spurious trailing '%' in format [-Wformat=]
     if (sscanf (b, "%" PRIu64, u) == 1) {
                                 ^
../common/JackAPI.cpp:2119:33: warning: too many arguments for format [-Wformat-extra-args]
../common/JackAPI.cpp: In function 'void jack_uuid_unparse(jack_uuid_t, char*)':
../common/JackAPI.cpp:2134:45: error: expected ')' before 'PRIu64'
     snprintf (b, JACK_UUID_STRING_SIZE, "%" PRIu64, u);
                                             ^
../common/JackAPI.cpp:2134:54: warning: spurious trailing '%' in format [-Wformat=]
     snprintf (b, JACK_UUID_STRING_SIZE, "%" PRIu64, u);
                                                      ^
../common/JackAPI.cpp:2134:54: warning: too many arguments for format [-Wformat-extra-args]

This could be resolved by adding those two lines:

#define __STDC_FORMAT_MACROS 1
#include <inttypes.h>

References:
https://stackoverflow.com/questions/14535556/why-doesnt-priu64-work-in-this-code
https://stackoverflow.com/questions/8132399/how-to-printf-uint64-t-fails-with-spurious-trailing-in-format