### PR TITLE
Extend API to support S16 and S32 audio formats

### DIFF
--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -26,6 +26,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackGlobals.h"
 #include "JackTime.h"
 #include "JackPortType.h"
+#include "jack.h"
+#include "memops.h"
+#include <typeinfo>
 #include <math.h>
 #define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
@@ -1096,6 +1099,93 @@ LIB_EXPORT jack_port_t* jack_port_register(jack_client_t* ext_client, const char
         return NULL;
     } else {
         return (jack_port_t *)((uintptr_t)client->PortRegister(port_name, port_type, flags, buffer_size));
+    }
+}
+
+class BaseJackPortConverter : public IJackPortConverter {
+    protected:
+        jack_port_t* const port;
+    public:
+        BaseJackPortConverter(jack_port_t* pt) : port(pt) {}
+};
+
+class ForwardJackPortConverter : public BaseJackPortConverter {
+    private:
+        void* buffer = NULL;
+    public:
+        ForwardJackPortConverter(jack_port_t* pt) : BaseJackPortConverter(pt) {}
+
+        virtual void* get( jack_nframes_t frames) {
+            buffer = jack_port_get_buffer(port, frames);
+            return buffer;
+        }
+
+        virtual void set(void* buf,  jack_nframes_t frames) {
+            if (buf == buffer)
+                return;
+            memcpy(jack_port_get_buffer(port, frames), buf, frames*sizeof(jack_default_audio_sample_t));
+        }
+};
+
+class IntegerJackPortConverter : public BaseJackPortConverter {
+    typedef void (*ReadCopyFunction)  (jack_default_audio_sample_t *dst, char *src,
+                                       unsigned long src_bytes,
+                                       unsigned long src_skip_bytes);
+    typedef void (*WriteCopyFunction) (char *dst, jack_default_audio_sample_t *src,
+                                       unsigned long src_bytes,
+                                       unsigned long dst_skip_bytes,
+                                       dither_state_t *state);
+
+    private:
+        int32_t buffer[BUFFER_SIZE_MAX + 8];
+        const ReadCopyFunction to_jack;
+        const WriteCopyFunction from_jack;
+        const size_t sample_size;
+
+        int32_t* GetBuffer()
+        {
+            return (int32_t*)((uintptr_t)buffer & ~31L) + 8;
+        }
+
+    public:
+        IntegerJackPortConverter(const ReadCopyFunction to_jack,
+                                 const WriteCopyFunction from_jack,
+                                 const size_t sample_size,
+                                 jack_port_t* pt) : BaseJackPortConverter(pt),
+        to_jack(to_jack), from_jack(from_jack), sample_size(sample_size) {}
+
+        virtual void* get(jack_nframes_t frames) {
+            int32_t * aligned_ptr = GetBuffer();
+            jack_default_audio_sample_t* src = (jack_default_audio_sample_t*) jack_port_get_buffer(port, frames);
+            from_jack ((char *)aligned_ptr, src, frames, sample_size, NULL);
+            return aligned_ptr;
+        }
+
+        virtual void set(void* src, jack_nframes_t frames) {
+            jack_default_audio_sample_t* dst = (jack_default_audio_sample_t*) jack_port_get_buffer(port, frames);
+            to_jack (dst,(char *) src, frames, sample_size);
+            return;
+        }
+};
+
+LIB_EXPORT IJackPortConverter* jack_port_create_converter(jack_port_t* port, const std::type_info& dst_type, const bool init_output_silence)
+{
+    if(dst_type == (typeid(jack_default_audio_sample_t))) {
+        return new ForwardJackPortConverter(port);
+    }
+    else if(dst_type == (typeid(int32_t))) {
+        return new IntegerJackPortConverter(sample_move_dS_s32,
+                                            sample_move_d32_sS, sizeof(int32_t),
+                                            port);
+    }
+    else if(dst_type == (typeid(int16_t))) {
+        return new IntegerJackPortConverter(sample_move_dS_s16,
+                                            sample_move_d16_sS,  sizeof(int16_t),
+                                            port);
+    }
+    else {
+        jack_error("jack_port_create_converter called with dst_type that is not supported");
+        return NULL;
     }
 }
 

--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -1174,8 +1174,8 @@ LIB_EXPORT IJackPortConverter* jack_port_create_converter(jack_port_t* port, con
         return new ForwardJackPortConverter(port);
     }
     else if(dst_type == (typeid(int32_t))) {
-        return new IntegerJackPortConverter(sample_move_dS_s32,
-                                            sample_move_d32_sS, sizeof(int32_t),
+        return new IntegerJackPortConverter(sample_move_dS_s32u24,
+                                            sample_move_d32u24_sS, sizeof(int32_t),
                                             port);
     }
     else if(dst_type == (typeid(int16_t))) {

--- a/common/jack/jack.h
+++ b/common/jack/jack.h
@@ -1464,6 +1464,32 @@ void jack_free(void* ptr) JACK_OPTIONAL_WEAK_EXPORT;
 
 
 #ifdef __cplusplus
+
+class IJackPortConverter {
+
+    public:
+
+        virtual void* get(jack_nframes_t frames) = 0;
+        virtual void set(void* buf, jack_nframes_t frames) = 0;
+};
+
+/**
+ * This returns a pointer to the instance of the object IJackPortConverter based
+ * on the dst_type. Applications can use the get() and set()
+ * of this object to get and set the pointers to the memory area associated with the specified port.
+ * Currently Jack only supports Float, int32_t and int16_t.
+ *
+ * @param port jack_port_t pointer.
+ * @param dst_type type required by client.
+ * @param init_output_silence if true, jack will initialize the output port with silence
+ *
+ * @return ptr to IJackPortConverter on success, otherwise NULL if dst_type is not supported.
+ */
+
+IJackPortConverter* jack_port_create_converter(jack_port_t* port, const std::type_info& dst_type, const bool init_output_silence=true) JACK_OPTIONAL_WEAK_EXPORT;
+#endif
+
+#ifdef __cplusplus
 }
 #endif
 

--- a/common/wscript
+++ b/common/wscript
@@ -67,6 +67,7 @@ def build(bld):
         'JackTools.cpp',
         'JackMessageBuffer.cpp',
         'JackEngineProfiling.cpp',
+        'memops.c',
         ]
 
     includes = ['.', './jack']

--- a/example-clients/inprocess_s32.cpp
+++ b/example-clients/inprocess_s32.cpp
@@ -1,0 +1,134 @@
+/** @file inprocess_s32.cpp
+ *
+ * @brief This demonstrates the basic concepts for writing a client
+ * that runs within the JACK server process for s32 format.
+ *
+ * For the sake of example, a port_converter_pair_t is allocated in
+ * jack_initialize(), passed to inprocess() as an argument, then freed
+ * in jack_finish().
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <memory.h>
+#include <typeinfo>
+#include <jack/jack.h>
+
+/**
+ * For the sake of example, an instance of this struct is allocated in
+ * jack_initialize(), passed to inprocess() as an argument, then freed
+ * in jack_finish().
+ */
+typedef struct {
+	IJackPortConverter* input_port_converter;
+	IJackPortConverter* output_port_converter;
+} port_converter_pair_t;
+
+/**
+ * Called in the realtime thread on every process cycle.  The entry
+ * point name was passed to jack_set_process_callback() from
+ * jack_initialize().  Although this is an internal client, its
+ * process() interface is identical to @ref simple_client.c.
+ *
+ * @return 0 if successful; otherwise jack_finish() will be called and
+ * the client terminated immediately.
+ */
+int
+inprocess (jack_nframes_t nframes, void *arg)
+{
+	port_converter_pair_t *pp = (port_converter_pair_t *)arg;
+	int32_t *in_buffer;
+	int32_t *out_buffer;
+
+	in_buffer = (int32_t *) pp->input_port_converter->get(nframes);
+	out_buffer = (int32_t *) pp->output_port_converter->get(nframes);
+
+	/* This memcpy needs to be replaced with the actual processing */
+	memcpy (out_buffer, in_buffer, sizeof(int32_t) * nframes);
+
+	pp->output_port_converter->set(out_buffer, nframes);
+
+	return 0;
+}
+
+/**
+ * This required entry point is called after the client is loaded by
+ * jack_internal_client_load().
+ *
+ * @param client pointer to JACK client structure.
+ * @param load_init character string passed to the load operation.
+ *
+ * @return 0 if successful; otherwise jack_finish() will be called and
+ * the client terminated immediately.
+ */
+extern "C" int
+jack_initialize (jack_client_t *client, const char *load_init)
+{
+	jack_port_t *input_port;
+	jack_port_t *output_port;
+
+	port_converter_pair_t *pp = (port_converter_pair_t *) malloc (sizeof (port_converter_pair_t));
+	const char **ports;
+
+	if (pp == NULL)
+		return 1;		/* heap exhausted */
+
+	jack_set_process_callback (client, inprocess, pp);
+
+	/* create a pair of ports */
+	input_port = jack_port_register (client, "input",
+					     JACK_DEFAULT_AUDIO_TYPE,
+					     JackPortIsInput, 0);
+	output_port = jack_port_register (client, "output",
+					      JACK_DEFAULT_AUDIO_TYPE,
+					      JackPortIsOutput, 0);
+
+	pp->input_port_converter = jack_port_create_converter(input_port, typeid(int32_t), false);
+	pp->output_port_converter = jack_port_create_converter(output_port, typeid(int32_t), false);
+
+	/* join the process() cycle */
+	jack_activate (client);
+
+	ports = jack_get_ports (client, NULL, NULL,
+				JackPortIsPhysical|JackPortIsOutput);
+	if (ports == NULL) {
+		fprintf(stderr, "no physical capture ports\n");
+		return 1;		/* terminate client */
+	}
+
+	if (jack_connect (client, ports[0], jack_port_name (input_port))) {
+		fprintf (stderr, "cannot connect input ports\n");
+	}
+
+	jack_free (ports);
+
+	ports = jack_get_ports (client, NULL, NULL,
+				JackPortIsPhysical|JackPortIsInput);
+	if (ports == NULL) {
+		fprintf(stderr, "no physical playback ports\n");
+		return 1;		/* terminate client */
+	}
+
+	if (jack_connect (client, jack_port_name (output_port), ports[0])) {
+		fprintf (stderr, "cannot connect output ports\n");
+	}
+
+	jack_free (ports);
+
+	return 0;			/* success */
+}
+
+/**
+ * This required entry point is called immediately before the client
+ * is unloaded, which could happen due to a call to
+ * jack_internal_client_unload(), or a nonzero return from either
+ * jack_initialize() or inprocess().
+ *
+ * @param arg the same parameter provided to inprocess().
+ */
+extern "C" void
+jack_finish (void *arg)
+{
+	if (arg)
+		free ((port_converter_pair_t *) arg);
+}

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -35,6 +35,7 @@ example_programs = {
 
 example_libs = {
     'inprocess' : 'inprocess.c',
+    'inprocess_s32' : 'inprocess_s32.cpp',
     }
 
 def configure(conf):
@@ -136,9 +137,10 @@ def build(bld):
         prog.target = 'alsa_out'
 
     for example_lib, example_lib_source in list(example_libs.items()):
-        lib = bld(features = 'c cshlib')
+        lib = bld(features = 'c cxx cshlib cxxshlib')
         if not bld.env['IS_WINDOWS']:
             lib.env['cshlib_PATTERN'] = '%s.so'
+            lib.env['cxxshlib_PATTERN'] = '%s.so'
         lib.includes = os_incdir + ['../common/jack', '../common']
         lib.target = example_lib
         lib.source = example_lib_source


### PR DESCRIPTION
This new API allows applications to exchange the audio data with JACK as S16 or S32 format. It can easily extended for other formats.
The conversion is done by the already optimized functions implemented in `common/memops.c`