### PR TITLE
MIDI port pretty names

### DIFF
--- a/common/JackEngine.cpp
+++ b/common/JackEngine.cpp
@@ -1073,7 +1073,7 @@ int JackEngine::PortRename(int refnum, jack_port_id_t port, const char* name)
     return 0;
 }
 
-int JackEngine::PortSetPrettyNameProperty(jack_port_id_t port, const char* pretty_name)
+int JackEngine::PortSetDeviceName(jack_port_id_t port, const char* pretty_name)
 {
     jack_uuid_t uuid = jack_port_uuid_generate(port);
     static const char* key = "http://jackaudio.org/metadata/pretty-name";

--- a/common/JackEngine.cpp
+++ b/common/JackEngine.cpp
@@ -34,6 +34,8 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackChannel.h"
 #include "JackError.h"
 
+extern const char* JACK_METADATA_PRETTY_NAME;
+
 namespace Jack
 {
 
@@ -1069,6 +1071,14 @@ int JackEngine::PortRename(int refnum, jack_port_id_t port, const char* name)
     fGraphManager->GetPort(port)->SetName(name);
     NotifyPortRename(port, old_name);
     return 0;
+}
+
+int JackEngine::PortSetPrettyNameProperty(jack_port_id_t port, const char* pretty_name)
+{
+    jack_uuid_t uuid = jack_port_uuid_generate(port);
+    static const char* key = "http://jackaudio.org/metadata/pretty-name";
+    static const char* type = "text/plain";
+    return fMetadata.SetProperty(NULL, uuid, key, pretty_name, type);
 }
 
 //--------------------

--- a/common/JackEngine.cpp
+++ b/common/JackEngine.cpp
@@ -34,6 +34,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackChannel.h"
 #include "JackError.h"
 
+extern const char* JACK_METADATA_HARDWARE;
 extern const char* JACK_METADATA_PRETTY_NAME;
 
 namespace Jack
@@ -1075,10 +1076,21 @@ int JackEngine::PortRename(int refnum, jack_port_id_t port, const char* name)
 
 int JackEngine::PortSetDeviceName(jack_port_id_t port, const char* pretty_name)
 {
-    jack_uuid_t uuid = jack_port_uuid_generate(port);
-    static const char* key = "http://jackaudio.org/metadata/pretty-name";
     static const char* type = "text/plain";
-    return fMetadata.SetProperty(NULL, uuid, key, pretty_name, type);
+    jack_uuid_t uuid = jack_port_uuid_generate(port);
+    
+    int res = fMetadata.SetProperty(NULL, uuid, JACK_METADATA_HARDWARE, pretty_name, type);
+    if (res == -1) {
+        return -1;
+    }
+
+    char *v, *t;
+    res = fMetadata.GetProperty(uuid, JACK_METADATA_PRETTY_NAME, &v, &t);
+    if (res == -1) {
+        res = fMetadata.SetProperty(NULL, uuid, JACK_METADATA_PRETTY_NAME, pretty_name, type);
+    }
+    
+    return res;
 }
 
 //--------------------

--- a/common/JackEngine.h
+++ b/common/JackEngine.h
@@ -138,7 +138,7 @@ class SERVER_EXPORT JackEngine : public JackLockAble
 
         int PortRename(int refnum, jack_port_id_t port, const char* name);
 
-        int PortSetPrettyNameProperty(jack_port_id_t port, const char* pretty_name);
+        int PortSetDeviceName(jack_port_id_t port, const char* pretty_name);
 
         int ComputeTotalLatencies();
 

--- a/common/JackEngine.h
+++ b/common/JackEngine.h
@@ -138,6 +138,8 @@ class SERVER_EXPORT JackEngine : public JackLockAble
 
         int PortRename(int refnum, jack_port_id_t port, const char* name);
 
+        int PortSetPrettyNameProperty(jack_port_id_t port, const char* pretty_name);
+
         int ComputeTotalLatencies();
 
         int PropertyChangeNotify(jack_uuid_t subject, const char* key,jack_property_change_t change);

--- a/common/JackLibAPI.cpp
+++ b/common/JackLibAPI.cpp
@@ -48,12 +48,6 @@ extern "C"
     LIB_EXPORT int jack_get_client_pid (const char *name);
 
     // Metadata API
-    LIB_EXPORT const char* JACK_METADATA_PRETTY_NAME = "http://jackaudio.org/metadata/pretty-name";
-    LIB_EXPORT const char* JACK_METADATA_HARDWARE = "http://jackaudio.org/metadata/hardware";
-    LIB_EXPORT const char* JACK_METADATA_CONNECTED = "http://jackaudio.org/metadata/connected";
-    LIB_EXPORT const char* JACK_METADATA_PORT_GROUP = "http://jackaudio.org/metadata/port-group";
-    LIB_EXPORT const char* JACK_METADATA_ICON_SMALL = "http://jackaudio.org/metadata/icon-small";
-    LIB_EXPORT const char* JACK_METADATA_ICON_LARGE = "http://jackaudio.org/metadata/icon-large";
 
     LIB_EXPORT int jack_set_property(jack_client_t*, jack_uuid_t subject, const char* key, const char* value, const char* type);
     LIB_EXPORT int jack_get_property(jack_uuid_t subject, const char* key, char** value, char** type);

--- a/common/JackLockedEngine.h
+++ b/common/JackLockedEngine.h
@@ -246,6 +246,14 @@ class SERVER_EXPORT JackLockedEngine
             CATCH_EXCEPTION_RETURN
         }
 
+        int PortSetPrettyNameProperty(int refnum, jack_port_id_t port, const char* pretty_name)
+        {
+            TRY_CALL
+            JackLock lock(&fEngine);
+            return (fEngine.CheckClient(refnum)) ? fEngine.PortSetPrettyNameProperty(port, pretty_name) : -1;
+            CATCH_EXCEPTION_RETURN
+        }
+
         int ComputeTotalLatencies()
         {
             TRY_CALL

--- a/common/JackLockedEngine.h
+++ b/common/JackLockedEngine.h
@@ -246,11 +246,11 @@ class SERVER_EXPORT JackLockedEngine
             CATCH_EXCEPTION_RETURN
         }
 
-        int PortSetPrettyNameProperty(int refnum, jack_port_id_t port, const char* pretty_name)
+        int PortSetDeviceName(int refnum, jack_port_id_t port, const char* pretty_name)
         {
             TRY_CALL
             JackLock lock(&fEngine);
-            return (fEngine.CheckClient(refnum)) ? fEngine.PortSetPrettyNameProperty(port, pretty_name) : -1;
+            return (fEngine.CheckClient(refnum)) ? fEngine.PortSetDeviceName(port, pretty_name) : -1;
             CATCH_EXCEPTION_RETURN
         }
 

--- a/common/JackMetadata.cpp
+++ b/common/JackMetadata.cpp
@@ -25,6 +25,14 @@
 #include <limits.h>
 
 
+LIB_EXPORT const char* JACK_METADATA_PRETTY_NAME = "http://jackaudio.org/metadata/pretty-name";
+LIB_EXPORT const char* JACK_METADATA_HARDWARE = "http://jackaudio.org/metadata/hardware";
+LIB_EXPORT const char* JACK_METADATA_CONNECTED = "http://jackaudio.org/metadata/connected";
+LIB_EXPORT const char* JACK_METADATA_PORT_GROUP = "http://jackaudio.org/metadata/port-group";
+LIB_EXPORT const char* JACK_METADATA_ICON_SMALL = "http://jackaudio.org/metadata/icon-small";
+LIB_EXPORT const char* JACK_METADATA_ICON_LARGE = "http://jackaudio.org/metadata/icon-large";
+
+
 namespace Jack
 {
 

--- a/linux/alsarawmidi/JackALSARawMidiDriver.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiDriver.cpp
@@ -80,7 +80,7 @@ JackALSARawMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(alias);
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         input_port->GetDeviceName());
         fCapturePortList[i] = index;
 
@@ -108,7 +108,7 @@ JackALSARawMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(alias);
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         output_port->GetDeviceName());
         fPlaybackPortList[i] = index;
 

--- a/linux/alsarawmidi/JackALSARawMidiDriver.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiDriver.cpp
@@ -409,6 +409,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
     }
     size_t num_inputs = 0;
     size_t num_outputs = 0;
+    const char *client_name = fClientControl.fName;
     if (potential_inputs) {
         try {
             input_ports = new JackALSARawMidiInputPort *[potential_inputs];
@@ -432,7 +433,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
     for (size_t i = 0; i < potential_inputs; i++) {
         snd_rawmidi_info_t *info = in_info_list.at(i);
         try {
-            input_ports[num_inputs] = new JackALSARawMidiInputPort(info, i);
+            input_ports[num_inputs] = new JackALSARawMidiInputPort(client_name, info, i);
             num_inputs++;
         } catch (std::exception& e) {
             jack_error("JackALSARawMidiDriver::Open - while creating new "
@@ -443,7 +444,7 @@ JackALSARawMidiDriver::Open(bool capturing, bool playing, int in_channels,
     for (size_t i = 0; i < potential_outputs; i++) {
         snd_rawmidi_info_t *info = out_info_list.at(i);
         try {
-            output_ports[num_outputs] = new JackALSARawMidiOutputPort(info, i);
+            output_ports[num_outputs] = new JackALSARawMidiOutputPort(client_name, info, i);
             num_outputs++;
         } catch (std::exception& e) {
             jack_error("JackALSARawMidiDriver::Open - while creating new "

--- a/linux/alsarawmidi/JackALSARawMidiDriver.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiDriver.cpp
@@ -80,6 +80,8 @@ JackALSARawMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(alias);
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        input_port->GetDeviceName());
         fCapturePortList[i] = index;
 
         jack_info("JackALSARawMidiDriver::Attach - input port registered "
@@ -106,6 +108,8 @@ JackALSARawMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(alias);
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        output_port->GetDeviceName());
         fPlaybackPortList[i] = index;
 
         jack_info("JackALSARawMidiDriver::Attach - output port registered "

--- a/linux/alsarawmidi/JackALSARawMidiInputPort.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiInputPort.cpp
@@ -26,11 +26,12 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 using Jack::JackALSARawMidiInputPort;
 
-JackALSARawMidiInputPort::JackALSARawMidiInputPort(snd_rawmidi_info_t *info,
+JackALSARawMidiInputPort::JackALSARawMidiInputPort(const char* client_name,
+                                                   snd_rawmidi_info_t *info,
                                                    size_t index,
                                                    size_t max_bytes,
                                                    size_t max_messages):
-    JackALSARawMidiPort(info, index, POLLIN)
+    JackALSARawMidiPort(client_name, info, index, POLLIN)
 {
     alsa_event = 0;
     jack_event = 0;

--- a/linux/alsarawmidi/JackALSARawMidiInputPort.h
+++ b/linux/alsarawmidi/JackALSARawMidiInputPort.h
@@ -41,7 +41,9 @@ namespace Jack {
 
     public:
 
-        JackALSARawMidiInputPort(snd_rawmidi_info_t *info, size_t index,
+        JackALSARawMidiInputPort(const char* client_name,
+                                 snd_rawmidi_info_t *info,
+                                 size_t index,
                                  size_t max_bytes=4096,
                                  size_t max_messages=1024);
 

--- a/linux/alsarawmidi/JackALSARawMidiOutputPort.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiOutputPort.cpp
@@ -25,12 +25,13 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 using Jack::JackALSARawMidiOutputPort;
 
-JackALSARawMidiOutputPort::JackALSARawMidiOutputPort(snd_rawmidi_info_t *info,
+JackALSARawMidiOutputPort::JackALSARawMidiOutputPort(const char* client_name,
+                                                     snd_rawmidi_info_t *info,
                                                      size_t index,
                                                      size_t max_bytes_per_poll,
                                                      size_t max_bytes,
                                                      size_t max_messages):
-    JackALSARawMidiPort(info, index, POLLOUT)
+    JackALSARawMidiPort(client_name, info, index, POLLOUT)
 {
     alsa_event = 0;
     read_queue = new JackMidiBufferReadQueue();

--- a/linux/alsarawmidi/JackALSARawMidiOutputPort.h
+++ b/linux/alsarawmidi/JackALSARawMidiOutputPort.h
@@ -40,7 +40,9 @@ namespace Jack {
 
     public:
 
-        JackALSARawMidiOutputPort(snd_rawmidi_info_t *info, size_t index,
+        JackALSARawMidiOutputPort(const char* client_name,
+                                  snd_rawmidi_info_t *info,
+                                  size_t index,
                                   size_t max_bytes_per_poll=3,
                                   size_t max_bytes=4096,
                                   size_t max_messages=1024);

--- a/linux/alsarawmidi/JackALSARawMidiPort.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiPort.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 using Jack::JackALSARawMidiPort;
 
-JackALSARawMidiPort::JackALSARawMidiPort(snd_rawmidi_info_t *info,
+JackALSARawMidiPort::JackALSARawMidiPort(const char *client_name, snd_rawmidi_info_t *info,
                                          size_t index, unsigned short io_mask)
 {
     int card = snd_rawmidi_info_get_card(info);
@@ -40,17 +40,17 @@ JackALSARawMidiPort::JackALSARawMidiPort(snd_rawmidi_info_t *info,
     const char *alias_suffix;
     const char *error_message;
     snd_rawmidi_t **in;
-    const char *name_prefix;
+    const char *port_name;
     snd_rawmidi_t **out;
     if (snd_rawmidi_info_get_stream(info) == SND_RAWMIDI_STREAM_OUTPUT) {
         alias_suffix = "out";
         in = 0;
-        name_prefix = "system:midi_playback_";
+        port_name = "playback_";
         out = &rawmidi;
     } else {
         alias_suffix = "in";
         in = &rawmidi;
-        name_prefix = "system:midi_capture_";
+        port_name = "capture_";
         out = 0;
     }
     const char *func;
@@ -117,7 +117,7 @@ JackALSARawMidiPort::JackALSARawMidiPort(snd_rawmidi_info_t *info,
     snprintf(alias, sizeof(alias), "system:%d-%d %s %d %s", card + 1,
              device + 1, driver_name, subdevice + 1,
              alias_suffix);
-    snprintf(name, sizeof(name), "%s%zu", name_prefix, index + 1);
+    snprintf(name, sizeof(name), "%s:%s%zu", client_name, port_name, index + 1);
     strncpy(device_name, driver_name, sizeof(device_name) - 1);
     this->io_mask = io_mask;
     return;

--- a/linux/alsarawmidi/JackALSARawMidiPort.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiPort.cpp
@@ -36,6 +36,7 @@ JackALSARawMidiPort::JackALSARawMidiPort(snd_rawmidi_info_t *info,
     char device_id[32];
     snprintf(device_id, sizeof(device_id), "hw:%d,%d,%d", card, device,
              subdevice);
+    const char* driver_name = snd_rawmidi_info_get_name(info);
     const char *alias_suffix;
     const char *error_message;
     snd_rawmidi_t **in;
@@ -114,9 +115,10 @@ JackALSARawMidiPort::JackALSARawMidiPort(snd_rawmidi_info_t *info,
         goto close;
     }
     snprintf(alias, sizeof(alias), "system:%d-%d %s %d %s", card + 1,
-             device + 1, snd_rawmidi_info_get_name(info), subdevice + 1,
+             device + 1, driver_name, subdevice + 1,
              alias_suffix);
     snprintf(name, sizeof(name), "%s%zu", name_prefix, index + 1);
+    strncpy(device_name, driver_name, sizeof(device_name) - 1);
     this->io_mask = io_mask;
     return;
  free_params:
@@ -176,6 +178,12 @@ const char *
 JackALSARawMidiPort::GetName()
 {
     return name;
+}
+
+const char *
+JackALSARawMidiPort::GetDeviceName()
+{
+    return device_name;
 }
 
 int

--- a/linux/alsarawmidi/JackALSARawMidiPort.h
+++ b/linux/alsarawmidi/JackALSARawMidiPort.h
@@ -61,8 +61,8 @@ namespace Jack {
 
     public:
 
-        JackALSARawMidiPort(snd_rawmidi_info_t *info, size_t index,
-                            unsigned short io_mask);
+        JackALSARawMidiPort(const char *client_name, snd_rawmidi_info_t *info,
+                            size_t index, unsigned short io_mask);
 
         virtual
         ~JackALSARawMidiPort();

--- a/linux/alsarawmidi/JackALSARawMidiPort.h
+++ b/linux/alsarawmidi/JackALSARawMidiPort.h
@@ -37,6 +37,7 @@ namespace Jack {
         int fds[2];
         unsigned short io_mask;
         char name[REAL_JACK_PORT_NAME_SIZE+1];
+        char device_name[REAL_JACK_PORT_NAME_SIZE+1];
         struct pollfd *queue_poll_fd;
 
     protected:
@@ -71,6 +72,9 @@ namespace Jack {
 
         const char *
         GetName();
+
+        const char *
+        GetDeviceName();
 
         int
         GetPollDescriptorCount();

--- a/macosx/coremidi/JackCoreMidiDriver.mm
+++ b/macosx/coremidi/JackCoreMidiDriver.mm
@@ -372,7 +372,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fCapturePortList[i] = index;
     }
@@ -392,7 +392,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fCapturePortList[num_physical_inputs + i] = index;
     }
@@ -419,7 +419,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fPlaybackPortList[i] = index;
     }
@@ -440,7 +440,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fPlaybackPortList[num_physical_outputs + i] = index;
     }

--- a/macosx/coremidi/JackCoreMidiDriver.mm
+++ b/macosx/coremidi/JackCoreMidiDriver.mm
@@ -372,6 +372,8 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        port_obj->GetDeviceName());
         fCapturePortList[i] = index;
     }
 
@@ -390,6 +392,8 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        port_obj->GetDeviceName());
         fCapturePortList[num_physical_inputs + i] = index;
     }
 
@@ -415,6 +419,8 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        port_obj->GetDeviceName());
         fPlaybackPortList[i] = index;
     }
 
@@ -434,6 +440,8 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        port_obj->GetDeviceName());
         fPlaybackPortList[num_physical_outputs + i] = index;
     }
 

--- a/macosx/coremidi/JackCoreMidiPort.h
+++ b/macosx/coremidi/JackCoreMidiPort.h
@@ -33,6 +33,7 @@ namespace Jack {
 
         char alias[REAL_JACK_PORT_NAME_SIZE+1];
         char name[REAL_JACK_PORT_NAME_SIZE+1];
+        char device_name[REAL_JACK_PORT_NAME_SIZE+1];
         bool initialized;
 
     protected:
@@ -62,7 +63,10 @@ namespace Jack {
 
         const char *
         GetName();
-        
+
+        const char *
+        GetDeviceName();
+
         static bool IsInternalPort(MIDIObjectRef port_aux);
 
     };

--- a/macosx/coremidi/JackCoreMidiPort.mm
+++ b/macosx/coremidi/JackCoreMidiPort.mm
@@ -65,6 +65,13 @@ JackCoreMidiPort::GetName()
     return name;
 }
 
+const char *
+JackCoreMidiPort::GetDeviceName()
+{
+    assert(initialized);
+    return device_name;
+}
+
 void
 JackCoreMidiPort::Initialize(const char *alias_name, const char *client_name,
                              const char *driver_name, int index,
@@ -96,6 +103,7 @@ JackCoreMidiPort::Initialize(const char *alias_name, const char *client_name,
     }
     snprintf(name, sizeof(name), "%s:%s_%d", client_name,
              is_output ? "playback" : "capture", num);
+    strncpy(device_name, endpoint_name, sizeof(device_name) - 1);
     this->endpoint = endpoint;
     initialized = true;
 }

--- a/windows/winmme/JackWinMMEDriver.cpp
+++ b/windows/winmme/JackWinMMEDriver.cpp
@@ -71,7 +71,7 @@ JackWinMMEDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(input_port->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         input_port->GetDeviceName());
         fCapturePortList[i] = index;
     }
@@ -97,7 +97,7 @@ JackWinMMEDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(output_port->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+        fEngine->PortSetDeviceName(fClientControl.fRefNum, index,
                                         output_port->GetDeviceName());
         fPlaybackPortList[i] = index;
     }

--- a/windows/winmme/JackWinMMEDriver.cpp
+++ b/windows/winmme/JackWinMMEDriver.cpp
@@ -71,6 +71,8 @@ JackWinMMEDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(input_port->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        input_port->GetDeviceName());
         fCapturePortList[i] = index;
     }
 
@@ -95,6 +97,8 @@ JackWinMMEDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(output_port->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
+        fEngine->PortSetPrettyNameProperty(fClientControl.fRefNum, index,
+                                        output_port->GetDeviceName());
         fPlaybackPortList[i] = index;
     }
 
@@ -424,22 +428,3 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-
-/*
-jack_connect system:midi_capture_1 system_midi:playback_1
-jack_connect system:midi_capture_1 system_midi:playback_2
-
-jack_connect system:midi_capture_1 system_midi:playback_1
-
-jack_connect system:midi_capture_1 system_midi:playback_1
-
-jack_connect system:midi_capture_1 system_midi:playback_1
-
-jack_connect system_midi:capture_1 system:midi_playback_1
-jack_connect system_midi:capture_2 system:midi_playback_1
-
-jack_connect system_midi:capture_1  system_midi:playback_1
-
-*/
-

--- a/windows/winmme/JackWinMMEInputPort.cpp
+++ b/windows/winmme/JackWinMMEInputPort.cpp
@@ -92,6 +92,7 @@ JackWinMMEInputPort::JackWinMMEInputPort(const char *alias_name,
     snprintf(alias, sizeof(alias) - 1, "%s:%s:in%d", alias_name, name_tmp,
              index + 1);
     snprintf(name, sizeof(name) - 1, "%s:capture_%d", client_name, index + 1);
+    strncpy(device_name, name_tmp, sizeof(device_name) - 1);
     jack_event = 0;
     started = false;
     write_queue_ptr.release();

--- a/windows/winmme/JackWinMMEOutputPort.cpp
+++ b/windows/winmme/JackWinMMEOutputPort.cpp
@@ -87,6 +87,7 @@ JackWinMMEOutputPort::JackWinMMEOutputPort(const char *alias_name,
     snprintf(alias, sizeof(alias) - 1, "%s:%s:out%d", alias_name, name_tmp,
              index + 1);
     snprintf(name, sizeof(name) - 1, "%s:playback_%d", client_name, index + 1);
+    strncpy(device_name, name_tmp, sizeof(device_name) - 1);
     read_queue_ptr.release();
     thread_queue_ptr.release();
     thread_ptr.release();

--- a/windows/winmme/JackWinMMEPort.cpp
+++ b/windows/winmme/JackWinMMEPort.cpp
@@ -48,6 +48,12 @@ JackWinMMEPort::GetName()
      return name;
 }
 
+const char *
+JackWinMMEPort::GetDeviceName()
+{
+     return device_name;
+}
+
 void
 JackWinMMEPort::GetOSErrorString(LPTSTR text)
 {

--- a/windows/winmme/JackWinMMEPort.h
+++ b/windows/winmme/JackWinMMEPort.h
@@ -33,6 +33,7 @@ namespace Jack {
 
         char alias[REAL_JACK_PORT_NAME_SIZE+1];
         char name[REAL_JACK_PORT_NAME_SIZE+1];
+        char device_name[REAL_JACK_PORT_NAME_SIZE+1];
 
     public:
 
@@ -45,6 +46,9 @@ namespace Jack {
 
         const char *
         GetName();
+
+        const char *
+        GetDeviceName();
 
         void
         GetOSErrorString(LPTSTR text);


### PR DESCRIPTION
This patch makes JACK set the pretty name for each MIDI port on server startup. Currently the pretty name is equal to the MIDI device name as reported by the system MIDI implementation. The following JACK MIDI drivers have been modified:

alsarawmidi, coremidi, winmme

The pretty names are not updated if a previous value is found, ie. to avoid overwriting user defined values. A better implementation might set a new "device name" key property instead, but existing clients already rely on pretty names for presenting ports to the user (for example QjackCtl and Ardour).

There is an existing property key presumably for describing hardware (http://jackaudio.org/metadata/hardware). This patch also sets such property to the MIDI device name on server startup, overwriting any previous value found. If future clients rely on a hardware/device property on addition to pretty names for presentation, pretty names might be reserved for custom names exclusively (ie., user defined).

The ultimate goal is to add a practical solution for MIDI port names confusion on systems with a large quantity of such devices, which is not uncommon in home studio environments.
