### PR TITLE
Connect all ports with the same alias

### DIFF
--- a/common/JackGraphManager.cpp
+++ b/common/JackGraphManager.cpp
@@ -742,15 +742,25 @@ int JackGraphManager::GetTwoPorts(const char* src_name, const char* dst_name, ja
 }
 
 // Client : port array
-jack_port_id_t JackGraphManager::GetPort(const char* name)
+jack_port_id_t JackGraphManager::GetPortAux(const char* const name, const jack_port_id_t current)
 {
-    for (unsigned int i = 0; i < fPortMax; i++) {
+    for (unsigned int i = current; i < fPortMax; i++) {
         JackPort* port = GetPort(i);
         if (port->IsUsed() && port->NameEquals(name)) {
             return i;
         }
     }
     return NO_PORT;
+}
+
+jack_port_id_t JackGraphManager::GetPort(const char* const name)
+{
+    return GetPortAux(name, 0);
+}
+
+jack_port_id_t JackGraphManager::GetNextPort(const char* const name, const jack_port_id_t current)
+{
+    return GetPortAux(name, current+1);
 }
 
 /*!

--- a/common/JackGraphManager.h
+++ b/common/JackGraphManager.h
@@ -49,6 +49,7 @@ class SERVER_EXPORT JackGraphManager : public JackShmMem, public JackAtomicState
         void AssertPort(jack_port_id_t port_index);
         jack_port_id_t AllocatePortAux(int refnum, const char* port_name, const char* port_type, JackPortFlags flags);
         void GetConnectionsAux(JackConnectionManager* manager, const char** res, jack_port_id_t port_index);
+        jack_port_id_t GetPortAux(const char* const name, const jack_port_id_t current);
         void GetPortsAux(const char** matching_ports, const char* port_name_pattern, const char* type_name_pattern, unsigned long flags);
         jack_default_audio_sample_t* GetBuffer(jack_port_id_t port_index);
         void* GetBufferAux(JackConnectionManager* manager, jack_port_id_t port_index, jack_nframes_t frames);
@@ -72,7 +73,8 @@ class SERVER_EXPORT JackGraphManager : public JackShmMem, public JackAtomicState
         void DisconnectAllPorts(int refnum);
 
         JackPort* GetPort(jack_port_id_t index);
-        jack_port_id_t GetPort(const char* name);
+        jack_port_id_t GetPort(const char* const name);
+        jack_port_id_t GetNextPort(const char* const name, const jack_port_id_t current);
 
         int ComputeTotalLatency(jack_port_id_t port_index);
         int ComputeTotalLatencies();

--- a/common/JackInternalSessionLoader.h
+++ b/common/JackInternalSessionLoader.h
@@ -37,6 +37,7 @@ public:
 private:
     void LoadClient(std::istringstream& iss, const int linenr);
     void ConnectPorts(std::istringstream& iss, const int linenr);
+    void SetAlias(std::istringstream& iss, const int linenr);
 
     JackServer* const fServer;
 };

--- a/example-clients/connect.c
+++ b/example-clients/connect.c
@@ -68,8 +68,8 @@ main (int argc, char *argv[])
 	int option_index;
 	jack_options_t options = JackNoStartServer;
 	char *my_name = strrchr(argv[0], '/');
-	jack_port_t *src_port = 0;
-	jack_port_t *dst_port = 0;
+	const char *src_port = 0;
+	const char *dst_port = 0;
 	jack_port_t *port1 = 0;
 	jack_port_t *port2 = 0;
 	char portA[300];
@@ -194,13 +194,13 @@ main (int argc, char *argv[])
 
 	if (port1_flags & JackPortIsInput) {
 		if (port2_flags & JackPortIsOutput) {
-			src_port = port2;
-			dst_port = port1;
+			src_port = portB;
+			dst_port = portA;
 		}
 	} else {
 		if (port2_flags & JackPortIsInput) {
-			src_port = port1;
-			dst_port = port2;
+			src_port = portA;
+			dst_port = portB;
 		}
 	}
 
@@ -220,13 +220,13 @@ main (int argc, char *argv[])
 	*/
 
 	if (connecting) {
-		if (jack_connect(client, jack_port_name(src_port), jack_port_name(dst_port))) {
+		if (jack_connect(client, src_port, dst_port)) {
             fprintf (stderr, "cannot connect client, already connected?\n");
 			goto exit;
 		}
 	}
 	if (disconnecting) {
-		if (jack_disconnect(client, jack_port_name(src_port), jack_port_name(dst_port))) {
+		if (jack_disconnect(client, src_port, dst_port)) {
             fprintf (stderr, "cannot disconnect client, already disconnected?\n");
 			goto exit;
 		}

--- a/man/jackd.0
+++ b/man/jackd.0
@@ -144,6 +144,11 @@ sent to the client library.
 With this command a source port will be connected to a destination port.
 \fIsource-port\fR and \fIdestination-port\fR cannot contain spaces.
 .br
+\fBa(lias)\fR \fIalias-name port1\fR [\fIport2\fR [...]]
+.br
+With this command an alias can be set to a port. Multiple ports can be specified to set the same alias to these ports. This makes sense if one application should connect to multible ports. Therefore only the alias name has to be specified in the connect command.
+\fIalias-name\fR and \fIport*\fR cannot contain spaces.
+.br
 Comments are allowed, they start with \fB#\fR.
 .br
 An example configuration could look like the following:
@@ -151,7 +156,9 @@ An example configuration could look like the following:
  l inprocess1 inprocess
  l amp1 jalv http://lv2plug.in/plugins/eg-amp
 .br
- c amp:out system:playback_1
+ c amp1:out system:playback_1
+.br
+ a alias:media amp1:in system:playback_2
 
 .TP
 \fB\-u, \-\-unlock\fR


### PR DESCRIPTION
If there are multiple ports with the same alias the user has to call jack_connect() only once and all ports with the same alias will be connected. With this feature for example a media player does not need to know which JACK clients are interested in its audio data. The media player has only to connect to the right alias and will automatically be connected to all ports with the same alias.

Without this patch only the first register port with the matching name or alias will be connected. The following ports were ignored.

```
$ cat /etc/jackd-session.conf
a alias:media system:playback_1 system:playback_2
$ jackd -C /etc/jackd-session.conf -d alsa
$ jack_lsp -A
system:capture_1
   alsa_pcm:jack_be_in:out1
system:capture_2
   alsa_pcm:jack_be_in:out2
system:playback_1
   alsa_pcm:jack_be_out:in1
   alias:media
system:playback_2
   alsa_pcm:jack_be_out:in2
   alias:media

# only one connect call is required to connect all ports with alias:media
$ jack_connect system:capture_1 alias:media
$ jack_lsp -c
system:capture_1
   system:playback_1
   system:playback_2
system:capture_2
system:playback_1
   system:capture_1
system:playback_2
   system:capture_1
```

This feature is also useful in combination with the ALSA JACK plugin. The ALSA application can playback the same channel to multiple audio ports (by connecting to an alias) or capture from multiple audio ports.