### PR TITLE
memops-alsa_bad_sound-fix-1

### DIFF
--- a/common/memops.c
+++ b/common/memops.c
@@ -73,8 +73,8 @@
    So, for now (October 2008) we use 2^(N-1)-1 as the scaling factor.
 */
 
-#define SAMPLE_24BIT_SCALING  8388607
-#define SAMPLE_16BIT_SCALING  32767
+#define SAMPLE_24BIT_SCALING  8388607.0f
+#define SAMPLE_16BIT_SCALING  32767.0f
 
 /* these are just values to use if the floating point value was out of range
    
@@ -414,10 +414,8 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 
 void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
-	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
-
 #if defined (__ARM_NEON__) || defined (__ARM_NEON)
-	float32x4_t factor = vdupq_n_f32(scaling);
+	float32x4_t factor = vdupq_n_f32(1.0 / SAMPLE_24BIT_SCALING);
 	unsigned long unrolled = nsamples / 4;
 	while (unrolled--) {
 		int32x4_t src128;
@@ -437,8 +435,7 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 				break;
 		}
 		src128 = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(src128)));
-		/* sign extension - left shift will be reverted by scaling */
-		int32x4_t shifted = vshlq_n_s32(src128, 8);
+		int32x4_t shifted = vshrq_n_s32(src128, 8);
 		float32x4_t as_float = vcvtq_f32_s32(shifted);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
@@ -450,6 +447,8 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 #endif
 
 	/* ALERT: signed sign-extension portability !!! */
+
+	const jack_default_audio_sample_t scaling = 1.0/SAMPLE_24BIT_SCALING;
 
 	while (nsamples--) {
 		int x;
@@ -470,8 +469,7 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 		x <<= 8;
 		x |= (unsigned char)(src[0]);
 #endif
-		/* sign extension - left shift will be reverted by scaling */
-		*dst = (x << 8) * scaling;
+		*dst = (x >> 8) * scaling;
 		dst++;
 		src += src_skip;
 	}
@@ -479,11 +477,10 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 
 void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
-	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
-
 #if defined (__SSE2__) && !defined (__sun__)
 	unsigned long unrolled = nsamples / 4;
-	__m128 factor = _mm_set1_ps(scaling);
+	static float inv_sample_max_24bit = 1.0 / SAMPLE_24BIT_SCALING;
+	__m128 factor = _mm_set1_ps(inv_sample_max_24bit);
 	while (unrolled--)
 	{
 		int i1 = *((int *) src);
@@ -496,8 +493,7 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 		src+= src_skip;
 
 		__m128i src = _mm_set_epi32(i4, i3, i2, i1);
-		/* sign extension - left shift will be reverted by scaling */
-		__m128i shifted = _mm_slli_epi32(src, 8);
+		__m128i shifted = _mm_srai_epi32(src, 8);
 
 		__m128 as_float = _mm_cvtepi32_ps(shifted);
 		__m128 divided = _mm_mul_ps(as_float, factor);
@@ -509,7 +505,7 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 	nsamples = nsamples & 3;
 #elif defined (__ARM_NEON__) || defined (__ARM_NEON)
 	unsigned long unrolled = nsamples / 4;
-	float32x4_t factor = vdupq_n_f32(scaling);
+	float32x4_t factor = vdupq_n_f32(1.0 / SAMPLE_24BIT_SCALING);
 	while (unrolled--) {
 		int32x4_t src128;
 		switch(src_skip) {
@@ -526,8 +522,7 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 				src128 = vld1q_lane_s32((int32_t*)(src+3*src_skip), src128, 3);
 				break;
 		}
-		/* sign extension  - left shift will be reverted by scaling */
-		int32x4_t shifted = vshlq_n_s32(src128, 8);
+		int32x4_t shifted = vshrq_n_s32(src128, 8);
 		float32x4_t as_float = vcvtq_f32_s32(shifted);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
@@ -540,9 +535,9 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 
 	/* ALERT: signed sign-extension portability !!! */
 
+	const jack_default_audio_sample_t scaling = 1.0/SAMPLE_24BIT_SCALING;
 	while (nsamples--) {
-		/* sign extension  - left shift will be reverted by scaling */
-		*dst = (*((int *) src) << 8) * scaling;
+		*dst = (*((int *) src) >> 8) * scaling;
 		dst++;
 		src += src_skip;
 	}

--- a/common/memops.c
+++ b/common/memops.c
@@ -137,6 +137,17 @@
 		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
 	}
 
+/* call this when "s" has already been scaled (e.g. when dithering)
+ */
+
+#define float_24u32_scaled(s, d)\
+        if ((s) <= SAMPLE_24BIT_MIN_F) {\
+		(d) = SAMPLE_24BIT_MIN << 8;\
+	} else if ((s) >= SAMPLE_24BIT_MAX_F) {	\
+		(d) = SAMPLE_24BIT_MAX << 8;		\
+	} else {\
+		(d) = f_round ((s)) << 8; \
+	}
 
 #define float_24(s, d) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
@@ -145,6 +156,18 @@
 		(d) = SAMPLE_24BIT_MAX;\
 	} else {\
 		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
+	}
+
+/* call this when "s" has already been scaled (e.g. when dithering)
+ */
+
+#define float_24_scaled(s, d)\
+        if ((s) <= SAMPLE_24BIT_MIN_F) {\
+		(d) = SAMPLE_24BIT_MIN;\
+	} else if ((s) >= SAMPLE_24BIT_MAX_F) {	\
+		(d) = SAMPLE_24BIT_MAX;		\
+	} else {\
+		(d) = f_round ((s)); \
 	}
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -29,7 +29,6 @@
 #include <memory.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <stdbool.h>
 #include <limits.h>
 #ifdef __linux__
 #include <endian.h>
@@ -413,10 +412,9 @@ void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src, unsigned l
 }
 
 
-static inline void sample_move_dS_s32s_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
+void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
-	const jack_default_audio_sample_t scaling_divisor = do_signext ? (SAMPLE_24BIT_SCALING << 8) : SAMPLE_32BIT_SCALING;
-	const jack_default_audio_sample_t scaling = 1.0 / scaling_divisor;
+	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
 
 #if defined (__ARM_NEON__) || defined (__ARM_NEON)
 	float32x4_t factor = vdupq_n_f32(scaling);
@@ -439,11 +437,9 @@ static inline void sample_move_dS_s32s_signext (jack_default_audio_sample_t *dst
 				break;
 		}
 		src128 = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(src128)));
-		if (do_signext) {
-			/* sign extension - left shift will be reverted by scaling */
-			src128 = vshlq_n_s32(src128, 8);
-		}
-		float32x4_t as_float = vcvtq_f32_s32(src128);
+		/* sign extension - left shift will be reverted by scaling */
+		int32x4_t shifted = vshlq_n_s32(src128, 8);
+		float32x4_t as_float = vcvtq_f32_s32(shifted);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
 
@@ -474,26 +470,16 @@ static inline void sample_move_dS_s32s_signext (jack_default_audio_sample_t *dst
 		x <<= 8;
 		x |= (unsigned char)(src[0]);
 #endif
-		if (do_signext) {
-			/* sign extension - left shift will be reverted by scaling */
-			x <<= 8;
-		}
-		*dst = x * scaling;
+		/* sign extension - left shift will be reverted by scaling */
+		*dst = (x << 8) * scaling;
 		dst++;
 		src += src_skip;
 	}
 }	
 
-void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
-	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, true);
-}
-
-
-static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
-{
-	const jack_default_audio_sample_t scaling_divisor = do_signext ? (SAMPLE_24BIT_SCALING << 8) : SAMPLE_32BIT_SCALING;
-	const jack_default_audio_sample_t scaling = 1.0 / scaling_divisor;
+	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
 
 #if defined (__SSE2__) && !defined (__sun__)
 	unsigned long unrolled = nsamples / 4;
@@ -509,12 +495,11 @@ static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst,
 		int i4 = *((int *) src);
 		src+= src_skip;
 
-		__m128i src128 = _mm_set_epi32(i4, i3, i2, i1);
-		if (do_signext) {
-			/* sign extension - left shift will be reverted by scaling */
-			src128 = _mm_slli_epi32(src128, 8);
-		}
-		__m128 as_float = _mm_cvtepi32_ps(src128);
+		__m128i src = _mm_set_epi32(i4, i3, i2, i1);
+		/* sign extension - left shift will be reverted by scaling */
+		__m128i shifted = _mm_slli_epi32(src, 8);
+
+		__m128 as_float = _mm_cvtepi32_ps(shifted);
 		__m128 divided = _mm_mul_ps(as_float, factor);
 
 		_mm_storeu_ps(dst, divided);
@@ -541,11 +526,9 @@ static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst,
 				src128 = vld1q_lane_s32((int32_t*)(src+3*src_skip), src128, 3);
 				break;
 		}
-		if (do_signext) {
-			/* sign extension  - left shift will be reverted by scaling */
-			src128 = vshlq_n_s32(src128, 8);
-		}
-		float32x4_t as_float = vcvtq_f32_s32(src128);
+		/* sign extension  - left shift will be reverted by scaling */
+		int32x4_t shifted = vshlq_n_s32(src128, 8);
+		float32x4_t as_float = vcvtq_f32_s32(shifted);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
 
@@ -558,22 +541,12 @@ static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst,
 	/* ALERT: signed sign-extension portability !!! */
 
 	while (nsamples--) {
-		int src32 = *((int *) src);
-		if (do_signext) {
-			/* sign extension  - left shift will be reverted by scaling */
-			src32 <<= 8;
-		}
-		*dst = src32 * scaling;
+		/* sign extension  - left shift will be reverted by scaling */
+		*dst = (*((int *) src) << 8) * scaling;
 		dst++;
 		src += src_skip;
 	}
 }	
-
-void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
-{
-	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, true);
-}
-
 
 void sample_move_d24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {

--- a/common/memops.c
+++ b/common/memops.c
@@ -73,7 +73,6 @@
    So, for now (October 2008) we use 2^(N-1)-1 as the scaling factor.
 */
 
-#define SAMPLE_32BIT_SCALING  0x7FFFFFFF
 #define SAMPLE_24BIT_SCALING  8388607
 #define SAMPLE_16BIT_SCALING  32767
 
@@ -241,8 +240,6 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
    
    S      - sample is a jack_default_audio_sample_t, currently (October 2008) a 32 bit floating point value
    Ss     - like S but reverse endian from the host CPU
-   32     - sample is an signed 32 bit integer value
-   32s    - like 32 but reverse endian from the host CPU
    32u24  - sample is an signed 32 bit integer value, but data is in lower 24 bits only
    32u24s - like 32u24 but reverse endian from the host CPU
    24     - sample is an signed 24 bit integer value
@@ -309,11 +306,6 @@ static inline void sample_move_d32scal_sSs (char *dst, jack_default_audio_sample
 void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {
 	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
-}
-
-void sample_move_d32_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
-{
-	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_32BIT_SCALING);
 }
 
 
@@ -404,11 +396,6 @@ static inline void sample_move_d32scal_sS (char *dst, jack_default_audio_sample_
 void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {
 	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
-}
-
-void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
-{
-	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_32BIT_SCALING);
 }
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -489,11 +489,6 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, true);
 }
 
-void sample_move_dS_s32s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
-{
-	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, false);
-}
-
 
 static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
 {
@@ -577,11 +572,6 @@ static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst,
 void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
 	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, true);
-}
-
-void sample_move_dS_s32 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
-{
-	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, false);
 }
 
 

--- a/common/memops.h
+++ b/common/memops.h
@@ -81,8 +81,6 @@ void sample_move_dither_tri_d16_sS        (char *dst, jack_default_audio_sample_
 void sample_move_dither_shaped_d16_sSs    (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_dither_shaped_d16_sS     (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 
-void sample_move_dS_s32s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
-void sample_move_dS_s32              (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24s          (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24           (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s24s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);

--- a/common/memops.h
+++ b/common/memops.h
@@ -53,8 +53,6 @@ void sample_move_floatLE_sSs (jack_default_audio_sample_t *dst, char *src, unsig
 void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 
 /* integer functions */
-void sample_move_d32_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
-void sample_move_d32_sS              (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sSs          (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sS           (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d24_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);

--- a/example-clients/alsa_in.c
+++ b/example-clients/alsa_in.c
@@ -95,9 +95,9 @@ typedef struct alsa_format {
 
 alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
-	{ SND_PCM_FORMAT_S32, 4, sample_move_d32_sS, sample_move_dS_s32, "32bit" },
+	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/example-clients/alsa_out.c
+++ b/example-clients/alsa_out.c
@@ -96,9 +96,9 @@ typedef struct alsa_format {
 
 alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
-	{ SND_PCM_FORMAT_S32, 4, sample_move_d32_sS, sample_move_dS_s32, "32bit" },
+	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -312,19 +312,9 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 				break;
 
 			case 4: /* NO DITHER */
-				switch (driver->playback_sample_format) {
-				case SND_PCM_FORMAT_S24_LE:
-				case SND_PCM_FORMAT_S24_BE:
-					driver->write_via_copy = driver->quirk_bswap?
-						sample_move_d32u24_sSs:
-						sample_move_d32u24_sS;
-					break;
-				default:
-					driver->write_via_copy = driver->quirk_bswap?
-						sample_move_d32_sSs:
-						sample_move_d32_sS;
-					break;
-				}
+				driver->write_via_copy = driver->quirk_bswap?
+					sample_move_d32u24_sSs:
+					sample_move_d32u24_sS;
 				break;
 
 			default:
@@ -351,20 +341,9 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 					sample_move_dS_s24;
 				break;
 			case 4:
-				switch (driver->playback_sample_format) {
-				case SND_PCM_FORMAT_S24_LE:
-				case SND_PCM_FORMAT_S24_BE:
-					driver->read_via_copy = driver->quirk_bswap?
-						sample_move_dS_s32u24s:
-						sample_move_dS_s32u24;
-					break;
-				default:
-					driver->read_via_copy = driver->quirk_bswap?
-						sample_move_dS_s32s:
-						sample_move_dS_s32;
-					break;
-				}
-
+				driver->read_via_copy = driver->quirk_bswap?
+					sample_move_dS_s32u24s:
+					sample_move_dS_s32u24;
 				break;
 			}
 		}

--- a/solaris/oss/JackBoomerDriver.cpp
+++ b/solaris/oss/JackBoomerDriver.cpp
@@ -87,7 +87,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32(dst, (char*)s32src, nframes, byte_skip);
+            sample_move_dS_s32u24(dst, (char*)s32src, nframes, byte_skip);
 			break;
         }
 	}
@@ -112,7 +112,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32_sS((char*)s32dst, src, nframes, byte_skip, NULL);
+            sample_move_d32u24_sS((char*)s32dst, src, nframes, byte_skip, NULL);
 			break;
         }
 	}

--- a/solaris/oss/JackOSSAdapter.cpp
+++ b/solaris/oss/JackOSSAdapter.cpp
@@ -52,7 +52,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32(dst, (char*)s32src, nframes, chcount<<2);
+            sample_move_dS_s32u24(dst, (char*)s32src, nframes, chcount<<2);
 			break;
         }
 	}
@@ -77,7 +77,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
+            sample_move_d32u24_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
 			break;
         }
 	}

--- a/solaris/oss/JackOSSDriver.cpp
+++ b/solaris/oss/JackOSSDriver.cpp
@@ -86,7 +86,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32(dst, (char*)s32src, nframes, chcount<<2);
+            sample_move_dS_s32u24(dst, (char*)s32src, nframes, chcount<<2);
 			break;
         }
 	}
@@ -111,7 +111,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
+            sample_move_d32u24_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
 			break;
         }
 	}


### PR DESCRIPTION
This s about to revert ALL of the following series of commits, as given by:
```
> git log --oneline  c5a0f5ea...831163e5^

c5a0f5ea oss_driver: Use float to S32 conversion if requested
148c8d8e alsa_in/out: Use float to S32 conversion if requested
d017e1ff alsa_driver: Use float to S32 conversion if requested
bb99e09b memops: Provide function for float to S32 conversion
b4ea23df memops: Align S24LE and S32LE to float conversion
244fc27e memops: Provide function for S32 to float conversion
4455fe02 memops: Align float to S24LE and S32LE conversion
a82f3f2f memops: Remove not used conversion macros
e7532543 memops: Use right-aligned S24LE to float conversion
831163e5 memops: Use right-aligned float to S24LE conversion

```
Apparently at least one of the above is causing severe sound anomalies eg. glitching/clipping distortion, and/or also the opposite effect of extreme low level signal and perceived constant drop outs.

You can either revert explicitly starting from the top and step down or merge this PR.