### PR TITLE
Set fSocket to -1 after close on an error to prevent a double close.

### DIFF
--- a/posix/JackSocket.cpp
+++ b/posix/JackSocket.cpp
@@ -137,6 +137,7 @@ int JackClientSocket::Connect(const char* dir, const char* name, int which) // A
     if (connect(fSocket, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         jack_error("Cannot connect to server socket err = %s", strerror(errno));
         close(fSocket);
+        fSocket = -1;
         return -1;
     }
 
@@ -297,6 +298,7 @@ int JackServerSocket::Bind(const char* dir, const char* name, int which) // A re
 error:
     unlink(fName);
     close(fSocket);
+    fSocket = -1;
     return -1;
 }
 


### PR DESCRIPTION
Since alsa-plugins >= 1.1.7 now enables the ALSA jack plugin by default with 50-jack.conf, I've been seeing sporadic crashes in Kodi when the sound devices get reenumerated for a udev event. I traced this down to a double close on the audio engine thread concurrent with a close on the udev thread which asserts on EBADF in libudev causing the crash.
An strace pointed to the double close occuring in posix/JackSocket.cpp:139 and posix/JackSocket.cpp:158.
To fix this, reset fSocket to -1 after closing on an error to prevent a double close later.
Signed-off-by: Joe Yasi <joe.yasi@gmail.com>