### PR TITLE
remove 32 character named semophore limit on darwin #474

### DIFF
--- a/posix/JackPosixSemaphore.cpp
+++ b/posix/JackPosixSemaphore.cpp
@@ -44,9 +44,8 @@ void JackPosixSemaphore::BuildName(const char* client_name, const char* server_n
 {
     char ext_client_name[SYNC_MAX_NAME_SIZE + 1];
     JackTools::RewriteName(client_name, ext_client_name);
-#if __APPLE__  // POSIX semaphore names are limited to 32 characters... 
-    snprintf(res, 32, "js_%s", ext_client_name); 
-#else
+
+#ifndef __APPLE__
     if (fPromiscuous) {
         snprintf(res, size, "jack_sem.%s_%s", server_name, ext_client_name);
     } else {
@@ -239,4 +238,3 @@ void JackPosixSemaphore::Destroy()
 }
 
 } // end of namespace
-


### PR DESCRIPTION
this enabled longer client_name to be spawned, I also failed to find error nor documentation about a sopposed 32 char limit on named semophores.