### PR TITLE
alsa_driver: Exiting loop for need_playback and need_capture on XRUN …

### DIFF
--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -1294,7 +1294,7 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 
   again:
 
-	while (need_playback || need_capture) {
+	while ((need_playback || need_capture) && !xrun_detected) {
 
 		int poll_result;
 		unsigned int ci = 0;


### PR DESCRIPTION
…to execute recovery

Currently even on XRUN, the xrun recovery is not executed as the
need_playback or need_capture flag is still true and so it goes
and waits on poll again.

Signed-off-by: Laxmi Devi <Laxmi.Devi@in.bosch.com>