### PR TITLE
Solving problems while compiling jack2 on macOS X with dbus support

### DIFF
--- a/dbus/controller.c
+++ b/dbus/controller.c
@@ -796,7 +796,7 @@ jack_controller_run(
 
     if ((ut = uptime()) < 0)
     {
-        jack_error("sysinfo() failed with %d", errno);
+        jack_error(UPTIME_FUNCTION_NAME "() failed with %d", errno);
     }
     else if (ut < controller_ptr->pending_save + 2) /* delay save by two seconds */
     {

--- a/dbus/wscript
+++ b/dbus/wscript
@@ -63,8 +63,14 @@ def build(bld):
         ]
     obj.use = ['serverlib']
     if bld.env['IS_LINUX']:
+        obj.source += [
+            '../linux/uptime.c',
+        ]
         obj.use += ['PTHREAD', 'DL', 'RT', 'DBUS-1', 'EXPAT', 'STDC++']
     if bld.env['IS_MACOSX']:
+        obj.source += [
+            '../macosx/uptime.c',
+        ]
         obj.use += ['PTHREAD', 'DL', 'DBUS-1', 'EXPAT']
     obj.target = 'jackdbus'
 

--- a/linux/uptime.c
+++ b/linux/uptime.c
@@ -1,0 +1,12 @@
+#include <sys/sysinfo.h>
+
+long uptime(void) {
+    struct sysinfo si;
+
+    if (sysinfo(&si) != 0)
+    {
+        return -1;
+    }
+
+    return si.uptime;
+}

--- a/linux/uptime.h
+++ b/linux/uptime.h
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2004-2005 Grame
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#ifndef __uptime_LINUX__
+#define __uptime_LINUX__
+
+#define UPTIME_FUNCTION_NAME "sysinfo"
+
+long uptime(void);
+
+#endif

--- a/macosx/uptime.c
+++ b/macosx/uptime.c
@@ -1,0 +1,17 @@
+#include <time.h>
+#include <errno.h>
+#include <sys/sysctl.h>
+
+long uptime(void)
+{
+    struct timeval boottime;
+    size_t len = sizeof(boottime);
+    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
+    if (sysctl(mib, 2, &boottime, &len, NULL, 0) < 0)
+    {
+        return -1L;
+    }
+    time_t bsec = boottime.tv_sec, csec = time(NULL);
+
+    return (long) difftime(csec, bsec);
+}

--- a/macosx/uptime.h
+++ b/macosx/uptime.h
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2004-2005 Grame
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#ifndef __uptime_APPLE__
+#define __uptime_APPLE__
+
+#define UPTIME_FUNCTION_NAME "sysctl"
+
+long uptime(void);
+
+#endif


### PR DESCRIPTION
I have a problem while compiling jack2 on macOS X with dbus support because sysinfo.h is a linux exclusive.
I used sysctl on macOS to get uptime and it just works.