### PR TITLE
Fix warning: catching polymorphic type ‘class std::exception’ by value

### DIFF
--- a/linux/alsarawmidi/JackALSARawMidiPort.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiPort.cpp
@@ -109,7 +109,7 @@ JackALSARawMidiPort::JackALSARawMidiPort(const char *client_name, snd_rawmidi_in
     }
     try {
         CreateNonBlockingPipe(fds);
-    } catch (std::exception e) {
+    } catch (std::exception& e) {
         error_message = e.what();
         func = "CreateNonBlockingPipe";
         goto close;


### PR DESCRIPTION
Compiling with -Wcatch-value I got this warning:
../linux/alsarawmidi/JackALSARawMidiPort.cpp:112:29: warning: catching polymorphic type ‘class std::exception’ by value [-Wcatch-value=]