### PR TITLE
Remove GPL dependency from JackTools.

### DIFF
--- a/common/JackNetOneDriver.cpp
+++ b/common/JackNetOneDriver.cpp
@@ -287,7 +287,7 @@ int JackNetOneDriver::Read()
     }
 
     if ((netj.num_lost_packets * netj.period_size / netj.sample_rate) > 2)
-        JackTools::ThrowJackNetException();
+        throw JackNetException();
 
     //netjack_read(&netj, netj.period_size);
     JackDriver::CycleTakeBeginTime();

--- a/common/JackTools.cpp
+++ b/common/JackTools.cpp
@@ -18,7 +18,7 @@
 */
 
 #include "JackConstants.h"
-#include "JackDriverLoader.h"
+#include "driver_interface.h"
 #include "JackTools.h"
 #include "JackError.h"
 #include <stdlib.h>
@@ -42,11 +42,6 @@ namespace Jack {
     #else
         kill(GetPID(), SIGINT);
     #endif
-    }
-
-    void JackTools::ThrowJackNetException()
-    {
-        throw JackNetException();
     }
 
      int JackTools::MkDir(const char* path)
@@ -299,4 +294,3 @@ void BuildClientPath(char* path_to_so, int path_len, const char* so_name)
 
 
 }  // end of namespace
-


### PR DESCRIPTION
JackTools is a part of the LGPL licenced jacklib and should not pull in
GPL licensed code.