### PR TITLE
Rename PortSetDeviceMetadata to PortSetDefaultMetadata

### DIFF
--- a/common/JackEngine.cpp
+++ b/common/JackEngine.cpp
@@ -1086,7 +1086,7 @@ int JackEngine::PortRename(int refnum, jack_port_id_t port, const char* name)
     return 0;
 }
 
-int JackEngine::PortSetDeviceMetadata(jack_port_id_t port, const char* pretty_name)
+int JackEngine::PortSetDefaultMetadata(jack_port_id_t port, const char* pretty_name)
 {
     static const char* type = "text/plain";
     jack_uuid_t uuid = jack_port_uuid_generate(port);

--- a/common/JackEngine.h
+++ b/common/JackEngine.h
@@ -138,7 +138,7 @@ class SERVER_EXPORT JackEngine : public JackLockAble
 
         int PortRename(int refnum, jack_port_id_t port, const char* name);
 
-        int PortSetDeviceMetadata(jack_port_id_t port, const char* pretty_name);
+        int PortSetDefaultMetadata(jack_port_id_t port, const char* pretty_name);
 
         int ComputeTotalLatencies();
 

--- a/common/JackLockedEngine.h
+++ b/common/JackLockedEngine.h
@@ -246,11 +246,11 @@ class SERVER_EXPORT JackLockedEngine
             CATCH_EXCEPTION_RETURN
         }
 
-        int PortSetDeviceMetadata(int refnum, jack_port_id_t port, const char* pretty_name)
+        int PortSetDefaultMetadata(int refnum, jack_port_id_t port, const char* pretty_name)
         {
             TRY_CALL
             JackLock lock(&fEngine);
-            return (fEngine.CheckClient(refnum)) ? fEngine.PortSetDeviceMetadata(port, pretty_name) : -1;
+            return (fEngine.CheckClient(refnum)) ? fEngine.PortSetDefaultMetadata(port, pretty_name) : -1;
             CATCH_EXCEPTION_RETURN
         }
 

--- a/linux/alsa/JackAlsaDriver.cpp
+++ b/linux/alsa/JackAlsaDriver.cpp
@@ -471,9 +471,9 @@ void JackAlsaDriver::SetTimetAux(jack_time_t time)
     fBeginDateUst = time;
 }
 
-int JackAlsaDriver::PortSetDeviceMetadata(jack_port_id_t port_id, const char* pretty_name)
+int JackAlsaDriver::PortSetDefaultMetadata(jack_port_id_t port_id, const char* pretty_name)
 {
-    return fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, port_id, pretty_name);
+    return fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, port_id, pretty_name);
 }
 
 void JackAlsaDriver::WriteOutputAux(jack_nframes_t orig_nframes, snd_pcm_sframes_t contiguous, snd_pcm_sframes_t nwritten)

--- a/linux/alsa/JackAlsaDriver.h
+++ b/linux/alsa/JackAlsaDriver.h
@@ -93,7 +93,7 @@ class JackAlsaDriver : public JackAudioDriver
         void WriteOutputAux(jack_nframes_t orig_nframes, snd_pcm_sframes_t contiguous, snd_pcm_sframes_t nwritten);
         void SetTimetAux(jack_time_t time);
 
-        int PortSetDeviceMetadata(jack_port_id_t port_id, const char* pretty_name);
+        int PortSetDefaultMetadata(jack_port_id_t port_id, const char* pretty_name);
 
         // JACK API emulation for the midi driver
         int is_realtime() const;

--- a/linux/alsa/alsa_midi_impl.h
+++ b/linux/alsa/alsa_midi_impl.h
@@ -37,7 +37,7 @@ extern "C"
     int JACK_port_unregister(jack_client_t *, jack_port_t*);
     void* JACK_port_get_buffer(jack_port_t*, jack_nframes_t);
     int JACK_port_set_alias(jack_port_t* port, const char* name);
-    int JACK_port_set_device_metadata(jack_port_t* port, const char* pretty_name);
+    int jack_port_set_default_metadata(jack_port_t* port, const char* pretty_name);
 
     jack_nframes_t JACK_get_sample_rate(jack_client_t *);
     jack_nframes_t JACK_frame_time(jack_client_t *);
@@ -50,7 +50,7 @@ extern "C"
 #define jack_port_unregister JACK_port_unregister
 #define jack_port_get_buffer JACK_port_get_buffer
 #define jack_port_set_alias JACK_port_set_alias
-#define jack_port_set_device_metadata JACK_port_set_device_metadata
+#define jack_port_set_default_metadata jack_port_set_default_metadata
 
 #define jack_get_sample_rate JACK_get_sample_rate
 #define jack_frame_time JACK_frame_time

--- a/linux/alsa/alsa_midi_jackmp.cpp
+++ b/linux/alsa/alsa_midi_jackmp.cpp
@@ -71,10 +71,10 @@ int JACK_port_set_alias(jack_port_t *port, const char* name)
     return real->driver->port_set_alias(real->port_id, name);
 }
 
-int JACK_port_set_device_metadata(jack_port_t* port, const char* pretty_name)
+int jack_port_set_default_metadata(jack_port_t* port, const char* pretty_name)
 {
     fake_port_t* real = (fake_port_t*)port;
-    return real->driver->PortSetDeviceMetadata(real->port_id, pretty_name);
+    return real->driver->PortSetDefaultMetadata(real->port_id, pretty_name);
 }
 
 jack_nframes_t JACK_get_sample_rate(jack_client_t *client)

--- a/linux/alsa/alsa_rawmidi.c
+++ b/linux/alsa/alsa_rawmidi.c
@@ -440,7 +440,7 @@ inline int midi_port_open_jack(alsa_rawmidi_t *midi, midi_port_t *port, int type
 
 	if (port->jack) {
 		jack_port_set_alias(port->jack, alias);
-		jack_port_set_device_metadata(port->jack, port->device_name);
+		jack_port_set_default_metadata(port->jack, port->device_name);
 	}
 
 	return port->jack == NULL;

--- a/linux/alsa/alsa_seqmidi.c
+++ b/linux/alsa/alsa_seqmidi.c
@@ -521,7 +521,7 @@ port_t* port_create(alsa_seqmidi_t *self, int type, snd_seq_addr_t addr, const s
 		goto failed;
 
 	jack_port_set_alias (port->jack_port, port->name);
-	jack_port_set_device_metadata (port->jack_port, device_name);
+	jack_port_set_default_metadata (port->jack_port, device_name);
 
 	/* generate an alias */
 
@@ -534,7 +534,7 @@ port_t* port_create(alsa_seqmidi_t *self, int type, snd_seq_addr_t addr, const s
 			*c = '-';
 
 	jack_port_set_alias (port->jack_port, port->name);
-	jack_port_set_device_metadata (port->jack_port, device_name);
+	jack_port_set_default_metadata (port->jack_port, device_name);
 
 	if (type == PORT_INPUT)
 		err = alsa_connect_from(self, port->remote.client, port->remote.port);

--- a/linux/alsarawmidi/JackALSARawMidiDriver.cpp
+++ b/linux/alsarawmidi/JackALSARawMidiDriver.cpp
@@ -80,7 +80,7 @@ JackALSARawMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(alias);
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         input_port->GetDeviceName());
         fCapturePortList[i] = index;
 
@@ -108,7 +108,7 @@ JackALSARawMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(alias);
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         output_port->GetDeviceName());
         fPlaybackPortList[i] = index;
 

--- a/macosx/coremidi/JackCoreMidiDriver.mm
+++ b/macosx/coremidi/JackCoreMidiDriver.mm
@@ -372,7 +372,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fCapturePortList[i] = index;
     }
@@ -392,7 +392,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fCapturePortList[num_physical_inputs + i] = index;
     }
@@ -419,7 +419,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fPlaybackPortList[i] = index;
     }
@@ -440,7 +440,7 @@ JackCoreMidiDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(port_obj->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         port_obj->GetDeviceName());
         fPlaybackPortList[num_physical_outputs + i] = index;
     }

--- a/windows/winmme/JackWinMMEDriver.cpp
+++ b/windows/winmme/JackWinMMEDriver.cpp
@@ -71,7 +71,7 @@ JackWinMMEDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(input_port->GetAlias());
         port->SetLatencyRange(JackCaptureLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         input_port->GetDeviceName());
         fCapturePortList[i] = index;
     }
@@ -97,7 +97,7 @@ JackWinMMEDriver::Attach()
         port = fGraphManager->GetPort(index);
         port->SetAlias(output_port->GetAlias());
         port->SetLatencyRange(JackPlaybackLatency, &latency_range);
-        fEngine->PortSetDeviceMetadata(fClientControl.fRefNum, index,
+        fEngine->PortSetDefaultMetadata(fClientControl.fRefNum, index,
                                         output_port->GetDeviceName());
         fPlaybackPortList[i] = index;
     }


### PR DESCRIPTION
This PR continues https://github.com/jackaudio/jack2/pull/505 and https://github.com/jackaudio/jack2/pull/498 by renaming `PortSetDeviceMetadata` and `jack_port_set_device_metadata` to `PortSetDefaultMetadata` and `jack_port_set_default_metadata` respectively. I think these names better reflect the intention of those and make code more readable.

I previously proposed using `PortSetInitialMetadata` in https://github.com/jackaudio/jack2/pull/505, but think this naming is better.
