### PR TITLE
Add script to test jack_property (Metadata)

### DIFF
--- a/tests/jack_property_test.sh
+++ b/tests/jack_property_test.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+#test jack_property client
+#//tb/1902
+
+#this test needs:
+#	-a running jack server
+#	-client programs
+#		-jack_property
+#		-jack_metro
+#		-jack_lsp
+
+#uninstall jack, setup jack1, make sure /dev/shm/ is clean, start jackd -ddummy in new terminal, run this script in new terminal
+#	time ./jack_property_test.sh > /tmp/jack_property_test_jack1_out.txt 2>&1
+
+#uninstall jack, setup jack2, make sure /dev/shm/ is clean, start jackd -ddummy in new terminal, run this script in new terminal
+#	time ./jack_property_test.sh > /tmp/jack_property_test_jack2_out.txt 2>&1
+
+#for stress test: while true; do ./jack_property_test.sh; sleep 1; done
+#to inspect running script: start with bash -x ./jack_property_test.sh
+
+set -o pipefail
+
+#any failed test will set this to 1 (error)
+FINAL_RETURN_VALUE=0
+
+function expect()
+{
+	if [ "$1" = "$2" ];
+	then
+		echo "	OK: $2"
+		return 0
+	fi
+	echo "**	FAILED: $1"
+	echo "**	EXP EQ: $2"
+	FINAL_RETURN_VALUE=1
+	return 1
+}
+
+function expect_not()
+{
+	if [ "$1" != "$2" ];
+	then
+		echo "	OK: $2"
+		return 0
+	fi
+	echo "**	FAILED: $1"
+	echo "**	EXP NE: $2"
+	FINAL_RETURN_VALUE=1
+	return 1
+}
+
+function expect_ok_empty()
+{
+	expect "$1" 0
+	expect "$2" ""
+}
+
+TESTPREFIX=""
+function tell()
+{
+	echo "test ${TESTPREFIX}$1: $2"
+}
+
+#test using -c, --client
+function client_test()
+{
+client="$1"
+
+cmd="jack_property -D"
+tell c1 "$cmd"
+res="`$cmd 2>&1`"
+	expect $? 0
+	expect "$res" "JACK metadata successfully deleted"
+
+cmd="jack_property -l"
+tell c2 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -c -l $client"
+tell c3 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -c -s $client client_key client_value"
+tell c4 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -c -l $client"
+tell c5 "$cmd"
+res="`$cmd 2>&1`"
+	expect $? 0
+	expect "$res" "key: client_key value: client_value"
+
+cmd="jack_property -c -l $client client_key"
+tell c6 "$cmd"
+res="`$cmd 2>&1`"
+	expect $? 0
+	expect "$res" "client_value"
+
+cmd="jack_property -l" #     |tail -1"
+tell c7 "$cmd"
+res="`$cmd 2>&1     |tail -1`"
+	#18446744073709551615
+	#key: client_key value: client_value
+	expect $? 0
+	expect "$res" "key: client_key value: client_value"
+
+cmd="jack_property -p -l ${client}:non"
+tell c8 "$cmd"
+res="`$cmd 2>&1`"
+	expect_not $? 0
+	expect "$res" "cannot find port name ${client}:non"
+}
+
+#test using -p, --port
+function port_test()
+{
+port="$1"
+
+cmd="jack_property -D"
+tell p1 "$cmd"
+res="`$cmd 2>&1`"
+	expect $? 0
+	expect "$res" "JACK metadata successfully deleted"
+
+cmd="jack_property -l"
+tell p2 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -p -l $port"
+tell p3 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -p -s $port port_key port_value"
+tell p4 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -p -l $port"
+tell p5 "$cmd"
+res="`$cmd 2>&1`"
+	expect $? 0
+	expect "$res" "key: port_key value: port_value"
+
+cmd="jack_property -p -l $port port_key"
+tell p6 "$cmd"
+res="`$cmd 2>&1`"
+	expect $? 0
+	expect "$res" "port_value"
+
+cmd="jack_property -p -d $port port_key"
+tell p7 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -p -l $port port_key"
+tell p8 "$cmd"
+res="`$cmd 2>&1`"
+	expect_not $? 0
+	expect "$res" "Value not found for port_key of $port"
+
+cmd="jack_property -p -d $port port_key"
+tell p9 "$cmd"
+res="`$cmd 2>&1       |tail -1`"
+	#Cannot delete key port_key (BDB0073 DB_NOTFOUND: No matching key/data pair found)
+	#"port_key" property not removed for system:playback_1
+	expect_not $? 0
+	expect "$res" "\"port_key\" property not removed for $port"
+
+cmd="jack_property -p -l $port"
+tell p10 "$cmd"
+res="`$cmd 2>&1`"
+	expect_ok_empty $? "$res"
+
+cmd="jack_property -p -l $port non"
+tell p11 "$cmd"
+res="`$cmd 2>&1`"
+	expect_not $? 0
+	expect "$res" "Value not found for non of $port"
+
+cmd="jack_property -c -l non"
+tell p12 "$cmd"
+res="`$cmd 2>&1`"
+	expect_not $? 0
+	expect "$res" "cannot get UUID for client named non"
+}
+
+
+TESTPREFIX="system_"
+client_test system
+port_test system:playback_1
+
+#test with any jack client
+jack_metro -b120 &
+metro_pid=$!
+
+sleep 0.1
+jack_lsp|grep metro
+#metro:120_bpm
+
+TESTPREFIX="metro_"
+client_test metro
+port_test metro:120_bpm
+
+jack_property -D
+#JACK metadata successfully deleted
+jack_property -l
+
+kill -HUP $metro_pid
+sleep 0.5
+echo "done, exit status is $FINAL_RETURN_VALUE"
+
+###TO DO:
+#test short keys, values
+#test long keys, values
+#test many
+
+exit $FINAL_RETURN_VALUE
+#EOF


### PR DESCRIPTION
Running script 'jack_property_test.sh' with recent jack1 and jack2 git builds show different results.
Notes:
	-jack1 gives only false positives due to a small text change
	-jack2 has issues using client name as subject/identifier/uuid
		-> see '**      FAILED' lines
	-jack1 is much faster in performing the same script
	-running the script in a loop causes memory problems with jack2

```
output running with jack1:

test system_c1: jack_property -D
	OK: 0
**	FAILED: JACK metadata successfully delete
**	EXP EQ: JACK metadata successfully deleted
test system_c2: jack_property -l
	OK: 0
	OK:
test system_c3: jack_property -c -l system
	OK: 0
	OK:
test system_c4: jack_property -c -s system client_key client_value
	OK: 0
	OK:
test system_c5: jack_property -c -l system
	OK: 0
	OK: key: client_key value: client_value
test system_c6: jack_property -c -l system client_key
	OK: 0
	OK: client_value
test system_c7: jack_property -l
	OK: 0
	OK: key: client_key value: client_value
test system_c8: jack_property -p -l system:non
	OK: 0
	OK: cannot find port name system:non
test system_p1: jack_property -D
	OK: 0
**	FAILED: JACK metadata successfully delete
**	EXP EQ: JACK metadata successfully deleted
test system_p2: jack_property -l
	OK: 0
	OK:
test system_p3: jack_property -p -l system:playback_1
	OK: 0
	OK:
test system_p4: jack_property -p -s system:playback_1 port_key port_value
	OK: 0
	OK:
test system_p5: jack_property -p -l system:playback_1
	OK: 0
	OK: key: port_key value: port_value
test system_p6: jack_property -p -l system:playback_1 port_key
	OK: 0
	OK: port_value
test system_p7: jack_property -p -d system:playback_1 port_key
	OK: 0
	OK:
test system_p8: jack_property -p -l system:playback_1 port_key
	OK: 0
	OK: Value not found for port_key of system:playback_1
test system_p9: jack_property -p -d system:playback_1 port_key
	OK: 0
	OK: "port_key" property not removed for system:playback_1
test system_p10: jack_property -p -l system:playback_1
	OK: 0
	OK:
test system_p11: jack_property -p -l system:playback_1 non
	OK: 0
	OK: Value not found for non of system:playback_1
test system_p12: jack_property -c -l non
	OK: 0
	OK: cannot get UUID for client named non
metro:120_bpm
test metro_c1: jack_property -D
	OK: 0
**	FAILED: JACK metadata successfully delete
**	EXP EQ: JACK metadata successfully deleted
test metro_c2: jack_property -l
	OK: 0
	OK:
test metro_c3: jack_property -c -l metro
	OK: 0
	OK:
test metro_c4: jack_property -c -s metro client_key client_value
	OK: 0
	OK:
test metro_c5: jack_property -c -l metro
	OK: 0
	OK: key: client_key value: client_value
test metro_c6: jack_property -c -l metro client_key
	OK: 0
	OK: client_value
test metro_c7: jack_property -l
	OK: 0
	OK: key: client_key value: client_value
test metro_c8: jack_property -p -l metro:non
	OK: 0
	OK: cannot find port name metro:non
test metro_p1: jack_property -D
	OK: 0
**	FAILED: JACK metadata successfully delete
**	EXP EQ: JACK metadata successfully deleted
test metro_p2: jack_property -l
	OK: 0
	OK:
test metro_p3: jack_property -p -l metro:120_bpm
	OK: 0
	OK:
test metro_p4: jack_property -p -s metro:120_bpm port_key port_value
	OK: 0
	OK:
test metro_p5: jack_property -p -l metro:120_bpm
	OK: 0
	OK: key: port_key value: port_value
test metro_p6: jack_property -p -l metro:120_bpm port_key
	OK: 0
	OK: port_value
test metro_p7: jack_property -p -d metro:120_bpm port_key
	OK: 0
	OK:
test metro_p8: jack_property -p -l metro:120_bpm port_key
	OK: 0
	OK: Value not found for port_key of metro:120_bpm
test metro_p9: jack_property -p -d metro:120_bpm port_key
	OK: 0
	OK: "port_key" property not removed for metro:120_bpm
test metro_p10: jack_property -p -l metro:120_bpm
	OK: 0
	OK:
test metro_p11: jack_property -p -l metro:120_bpm non
	OK: 0
	OK: Value not found for non of metro:120_bpm
test metro_p12: jack_property -c -l non
	OK: 0
	OK: cannot get UUID for client named non
JACK metadata successfully delete
./jack_property_test.sh: line 215: 21025 Hangup                  jack_metro -b120
done, exit status is 1

real	0m1.011s
user	0m0.125s
sys	0m0.324s

==========================================
output running with jack2:

test system_c1: jack_property -D
	OK: 0
	OK: JACK metadata successfully deleted
test system_c2: jack_property -l
	OK: 0
	OK:
test system_c3: jack_property -c -l system
	OK: 0
	OK:
test system_c4: jack_property -c -s system client_key client_value
	OK: 0
	OK:
test system_c5: jack_property -c -l system
	OK: 0
	OK: key: client_key value: client_value
test system_c6: jack_property -c -l system client_key
	OK: 0
	OK: client_value
test system_c7: jack_property -l
	OK: 0
	OK: key: client_key value: client_value
test system_c8: jack_property -p -l system:non
	OK: 0
	OK: cannot find port name system:non
test system_p1: jack_property -D
	OK: 0
	OK: JACK metadata successfully deleted
test system_p2: jack_property -l
	OK: 0
	OK:
test system_p3: jack_property -p -l system:playback_1
	OK: 0
	OK:
test system_p4: jack_property -p -s system:playback_1 port_key port_value
	OK: 0
	OK:
test system_p5: jack_property -p -l system:playback_1
	OK: 0
	OK: key: port_key value: port_value
test system_p6: jack_property -p -l system:playback_1 port_key
	OK: 0
	OK: port_value
test system_p7: jack_property -p -d system:playback_1 port_key
	OK: 0
	OK:
test system_p8: jack_property -p -l system:playback_1 port_key
	OK: 0
	OK: Value not found for port_key of system:playback_1
test system_p9: jack_property -p -d system:playback_1 port_key
	OK: 0
	OK: "port_key" property not removed for system:playback_1
test system_p10: jack_property -p -l system:playback_1
	OK: 0
	OK:
test system_p11: jack_property -p -l system:playback_1 non
	OK: 0
	OK: Value not found for non of system:playback_1
test system_p12: jack_property -c -l non
	OK: 0
	OK: cannot get UUID for client named non
metro:120_bpm
test metro_c1: jack_property -D
	OK: 0
	OK: JACK metadata successfully deleted
test metro_c2: jack_property -l
	OK: 0
	OK:
test metro_c3: jack_property -c -l metro
**	FAILED: 255
**	EXP EQ: 0
**	FAILED: cannot parse client UUID as UUID
**	EXP EQ:
test metro_c4: jack_property -c -s metro client_key client_value
**	FAILED: 255
**	EXP EQ: 0
**	FAILED: cannot parse client UUID as UUID
**	EXP EQ:
test metro_c5: jack_property -c -l metro
**	FAILED: 255
**	EXP EQ: 0
**	FAILED: cannot parse client UUID as UUID
**	EXP EQ: key: client_key value: client_value
test metro_c6: jack_property -c -l metro client_key
**	FAILED: 255
**	EXP EQ: 0
**	FAILED: cannot parse client UUID as UUID
**	EXP EQ: client_value
test metro_c7: jack_property -l
	OK: 0
**	FAILED:
**	EXP EQ: key: client_key value: client_value
test metro_c8: jack_property -p -l metro:non
	OK: 0
	OK: cannot find port name metro:non
test metro_p1: jack_property -D
	OK: 0
	OK: JACK metadata successfully deleted
test metro_p2: jack_property -l
	OK: 0
	OK:
test metro_p3: jack_property -p -l metro:120_bpm
	OK: 0
	OK:
test metro_p4: jack_property -p -s metro:120_bpm port_key port_value
	OK: 0
	OK:
test metro_p5: jack_property -p -l metro:120_bpm
	OK: 0
	OK: key: port_key value: port_value
test metro_p6: jack_property -p -l metro:120_bpm port_key
	OK: 0
	OK: port_value
test metro_p7: jack_property -p -d metro:120_bpm port_key
	OK: 0
	OK:
test metro_p8: jack_property -p -l metro:120_bpm port_key
	OK: 0
	OK: Value not found for port_key of metro:120_bpm
test metro_p9: jack_property -p -d metro:120_bpm port_key
	OK: 0
	OK: "port_key" property not removed for metro:120_bpm
test metro_p10: jack_property -p -l metro:120_bpm
	OK: 0
	OK:
test metro_p11: jack_property -p -l metro:120_bpm non
	OK: 0
	OK: Value not found for non of metro:120_bpm
test metro_p12: jack_property -c -l non
	OK: 0
	OK: cannot get UUID for client named non
JACK metadata successfully deleted
signal received, exiting ...
done, exit status is 1

real	0m2.806s
user	0m0.176s
sys	0m0.374s
```
