### PR TITLE
Windows: Use widechar instead of char when loading drivers.

### DIFF
--- a/common/JackDriverLoader.cpp
+++ b/common/JackDriverLoader.cpp
@@ -34,39 +34,39 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #ifdef WIN32
 
-static char* locate_dll_driver_dir()
+static wchar_t* locate_dll_driver_dir()
 {
     HMODULE libjack_handle = NULL;
-    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                      reinterpret_cast<LPCSTR>(locate_dll_driver_dir), &libjack_handle);
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       reinterpret_cast<LPCWSTR>(locate_dll_driver_dir), &libjack_handle);
 
     // For WIN32 ADDON_DIR is defined in JackConstants.h as relative path
-    char driver_dir_storage[512];
-    if (3 < GetModuleFileName(libjack_handle, driver_dir_storage, 512)) {
-        char *p = strrchr(driver_dir_storage, '\\');
+    wchar_t driver_dir_storage[512];
+    if (3 < GetModuleFileNameW(libjack_handle, driver_dir_storage, 512)) {
+        wchar_t *p = wcsrchr(driver_dir_storage, L'\\');
         if (p && (p != driver_dir_storage)) {
             *p = 0;
-        }
-        jack_info("Drivers/internals found in : %s", driver_dir_storage);
-        strcat(driver_dir_storage, "/");
-        strcat(driver_dir_storage, ADDON_DIR);
-        return strdup(driver_dir_storage);
+        }   
+        jack_info("Drivers/internals found in : %S", driver_dir_storage);
+        wcscat(driver_dir_storage, L"\\");
+        wcscat(driver_dir_storage, ADDON_DIRW);
+        return wcsdup(driver_dir_storage);
     } else {
         jack_error("Cannot get JACK dll directory : %d", GetLastError());
         return NULL;
     }
 }
 
-static char* locate_driver_dir(HANDLE& file, WIN32_FIND_DATA& filedata)
+static wchar_t* locate_driver_dir(HANDLE& file, WIN32_FIND_DATAW& filedata)
 {
     // Search drivers/internals iin the same folder of "libjackserver.dll"
-    char* driver_dir = locate_dll_driver_dir();
-    char dll_filename[512];
-    snprintf(dll_filename, sizeof(dll_filename), "%s/*.dll", driver_dir);
-    file = (HANDLE)FindFirstFile(dll_filename, &filedata);
+    wchar_t* driver_dir = locate_dll_driver_dir();
+    wchar_t dll_filename[512];
+    swprintf(dll_filename, 510, L"%S/*.dll", driver_dir);
+    file = (HANDLE)FindFirstFileW(dll_filename, &filedata);
 
     if (file == INVALID_HANDLE_VALUE) {
-        jack_error("Drivers not found ");
+        jack_error("Drivers not found in \"%S\": \"%S\"", driver_dir, dll_filename);
         free(driver_dir);
         return NULL;
     } else {
@@ -412,16 +412,16 @@ jack_driver_desc_t* jack_find_driver_descriptor (JSList * drivers, const char* n
     return desc;
 }
 
-static void* check_symbol(const char* sofile, const char* symbol, const char* driver_dir, void** res_dllhandle = NULL)
+static void* check_symbol(const wchar_t* sofile, const char* symbol, const wchar_t* driver_dir, void** res_dllhandle = NULL)
 {
     void* dlhandle;
     void* res = NULL;
-    char filename[1024];
-    sprintf(filename, "%s/%s", driver_dir, sofile);
+    wchar_t filename[1024];
+    swprintf(filename, 1022, L"%S/%S", driver_dir, sofile);
 
     if ((dlhandle = LoadDriverModule(filename)) == NULL) {
 #ifdef WIN32
-        jack_error ("Could not open component .dll '%s': %ld", filename, GetLastError());
+        jack_error ("Could not open component .dll '%S': %ld", filename, GetLastError());
 #else
         jack_error ("Could not open component .so '%s': %s", filename, dlerror());
 #endif
@@ -437,25 +437,25 @@ static void* check_symbol(const char* sofile, const char* symbol, const char* dr
     return res;
 }
 
-static jack_driver_desc_t* jack_get_descriptor (JSList* drivers, const char* sofile, const char* symbol, const char* driver_dir)
+static jack_driver_desc_t* jack_get_descriptor (JSList* drivers, const wchar_t* sofile, const char* symbol, const wchar_t* driver_dir)
 {
     jack_driver_desc_t* descriptor = NULL;
     jack_driver_desc_t* other_descriptor;
     JackDriverDescFunction so_get_descriptor = NULL;
-    char filename[1024];
+    wchar_t filename[1024];
     JSList* node;
     void* dlhandle = NULL;
 
-    sprintf(filename, "%s/%s", driver_dir, sofile);
+    swprintf(filename, 1022, L"%S/%S", driver_dir, sofile);
     so_get_descriptor = (JackDriverDescFunction)check_symbol(sofile, symbol, driver_dir, &dlhandle);
 
     if (so_get_descriptor == NULL) {
-        jack_error("jack_get_descriptor : dll %s is not a driver", sofile);
+        jack_error("jack_get_descriptor : dll %S is not a driver", sofile);
         goto error;
     }
 
     if ((descriptor = so_get_descriptor ()) == NULL) {
-        jack_error("Driver from '%s' returned NULL descriptor", filename);
+        jack_error("Driver from '%S' returned NULL descriptor", filename);
         goto error;
     }
 
@@ -463,14 +463,14 @@ static jack_driver_desc_t* jack_get_descriptor (JSList* drivers, const char* sof
     for (node = drivers; node; node = jack_slist_next (node)) {
         other_descriptor = (jack_driver_desc_t*) node->data;
         if (strcmp(descriptor->name, other_descriptor->name) == 0) {
-            jack_error("The drivers in '%s' and '%s' both have the name '%s'; using the first",
+            jack_error("The drivers in '%S' and '%S' both have the name '%S'; using the first",
                        other_descriptor->file, filename, other_descriptor->name);
             /* FIXME: delete the descriptor */
             goto error;
         }
     }
 
-    strncpy(descriptor->file, filename, JACK_PATH_MAX);
+    wcsncpy(descriptor->file, filename, JACK_PATH_MAX);
 
 error:
     if (dlhandle) {
@@ -484,13 +484,13 @@ error:
 JSList * jack_drivers_load(JSList * drivers)
 {
     //char dll_filename[512];
-    WIN32_FIND_DATA filedata;
+    WIN32_FIND_DATAW filedata;
     HANDLE file;
-    const char* ptr = NULL;
+    const wchar_t* ptr = NULL;
     JSList* driver_list = NULL;
     jack_driver_desc_t* desc = NULL;
 
-    char* driver_dir = locate_driver_dir(file, filedata);
+    wchar_t* driver_dir = locate_driver_dir(file, filedata);
     if (!driver_dir) {
         jack_error("Driver folder not found");
         goto error;
@@ -498,17 +498,17 @@ JSList * jack_drivers_load(JSList * drivers)
 
     do {
         /* check the filename is of the right format */
-        if (strncmp ("jack_", filedata.cFileName, 5) != 0) {
+        if (wcsncmp (L"jack_", filedata.cFileName, 5) != 0) {
             continue;
         }
 
-        ptr = strrchr (filedata.cFileName, '.');
+        ptr = wcsrchr (filedata.cFileName, L'.');
         if (!ptr) {
             continue;
         }
 
         ptr++;
-        if (strncmp ("dll", ptr, 3) != 0) {
+        if (wcsncmp (L"dll", ptr, 3) != 0) {
             continue;
         }
 
@@ -521,13 +521,13 @@ JSList * jack_drivers_load(JSList * drivers)
         if (desc) {
             driver_list = jack_slist_append (driver_list, desc);
         } else {
-            jack_error ("jack_get_descriptor returns null for \'%s\'", filedata.cFileName);
+            jack_error ("jack_get_descriptor returns null for \'%S\'", filedata.cFileName);
         }
 
-    } while (FindNextFile(file, &filedata));
+    } while (FindNextFileW(file, &filedata));
 
     if (!driver_list) {
-        jack_error ("Could not find any drivers in %s!", driver_dir);
+        jack_error ("Could not find any drivers in %S!", driver_dir);
     }
 
 error:
@@ -613,13 +613,13 @@ JSList* jack_drivers_load (JSList * drivers)
 JSList* jack_internals_load(JSList * internals)
 {
     ///char dll_filename[512];
-    WIN32_FIND_DATA filedata;
+    WIN32_FIND_DATAW filedata;
     HANDLE file;
-    const char* ptr = NULL;
+    const wchar_t* ptr = NULL;
     JSList* driver_list = NULL;
     jack_driver_desc_t* desc;
 
-    char* driver_dir = locate_driver_dir(file, filedata);
+    wchar_t* driver_dir = locate_driver_dir(file, filedata);
     if (!driver_dir) {
         jack_error("Driver folder not found");
         goto error;
@@ -627,13 +627,13 @@ JSList* jack_internals_load(JSList * internals)
 
     do {
 
-        ptr = strrchr (filedata.cFileName, '.');
+        ptr = wcsrchr (filedata.cFileName, L'.');
         if (!ptr) {
             continue;
         }
 
         ptr++;
-        if (strncmp ("dll", ptr, 3) != 0) {
+        if (wcsncmp (L"dll", ptr, 3) != 0) {
             continue;
         }
 
@@ -649,7 +649,7 @@ JSList* jack_internals_load(JSList * internals)
             jack_error ("jack_get_descriptor returns null for \'%s\'", filedata.cFileName);
         }
 
-    } while (FindNextFile(file, &filedata));
+    } while (FindNextFileW(file, &filedata));
 
     if (!driver_list) {
         jack_error ("Could not find any internals in %s!", driver_dir);
@@ -745,18 +745,26 @@ Jack::JackDriverClientInterface* JackDriverInfo::Open(jack_driver_desc_t* driver
     if (fHandle == NULL) {
 #ifdef WIN32
         if ((errstr = GetLastError ()) != 0) {
-            jack_error ("Can't load \"%s\": %ld", driver_desc->file, errstr);
+            jack_error ("Can't load \"%S\": %ld", driver_desc->file, errstr);
 #else
         if ((errstr = dlerror ()) != 0) {
             jack_error ("Can't load \"%s\": %s", driver_desc->file, errstr);
 #endif
 
         } else {
-            jack_error ("Error loading driver shared object %s", driver_desc->file);
+#ifdef WIN32
+          jack_error ("Error loading driver shared object %S", driver_desc->file);
+#else
+          jack_error ("Error loading driver shared object %s", driver_desc->file);
+#endif
         }
         return NULL;
     }
 
+
+    //jack_error (" ---------------------------------  Successfully opened driver \"%S\"\n", driver_desc->file);
+
+        
     fInitialize = (driverInitialize)GetDriverProc(fHandle, "driver_initialize");
 
 #ifdef WIN32
@@ -764,7 +772,12 @@ Jack::JackDriverClientInterface* JackDriverInfo::Open(jack_driver_desc_t* driver
 #else
     if ((fInitialize == NULL) && (errstr = dlerror ()) != 0) {
 #endif
+
+#ifdef WIN32
+        jack_error("No initialize function in shared object %S\n", driver_desc->file);
+#else
         jack_error("No initialize function in shared object %s\n", driver_desc->file);
+#endif
         return NULL;
     }
 

--- a/common/driver_interface.h
+++ b/common/driver_interface.h
@@ -133,7 +133,11 @@ typedef struct {
     char name[JACK_DRIVER_NAME_MAX + 1];      /**< The driver's canonical name */
     jack_driver_type_t type;               /**< The driver's type */
     char desc[JACK_DRIVER_PARAM_DESC + 1];    /**< The driver's extended description */
+#ifdef WIN32
+    wchar_t file[JACK_PATH_MAX + 1];             /**< The filename of the driver's shared object file */
+#else
     char file[JACK_PATH_MAX + 1];             /**< The filename of the driver's shared object file */
+#endif
     uint32_t nparams;                         /**< The number of parameters the driver has */
     jack_driver_param_desc_t * params;        /**< An array of parameter descriptors */
 }

--- a/windows/JackPlatformPlug_os.h
+++ b/windows/JackPlatformPlug_os.h
@@ -30,6 +30,11 @@
     #define ADDON_DIR "jack"
 #endif
 
+#define MAKE_WIDECHAR_CONSTANT2(Quote) L##Quote
+#define MAKE_WIDECHAR_CONSTANT(Quote) MAKE_WIDECHAR_CONSTANT2(Quote)
+#define ADDON_DIRW MAKE_WIDECHAR_CONSTANT(ADDON_DIR)
+
+
 namespace Jack
 {
     struct JackRequest;

--- a/windows/JackSystemDeps_os.h
+++ b/windows/JackSystemDeps_os.h
@@ -28,10 +28,12 @@
 #define PATH_MAX   512
 #endif
 
+#ifndef UINT32_MAX
 #define UINT32_MAX 4294967295U
+#endif
 
 #define DRIVER_HANDLE HINSTANCE
-#define LoadDriverModule(name) LoadLibrary((name))
+#define LoadDriverModule(name) LoadLibraryW((name))
 #define UnloadDriverModule(handle) (FreeLibrary(((HMODULE)handle)))
 #define GetDriverProc(handle, name) GetProcAddress(((HMODULE)handle), (name))
 


### PR DESCRIPTION
Fixes loading drivers/internals if jack is installed in a directory with special characters.