### PR TITLE
systemdeps.h: define standard integer types correctly for MSVC

### DIFF
--- a/common/jack/systemdeps.h
+++ b/common/jack/systemdeps.h
@@ -70,14 +70,14 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
         #define __inline__ inline
         #if (!defined(int8_t) && !defined(_STDINT_H))
             #define __int8_t_defined
-            typedef char int8_t;
-            typedef unsigned char uint8_t;
-            typedef short int16_t;
-            typedef unsigned short uint16_t;
-            typedef long int32_t;
-            typedef unsigned long uint32_t;
-            typedef LONGLONG int64_t;
-            typedef ULONGLONG uint64_t;
+            typedef INT8 int8_t;
+            typedef UINT8 uint8_t;
+            typedef INT16 int16_t;
+            typedef UINT16 uint16_t;
+            typedef INT32 int32_t;
+            typedef UINT32 uint32_t;
+            typedef INT64 int64_t;
+            typedef UINT64 uint64_t;
         #endif
     #elif __MINGW32__   /* MINGW */
         #include <stdint.h>


### PR DESCRIPTION
Fixes the following errors:
```
C:\vcpkg\installed\x64-windows-static-md\include\jack/systemdeps.h(73): error C2371: 'int8_t': redefinition; different basic types
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include\stdint.h(14): note: see declaration of 'int8_t'
C:\vcpkg\installed\x64-windows-static-md\include\jack/systemdeps.h(77): error C2371: 'int32_t': redefinition; different basic types
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include\stdint.h(16): note: see declaration of 'int32_t'
C:\vcpkg\installed\x64-windows-static-md\include\jack/systemdeps.h(78): error C2371: 'uint32_t': redefinition; different basic types
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include\stdint.h(20): note: see declaration of 'uint32_t'
```

Tested with MSVC 14.23.28105 (2019).

---

Fixes #353.