### PR TITLE
example-clients: Use c++ compiler for jack_simdtests

### DIFF
--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -49,10 +49,15 @@ def build(bld):
         else:
             use = ['clientlib']
 
-        if bld.env['IS_MACOSX']:
-            prog = bld(features='c cprogram', framework = ['Foundation'])
+        if example_program == 'jack_simdtests':
+            ftrs = 'cxx cxxprogram'
         else:
-            prog = bld(features='c cprogram')
+            ftrs = 'c cprogram'
+
+        if bld.env['IS_MACOSX']:
+            prog = bld(features = ftrs, framework = ['Foundation'])
+        else:
+            prog = bld(features = ftrs)
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = example_program_source
         prog.use = use


### PR DESCRIPTION
It uses c++ sources and runtime therefore its best to use c++ compiler
to build it so it can find the correct runtime, cross compiling with
clang fails

x86_64-yoe-linux-ld: example-clients/simdtests.cpp.28.o: undefined reference to symbol '__cxa_call_unexpected@@CXXABI_1.3'

Signed-off-by: Khem Raj <raj.khem@gmail.com>