### PR TITLE
Set initial metadata for ALSA MIDI raw and seq ports

### DIFF
--- a/linux/alsa/JackAlsaDriver.cpp
+++ b/linux/alsa/JackAlsaDriver.cpp
@@ -471,6 +471,11 @@ void JackAlsaDriver::SetTimetAux(jack_time_t time)
     fBeginDateUst = time;
 }
 
+int JackAlsaDriver::PortSetDeviceMetadata(jack_port_id_t port_id, const char* pretty_name)
+{
+    return fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, port_id, pretty_name);
+}
+
 void JackAlsaDriver::WriteOutputAux(jack_nframes_t orig_nframes, snd_pcm_sframes_t contiguous, snd_pcm_sframes_t nwritten)
 {
     for (int chn = 0; chn < fPlaybackChannels; chn++) {

--- a/linux/alsa/JackAlsaDriver.h
+++ b/linux/alsa/JackAlsaDriver.h
@@ -93,6 +93,8 @@ class JackAlsaDriver : public JackAudioDriver
         void WriteOutputAux(jack_nframes_t orig_nframes, snd_pcm_sframes_t contiguous, snd_pcm_sframes_t nwritten);
         void SetTimetAux(jack_time_t time);
 
+        int PortSetDeviceMetadata(jack_port_id_t port_id, const char* pretty_name);
+
         // JACK API emulation for the midi driver
         int is_realtime() const;
         int create_thread(pthread_t *thread, int prio, int rt, void *(*start_func)(void*), void *arg);

--- a/linux/alsa/alsa_midi_impl.h
+++ b/linux/alsa/alsa_midi_impl.h
@@ -37,6 +37,7 @@ extern "C"
     int JACK_port_unregister(jack_client_t *, jack_port_t*);
     void* JACK_port_get_buffer(jack_port_t*, jack_nframes_t);
     int JACK_port_set_alias(jack_port_t* port, const char* name);
+    int JACK_port_set_device_metadata(jack_port_t* port, const char* pretty_name);
 
     jack_nframes_t JACK_get_sample_rate(jack_client_t *);
     jack_nframes_t JACK_frame_time(jack_client_t *);
@@ -49,6 +50,7 @@ extern "C"
 #define jack_port_unregister JACK_port_unregister
 #define jack_port_get_buffer JACK_port_get_buffer
 #define jack_port_set_alias JACK_port_set_alias
+#define jack_port_set_device_metadata JACK_port_set_device_metadata
 
 #define jack_get_sample_rate JACK_get_sample_rate
 #define jack_frame_time JACK_frame_time

--- a/linux/alsa/alsa_midi_jackmp.cpp
+++ b/linux/alsa/alsa_midi_jackmp.cpp
@@ -71,6 +71,12 @@ int JACK_port_set_alias(jack_port_t *port, const char* name)
     return real->driver->port_set_alias(real->port_id, name);
 }
 
+int JACK_port_set_device_metadata(jack_port_t* port, const char* pretty_name)
+{
+    fake_port_t* real = (fake_port_t*)port;
+    return real->driver->PortSetDeviceMetadata(real->port_id, pretty_name);
+}
+
 jack_nframes_t JACK_get_sample_rate(jack_client_t *client)
 {
     return ((JackAlsaDriver*)client)->get_sample_rate();

--- a/linux/alsa/alsa_rawmidi.c
+++ b/linux/alsa/alsa_rawmidi.c
@@ -431,9 +431,9 @@ inline int midi_port_open_jack(alsa_rawmidi_t *midi, midi_port_t *port, int type
 	char name[128];
 
 	if (type & JackPortIsOutput)
-		snprintf(name, sizeof(name), "system_midi:capture_%d", ++midi->midi_in_cnt);
+		snprintf(name, sizeof(name), "system:midi_capture_%d", ++midi->midi_in_cnt);
 	else
-		snprintf(name, sizeof(name), "system_midi:playback_%d", ++midi->midi_out_cnt);
+		snprintf(name, sizeof(name), "system:midi_playback_%d", ++midi->midi_out_cnt);
 
 	port->jack = jack_port_register(midi->client, name, JACK_DEFAULT_MIDI_TYPE,
 		type | JackPortIsPhysical | JackPortIsTerminal, 0);

--- a/linux/alsa/alsa_rawmidi.c
+++ b/linux/alsa/alsa_rawmidi.c
@@ -90,6 +90,7 @@ struct midi_port_t {
 	alsa_id_t id;
 	char dev[16];
 	char name[64];
+	char device_name[64];
 
 	jack_port_t *jack;
 	snd_rawmidi_t *rawmidi;
@@ -410,9 +411,10 @@ void midi_port_init(const alsa_rawmidi_t *midi, midi_port_t *port, snd_rawmidi_i
 
 	port->id = *id;
 	snprintf(port->dev, sizeof(port->dev), "hw:%d,%d,%d", id->id[0], id->id[1], id->id[3]);
+	snprintf(port->device_name, sizeof(port->device_name), snd_rawmidi_info_get_name(info));
 	name = snd_rawmidi_info_get_subdevice_name(info);
 	if (!strlen(name))
-		name = snd_rawmidi_info_get_name(info);
+		name = port->device_name;
 	snprintf(port->name, sizeof(port->name), "%s %s %s", port->id.id[2] ? "out":"in", port->dev, name);
 
 	// replace all offending characters with '-'
@@ -429,15 +431,18 @@ inline int midi_port_open_jack(alsa_rawmidi_t *midi, midi_port_t *port, int type
 	char name[128];
 
 	if (type & JackPortIsOutput)
-		snprintf(name, sizeof(name), "system:midi_capture_%d", ++midi->midi_in_cnt);
+		snprintf(name, sizeof(name), "system_midi:capture_%d", ++midi->midi_in_cnt);
 	else
-		snprintf(name, sizeof(name), "system:midi_playback_%d", ++midi->midi_out_cnt);
+		snprintf(name, sizeof(name), "system_midi:playback_%d", ++midi->midi_out_cnt);
 
 	port->jack = jack_port_register(midi->client, name, JACK_DEFAULT_MIDI_TYPE,
 		type | JackPortIsPhysical | JackPortIsTerminal, 0);
 
-	if (port->jack)
+	if (port->jack) {
 		jack_port_set_alias(port->jack, alias);
+		jack_port_set_device_metadata(port->jack, port->device_name);
+	}
+
 	return port->jack == NULL;
 }
 

--- a/linux/alsa/alsa_seqmidi.c
+++ b/linux/alsa/alsa_seqmidi.c
@@ -494,9 +494,9 @@ port_t* port_create(alsa_seqmidi_t *self, int type, snd_seq_addr_t addr, const s
 	}
 
 	if (jack_caps & JackPortIsOutput)
-		snprintf(name, sizeof(name), "system_midi:capture_%d", ++self->midi_in_cnt);
+		snprintf(name, sizeof(name), "system:midi_capture_%d", ++self->midi_in_cnt);
 	else
-		snprintf(name, sizeof(name), "system_midi:playback_%d", ++self->midi_out_cnt);
+		snprintf(name, sizeof(name), "system:midi_playback_%d", ++self->midi_out_cnt);
 
 	port->jack_port = jack_port_register(self->jack,
 		name, JACK_DEFAULT_MIDI_TYPE, jack_caps, 0);


### PR DESCRIPTION
This patch extends https://github.com/jackaudio/jack2/pull/498 by setting initial metadata also for ALSA `raw` and `seq` MIDI ports.

@falkTX what do you think about renaming` PortSetDeviceMetadata()` to `PortSetInitialMetadata()` ? I think the latter better explains what that method does. There is another lowercase version `jack_port_set_device_metadata()` in `alsa_midi_jackmp.cpp` that should also be renamed, just in case.