### PR TITLE
[metadata] Fix property key length to notification/callback requests.

### DIFF
--- a/common/JackRequest.h
+++ b/common/JackRequest.h
@@ -1632,7 +1632,7 @@ struct JackClientHasSessionCallbackRequest : public JackRequest
 struct JackPropertyChangeNotifyRequest : public JackRequest
 {
     jack_uuid_t fSubject;
-    char fKey[JACK_UUID_STRING_SIZE];
+    char fKey[MAX_PATH+1];
     jack_property_change_t fChange;
 
     JackPropertyChangeNotifyRequest() : fChange((jack_property_change_t)0)


### PR DESCRIPTION
Increase property key field length, from JACK_UUID_STRING_SIZE (37) to MAX_PATH+1 (256), as long to fit most metadata keys (URI) on change notification/callback requests.