### PR TITLE
Fix compilation of documentation

### DIFF
--- a/doxyfile.in
+++ b/doxyfile.in
@@ -792,7 +792,7 @@ HTML_HEADER            =
 # each generated HTML page. If it is left blank doxygen will generate a
 # standard footer.
 
-HTML_FOOTER            = @SRCDIR@/no_date_footer.html
+HTML_FOOTER            =
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading
 # style sheet that is used by each HTML page. It can be used to


### PR DESCRIPTION
Custom footer without date is not needed in documentation anymore.

That was an old Fedora patch, I thinks it's not needed anymore.
If that file is not present, doc compilation fails.