### PR TITLE
Make jackdbus logging configurable and add some log hints

### DIFF
--- a/dbus/jackdbus.c
+++ b/dbus/jackdbus.c
@@ -70,91 +70,91 @@ DBusConnection *g_connection;
 static
 char* expanduser(const char *path)
 {
-  if (!path)          return NULL;
-  if (!strlen(path))  return NULL;
+    if (!path)          return NULL;
+    if (!strlen(path))  return NULL;
 
-  // If the path doesn't start with a tilde, there's nothing interesting to do
-  // here
-  if (path[0] != '~') goto dup_and_exit;
+    // If the path doesn't start with a tilde, there's nothing interesting to do
+    // here
+    if (path[0] != '~') goto dup_and_exit;
 
-  // path is of form 1) '~/<whatever>'
-  // or              2) '~user/<whatever>'
-  // or              3) '~'
-  // or              4) '~user`
+    // path is of form 1) '~/<whatever>'
+    // or              2) '~user/<whatever>'
+    // or              3) '~'
+    // or              4) '~user`
 
-  // Look for a slash
-  size_t slash_idx   = 0;
-  bool   found_slash = false;
-  for (; slash_idx < strlen(path); ++slash_idx) {
-    if (path[slash_idx] == '/') {
-      found_slash = true;
-      break;
+    // Look for a slash
+    size_t slash_idx   = 0;
+    bool   found_slash = false;
+    for (; slash_idx < strlen(path); ++slash_idx) {
+        if (path[slash_idx] == '/') {
+            found_slash = true;
+            break;
+        }
     }
-  }
 
-  char        userbuf[32+1];           // theoretically max from posix
-  size_t      replace_until;           // [0, replace_until)
-  char const* replace_with     = NULL; // if set, we'll use this as homedir
-  char const* replace_user     = NULL; // if ^ not set, try to lookup this user's homedir
+    char        userbuf[32+1];           // theoretically max from posix
+    size_t      replace_until;           // [0, replace_until)
+    char const* replace_with     = NULL; // if set, we'll use this as homedir
+    char const* replace_user     = NULL; // if ^ not set, try to lookup this user's homedir
 
-  if (found_slash) { // size at least 2 (we have a tilde and a slash)
-    assert(slash_idx > 0); // cannot be at zero, first char must be ~
-    if (slash_idx == 1) {
-      // case 1
-      replace_until = 1;
-      replace_with  = getenv("HOME"); // if not found, we'll use USER
-      replace_user  = getenv("USER"); // if not found, we'll bail
+    if (found_slash) { // size at least 2 (we have a tilde and a slash)
+        assert(slash_idx > 0); // cannot be at zero, first char must be ~
+        if (slash_idx == 1) {
+            // case 1
+            replace_until = 1;
+            replace_with  = getenv("HOME"); // if not found, we'll use USER
+            replace_user  = getenv("USER"); // if not found, we'll bail
+        }
+        else {
+            // case 2
+            replace_until = slash_idx;
+            replace_with  = NULL;
+
+            // save from bit of path into the userbuf
+            if (slash_idx-1 > sizeof(userbuf)) goto dup_and_exit;
+            memcpy(userbuf, path + 1, slash_idx-1); // -1 for tilde at front
+            userbuf[slash_idx-1] = '\0';
+            replace_user = userbuf;
+        }
     }
     else {
-      // case 2
-      replace_until = slash_idx;
-      replace_with  = NULL;
-
-      // save from bit of path into the userbuf
-      if (slash_idx-1 > sizeof(userbuf)) goto dup_and_exit;
-      memcpy(userbuf, path + 1, slash_idx-1); // -1 for tilde at front
-      userbuf[slash_idx-1] = '\0';
-      replace_user = userbuf;
+        if (strlen(path) == 1) { // must be '~' only
+            // case 3
+            replace_until = strlen(path);
+            replace_with  = getenv("HOME");
+            replace_user  = getenv("USER");
+        }
+        else { // treat the entire thing as a username
+            // case 4
+            replace_until = strlen(path);
+            replace_with  = NULL;
+            replace_user  = path + 1; // already nul terminated
+            // if there's something weird like a space here, we'll fail the user lookup
+        }
     }
-  }
-  else {
-    if (strlen(path) == 1) { // must be '~' only
-      // case 3
-      replace_until = strlen(path);
-      replace_with  = getenv("HOME");
-      replace_user  = getenv("USER");
+
+    assert(replace_until); // cannot be zero at this point
+
+    if (!replace_with && replace_user) { // replace_with takes precendence
+        struct passwd* pw = getpwnam(replace_user); // not thread safe
+        if (!pw) goto dup_and_exit;
+        replace_with = pw->pw_dir;
     }
-    else { // treat the entire thing as a username
-      // case 4
-      replace_until = strlen(path);
-      replace_with  = NULL;
-      replace_user  = path + 1; // already nul terminated
-      // if there's something weird like a space here, we'll fail the user lookup
+
+    if (replace_with) {
+        size_t repsz = strlen(replace_with);
+        size_t new_size = strlen(path) - replace_until + repsz + 1;
+        char* ret = malloc(new_size);
+        if (!ret) return NULL;
+
+        memcpy(ret,         replace_with,         repsz); // do not copy terminator
+        memcpy(ret + repsz, path + replace_until, strlen(path)-replace_until+1); // copy terminator
+        return ret;
     }
-  }
-
-  assert(replace_until); // cannot be zero at this point
-
-  if (!replace_with && replace_user) { // replace_with takes precendence
-    struct passwd* pw = getpwnam(replace_user); // not thread safe
-    if (!pw) goto dup_and_exit;
-    replace_with = pw->pw_dir;
-  }
-
-  if (replace_with) {
-    size_t repsz = strlen(replace_with);
-    size_t new_size = strlen(path) - replace_until + repsz + 1;
-    char* ret = malloc(new_size);
-    if (!ret) return NULL;
-
-    memcpy(ret,         replace_with,         repsz); // do not copy terminator
-    memcpy(ret + repsz, path + replace_until, strlen(path)-replace_until+1); // copy terminator
-    return ret;
-  }
 
 dup_and_exit:
-  // If we get here, we couldn't figure it out
-  return strdup(path);
+    // If we get here, we couldn't figure it out
+    return strdup(path);
 }
 
 void
@@ -798,35 +798,35 @@ pathname_cat(const char *pathname_a, const char *pathname_b)
 static bool
 paths_init()
 {
-	const char *home_dir_env, *xdg_config_home_env, *xdg_log_home_env;
-  char *xdg_config_home, *xdg_log_home;
+    const char *home_dir_env, *xdg_config_home_env, *xdg_log_home_env;
+    char *xdg_config_home, *xdg_log_home;
 
-  home_dir_env = getenv("HOME");
-  if (home_dir_env == NULL) {
-    fprintf(stderr, "Environment variable HOME not set\n");
-    goto fail;
-  }
+    home_dir_env = getenv("HOME");
+    if (home_dir_env == NULL) {
+      fprintf(stderr, "Environment variable HOME not set\n");
+      goto fail;
+    }
 
-	xdg_config_home_env = getenv("XDG_CONFIG_HOME");
-	if (xdg_config_home_env) {
-    xdg_config_home = expanduser(xdg_config_home_env);
-    if (!xdg_config_home) goto fail;
-	}
-  else {
-    if (!(xdg_config_home = pathname_cat(home_dir_env, DEFAULT_XDG_CONFIG))) goto fail;
-  }
+    xdg_config_home_env = getenv("XDG_CONFIG_HOME");
+    if (xdg_config_home_env) {
+        xdg_config_home = expanduser(xdg_config_home_env);
+        if (!xdg_config_home) goto fail;
+    }
+    else {
+        if (!(xdg_config_home = pathname_cat(home_dir_env, DEFAULT_XDG_CONFIG))) goto fail;
+    }
 
-	xdg_log_home_env = getenv("JACK_LOG_DIR"); // no official XDG location for logs yet
-	if (xdg_log_home_env) {
-    xdg_log_home = expanduser(xdg_log_home_env);
-    if (!xdg_log_home) goto fail;
-	}
-  else {
-    if (!(xdg_log_home = pathname_cat(home_dir_env, DEFAULT_XDG_LOG))) goto fail;
-  }
+    xdg_log_home_env = getenv("JACK_LOG_DIR"); // no official XDG location for logs yet
+    if (xdg_log_home_env) {
+        xdg_log_home = expanduser(xdg_log_home_env);
+        if (!xdg_log_home) goto fail;
+    }
+    else {
+        if (!(xdg_log_home = pathname_cat(home_dir_env, DEFAULT_XDG_LOG))) goto fail;
+    }
 
-	if (!(g_jackdbus_config_dir = pathname_cat(xdg_config_home, JACKDBUS_DIR))) goto fail;
-	if (!(g_jackdbus_log_dir = pathname_cat(xdg_log_home, JACKDBUS_DIR))) goto fail;
+    if (!(g_jackdbus_config_dir = pathname_cat(xdg_config_home, JACKDBUS_DIR))) goto fail;
+    if (!(g_jackdbus_log_dir = pathname_cat(xdg_log_home, JACKDBUS_DIR))) goto fail;
 
     if (!ensure_dir_exist(xdg_config_home, 0700))
     {

--- a/example-clients/jack_control
+++ b/example-clients/jack_control
@@ -157,17 +157,16 @@ def main():
         sys.exit(0)
 
     bus = dbus.SessionBus()
+    try:
+        controller = bus.get_object(service_name, "/org/jackaudio/Controller")
+        control_iface = dbus.Interface(controller, control_interface_name)
+        configure_iface = dbus.Interface(controller, configure_interface_name)
 
-    controller = bus.get_object(service_name, "/org/jackaudio/Controller")
-    control_iface = dbus.Interface(controller, control_interface_name)
-    configure_iface = dbus.Interface(controller, configure_interface_name)
-
-    # check arguments
-    index = 1
-    while index < len(sys.argv):
-        arg = sys.argv[index]
-        index += 1
-        try:
+        # check arguments
+        index = 1
+        while index < len(sys.argv):
+            arg = sys.argv[index]
+            index += 1
             if arg == "exit":
                 print("--- exit")
                 control_iface.Exit()
@@ -393,8 +392,11 @@ def main():
                 result = control_iface.RemoveSlaveDriver(name)
             else:
                 print("Unknown command '%s'" % arg)
-        except dbus.DBusException as e:
-            print("DBus exception: %s" % str(e))
+    except dbus.DBusException as e:
+        print("DBus exception: %s" % str(e))
+        print("Please check the dbus logs, most likely in the systemd journal (view with journalctl)")
+        print("If that doesn't help, you can try running `jackdbus auto` to check for errors in stderr")
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/example-clients/jack_control
+++ b/example-clients/jack_control
@@ -157,16 +157,23 @@ def main():
         sys.exit(0)
 
     bus = dbus.SessionBus()
+
     try:
         controller = bus.get_object(service_name, "/org/jackaudio/Controller")
         control_iface = dbus.Interface(controller, control_interface_name)
         configure_iface = dbus.Interface(controller, configure_interface_name)
+    except dbus.DBusException as e:
+        print("DBus exception: %s" % str(e))
+        print("Please check the dbus logs, in the systemd journal (view with journalctl) or captured by syslog (probably /var/log/messages)")
+        print("If that doesn't help, you can try manually running `jackdbus auto` to check for startup errors in stderr")
+        sys.exit(1)
 
-        # check arguments
-        index = 1
-        while index < len(sys.argv):
-            arg = sys.argv[index]
-            index += 1
+    # check arguments
+    index = 1
+    while index < len(sys.argv):
+        arg = sys.argv[index]
+        index += 1
+        try:
             if arg == "exit":
                 print("--- exit")
                 control_iface.Exit()
@@ -392,11 +399,8 @@ def main():
                 result = control_iface.RemoveSlaveDriver(name)
             else:
                 print("Unknown command '%s'" % arg)
-    except dbus.DBusException as e:
-        print("DBus exception: %s" % str(e))
-        print("Please check the dbus logs, most likely in the systemd journal (view with journalctl)")
-        print("If that doesn't help, you can try running `jackdbus auto` to check for errors in stderr")
-        sys.exit(1)
+        except dbus.DBusException as e:
+            print("DBus exception: %s" % str(e))
 
 if __name__ == '__main__':
     main()

--- a/linux/alsarawmidi/JackALSARawMidiDriver.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiDriver.cpp
@@ -408,7 +408,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
     if (potential_inputs) {
         try {
             input_ports = new JackALSARawMidiInputPort *[potential_inputs];
-        } catch (std::exception e) {
+        } catch (std::exception const& e) {
             jack_error("JackALSARawMidiDriver::Open - while creating input "
                        "port array: %s", e.what());
             FreeDeviceInfo(&in_info_list, &out_info_list);
@@ -418,7 +418,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
     if (potential_outputs) {
         try {
             output_ports = new JackALSARawMidiOutputPort *[potential_outputs];
-        } catch (std::exception e) {
+        } catch (std::exception const& e) {
             jack_error("JackALSARawMidiDriver::Open - while creating output "
                        "port array: %s", e.what());
             FreeDeviceInfo(&in_info_list, &out_info_list);
@@ -430,7 +430,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
         try {
             input_ports[num_inputs] = new JackALSARawMidiInputPort(info, i);
             num_inputs++;
-        } catch (std::exception e) {
+        } catch (std::exception const& e) {
             jack_error("JackALSARawMidiDriver::Open - while creating new "
                        "JackALSARawMidiInputPort: %s", e.what());
         }
@@ -441,7 +441,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
         try {
             output_ports[num_outputs] = new JackALSARawMidiOutputPort(info, i);
             num_outputs++;
-        } catch (std::exception e) {
+        } catch (std::exception const& e) {
             jack_error("JackALSARawMidiDriver::Open - while creating new "
                        "JackALSARawMidiOutputPort: %s", e.what());
         }
@@ -504,7 +504,7 @@ JackALSARawMidiDriver::Start()
     }
     try {
         poll_fds = new pollfd[poll_fd_count];
-    } catch (std::exception e) {
+    } catch (std::exception const& e) {
         jack_error("JackALSARawMidiDriver::Start - creating poll descriptor "
                    "structures failed: %s", e.what());
         return -1;
@@ -512,7 +512,7 @@ JackALSARawMidiDriver::Start()
     if (fPlaybackChannels) {
         try {
             output_port_timeouts = new jack_nframes_t[fPlaybackChannels];
-        } catch (std::exception e) {
+        } catch (std::exception const& e) {
             jack_error("JackALSARawMidiDriver::Start - creating array for "
                        "output port timeout values failed: %s", e.what());
             goto free_poll_descriptors;
@@ -521,7 +521,7 @@ JackALSARawMidiDriver::Start()
     struct pollfd *poll_fd_iter;
     try {
         CreateNonBlockingPipe(fds);
-    } catch (std::exception e) {
+    } catch (std::exception const& e) {
         jack_error("JackALSARawMidiDriver::Start - while creating wake pipe: "
                    "%s", e.what());
         goto free_output_port_timeouts;

--- a/linux/alsarawmidi/JackALSARawMidiPort.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiPort.cpp
@@ -108,7 +108,7 @@ JackALSARawMidiPort::JackALSARawMidiPort(snd_rawmidi_info_t *info,
     }
     try {
         CreateNonBlockingPipe(fds);
-    } catch (std::exception e) {
+    } catch (std::exception const& e) {
         error_message = e.what();
         func = "CreateNonBlockingPipe";
         goto close;


### PR DESCRIPTION
Was looking for something to help out with; here's some small patches.

let me know what you think, figured it would be a nice principle-of-least-surprise feature to expand homedirs when simple to do so.

tested with things like

```
$ ./waf && XDG_CONFIG_HOME='~/' JACK_LOG_DIR='~/jacklogs/' build/dbus/jackdbus auto    
Waf: Entering directory `/home/dpzmick/programming/jack2/build'
Waf: Leaving directory `/home/dpzmick/programming/jack2/build'
'build' finished successfully (0.255s)
Directory "/home/dpzmick/jacklogs/" does not exist. Creating...
Directory "/home/dpzmick//jack" does not exist. Creating...
Directory "/home/dpzmick/jacklogs//jack" does not exist. Creating...
```