### PR TITLE
Jack Audio QNX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: all
+all:
+	CC=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-gcc CXX=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++ AR=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-ar LDFLAGS="-L${INSTALL_ROOT_nto}/aarch64le/lib -L${INSTALL_ROOT_nto}/aarch64le/usr/lib -L${QNX_TARGET}/aarch64le/lib -L${QNX_TARGET}/aarch64le/usr/lib" PKG_CONFIG_LIBDIR=${INSTALL_ROOT_nto}/usr/lib/pkgconfig ./waf configure --platform=qnx --prefix=/usr --libdir=/usr/lib64
+	./waf build
+	./waf install --destdir=${INSTALL_ROOT_nto}
+
+.PHONY: install
+install: all
+
+.PHONY:clean
+clean:
+	# ignore error codes otherwise it would for example fail if clean is called before configure
+	-./waf clean
+

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all
 all:
-	CC=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-gcc CXX=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++ AR=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-ar LDFLAGS="-L${INSTALL_ROOT_nto}/aarch64le/lib -L${INSTALL_ROOT_nto}/aarch64le/usr/lib -L${QNX_TARGET}/aarch64le/lib -L${QNX_TARGET}/aarch64le/usr/lib" PKG_CONFIG_LIBDIR=${INSTALL_ROOT_nto}/usr/lib/pkgconfig ./waf configure --platform=qnx --prefix=/usr --libdir=/usr/lib64
+	CC=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-gcc CXX=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++ AR=${QNX_HOST}/usr/bin/aarch64-unknown-nto-qnx7.0.0-ar LDFLAGS="-L${INSTALL_ROOT_nto}/aarch64le/lib -L${INSTALL_ROOT_nto}/aarch64le/usr/lib -L${QNX_TARGET}/aarch64le/lib -L${QNX_TARGET}/aarch64le/usr/lib" PKG_CONFIG_LIBDIR=${INSTALL_ROOT_nto}/aarch64le/usr/lib/pkgconfig ./waf configure --platform=qnx --prefix=/usr --libdir=/usr/lib64
 	./waf build
-	./waf install --destdir=${INSTALL_ROOT_nto}
+	./waf install --destdir=${INSTALL_ROOT_nto}/aarch64le
 
 .PHONY: install
 install: all

--- a/common/JackAudioAdapterInterface.cpp
+++ b/common/JackAudioAdapterInterface.cpp
@@ -22,7 +22,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #endif
 
 #include "JackAudioAdapter.h"
-#ifndef MY_TARGET_OS_IPHONE
+#if !defined(MY_TARGET_OS_IPHONE) && !defined(__QNXNTO__)
 #include "JackLibSampleRateResampler.h"
 #endif
 #include "JackTime.h"
@@ -185,7 +185,7 @@ namespace Jack
         fRunning = false;
     }
 
-#ifdef MY_TARGET_OS_IPHONE
+#if defined(MY_TARGET_OS_IPHONE) || defined(__QNXNTO__)
     void JackAudioAdapterInterface::Create()
     {}
 #else

--- a/common/JackAudioDriver.cpp
+++ b/common/JackAudioDriver.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackLockedEngine.h"
 #include "JackException.h"
 #include <assert.h>
+#include "JackServerGlobals.h"
 
 using namespace std;
 
@@ -199,7 +200,11 @@ int JackAudioDriver::Write()
 
 int JackAudioDriver::Process()
 {
-    return (fEngineControl->fSyncMode) ? ProcessSync() : ProcessAsync();
+    int err = (fEngineControl->fSyncMode) ? ProcessSync() : ProcessAsync();
+    if(err && JackServerGlobals::on_failure != NULL) {
+        JackServerGlobals::on_failure();
+    }
+    return err;
 }
 
 /*

--- a/common/JackClient.cpp
+++ b/common/JackClient.cpp
@@ -34,6 +34,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 using namespace std;
 
+#ifdef __QNXNTO__
+void __attribute__((constructor)) init_output_for_percent_s_NULL_for_clients();
+void init_output_for_percent_s_NULL_for_clients()
+{
+    extern const char *output_for_percent_s_NULL;
+    output_for_percent_s_NULL = "(null)";
+}
+#endif
+
 namespace Jack
 {
 

--- a/common/JackControlAPI.cpp
+++ b/common/JackControlAPI.cpp
@@ -663,7 +663,10 @@ jackctl_setup_signals(
     sigfillset(&allsignals);
     action.sa_handler = signal_handler;
     action.sa_mask = allsignals;
-    action.sa_flags = SA_RESTART|SA_RESETHAND;
+    action.sa_flags = SA_RESETHAND;
+#ifndef __QNXNTO__
+    action.sa_flags |= SA_RESTART;
+#endif
 
     for (i = 1; i < NSIG; i++)
     {

--- a/common/JackControlAPI.cpp
+++ b/common/JackControlAPI.cpp
@@ -26,6 +26,11 @@
 #include <pthread.h>
 #endif
 
+#ifdef __linux__
+#include <poll.h>
+#include <sys/signalfd.h>
+#endif
+
 #include "types.h"
 #include <string.h>
 #include <errno.h>
@@ -682,16 +687,56 @@ jackctl_setup_signals(
 SERVER_EXPORT void
 jackctl_wait_signals(jackctl_sigmask_t * sigmask)
 {
-    int sig;
+    int sig = 0;
     bool waiting = true;
+#ifdef __linux__
+    int err;
+    struct pollfd pfd;
+    struct signalfd_siginfo si;
+
+    /* Block the signals in order for signalfd to receive them */
+    sigprocmask(SIG_BLOCK, &sigmask->signals, NULL);
+
+    pfd.fd = signalfd(-1, &sigmask->signals, 0);
+    if(pfd.fd == -1) {
+        fprintf(stderr, "Jack : signalfd() failed with errno %d\n", -errno);
+        return;
+    }
+    pfd.events = POLLIN;
+#endif
 
     while (waiting) {
     #if defined(sun) && !defined(__sun__) // SUN compiler only, to check
         sigwait(&sigmask->signals);
+        fprintf(stderr, "Jack main caught signal\n");
+    #elif defined(__linux__)
+        err = poll(&pfd, 1, -1);
+        if (err < 0) {
+            if (errno == EINTR) {
+                continue;
+            } else {
+                fprintf(stderr, "Jack : poll() failed with errno %d\n", -errno);
+                break;
+            }
+        } else {
+            if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+                fprintf(stderr, "Jack : poll() exited with errno %d\n", -errno);
+                break;
+            } else if ((pfd.revents & POLLIN) == 0) {
+                continue;
+            }
+            err = read (pfd.fd, &si, sizeof(si));
+            if (err < 0) {
+                fprintf(stderr, "Jack : read() on signalfd failed with errno %d\n", -errno);
+                goto fail;
+            }
+            sig = si.ssi_signo;
+            fprintf(stderr, "Jack main caught signal %d\n", sig);
+        }
     #else
         sigwait(&sigmask->signals, &sig);
-    #endif
         fprintf(stderr, "Jack main caught signal %d\n", sig);
+    #endif
 
         switch (sig) {
             case SIGUSR1:
@@ -715,6 +760,12 @@ jackctl_wait_signals(jackctl_sigmask_t * sigmask)
         // bugs that cause segfaults etc. during shutdown.
         sigprocmask(SIG_UNBLOCK, &sigmask->signals, 0);
     }
+
+#ifdef __linux__
+fail:
+    close(pfd.fd);
+#endif
+
 }
 #endif
 

--- a/common/JackControlAPI.cpp
+++ b/common/JackControlAPI.cpp
@@ -29,6 +29,7 @@
 #ifdef __linux__
 #include <poll.h>
 #include <sys/signalfd.h>
+#include <sys/eventfd.h>
 #endif
 
 #include "types.h"
@@ -146,6 +147,35 @@ struct jackctl_parameter
     char id;
     jack_driver_param_constraint_desc_t * constraint_ptr;
 };
+
+#ifdef __linux__
+/** Jack file descriptors */
+typedef enum
+{
+    JackSignalFD,			/**< @brief File descriptor to accept the signals */
+    JackEventFD,			/**< @brief File descriptor to accept the events from threads */
+    JackFDCount				/**< @brief FD count, ensure this is the last element */
+} jackctl_fd;
+
+static int eventFD;
+#endif
+
+static
+void
+on_failure()
+{
+#ifdef __linux__
+    int ret = 0;
+    const uint64_t ev = 1;
+
+    ret = write(eventFD, &ev, sizeof(ev));
+    if (ret < 0) {
+        fprintf(stderr, "JackServerGlobals::on_failure : write() failed with errno %d\n", -errno);
+    }
+#else
+    fprintf(stderr, "JackServerGlobals::on_failure callback called from thread\n");
+#endif
+}
 
 const char * jack_get_self_connect_mode_description(char mode)
 {
@@ -691,18 +721,27 @@ jackctl_wait_signals(jackctl_sigmask_t * sigmask)
     bool waiting = true;
 #ifdef __linux__
     int err;
-    struct pollfd pfd;
+    struct pollfd pfd[JackFDCount];
     struct signalfd_siginfo si;
+    memset(pfd, 0, sizeof(pfd));
 
     /* Block the signals in order for signalfd to receive them */
     sigprocmask(SIG_BLOCK, &sigmask->signals, NULL);
 
-    pfd.fd = signalfd(-1, &sigmask->signals, 0);
-    if(pfd.fd == -1) {
-        fprintf(stderr, "Jack : signalfd() failed with errno %d\n", -errno);
+    pfd[JackSignalFD].fd = signalfd(-1, &sigmask->signals, 0);
+    if(pfd[JackSignalFD].fd == -1) {
+        fprintf(stderr, "signalfd() failed with errno %d\n", -errno);
         return;
     }
-    pfd.events = POLLIN;
+    pfd[JackSignalFD].events = POLLIN;
+
+    pfd[JackEventFD].fd = eventfd(0, EFD_NONBLOCK);
+    if(pfd[JackEventFD].fd == -1) {
+        goto fail;
+    }
+    eventFD = pfd[JackEventFD].fd;
+    pfd[JackEventFD].events = POLLIN;
+
 #endif
 
     while (waiting) {
@@ -710,7 +749,7 @@ jackctl_wait_signals(jackctl_sigmask_t * sigmask)
         sigwait(&sigmask->signals);
         fprintf(stderr, "Jack main caught signal\n");
     #elif defined(__linux__)
-        err = poll(&pfd, 1, -1);
+        err = poll(pfd, JackFDCount, -1);
         if (err < 0) {
             if (errno == EINTR) {
                 continue;
@@ -719,19 +758,24 @@ jackctl_wait_signals(jackctl_sigmask_t * sigmask)
                 break;
             }
         } else {
-            if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            if ((pfd[JackSignalFD].revents & (POLLERR | POLLHUP | POLLNVAL)) ||
+                 pfd[JackEventFD].revents & (POLLERR | POLLHUP | POLLNVAL)) {
                 fprintf(stderr, "Jack : poll() exited with errno %d\n", -errno);
                 break;
-            } else if ((pfd.revents & POLLIN) == 0) {
+            } else if ((pfd[JackSignalFD].revents & POLLIN) != 0) {
+                err = read (pfd[JackSignalFD].fd, &si, sizeof(si));
+                if (err < 0) {
+                    fprintf(stderr, "Jack : read() on signalfd failed with errno %d\n", -errno);
+                    break;
+                }
+                sig = si.ssi_signo;
+                fprintf(stderr, "Jack main caught signal %d\n", sig);
+            } else if ((pfd[JackEventFD].revents & POLLIN) != 0) {
+                sig = 0; /* Received an event from one of the Jack thread */
+                fprintf(stderr, "Jack main received event from child thread, Exiting\n");
+            } else {
                 continue;
             }
-            err = read (pfd.fd, &si, sizeof(si));
-            if (err < 0) {
-                fprintf(stderr, "Jack : read() on signalfd failed with errno %d\n", -errno);
-                goto fail;
-            }
-            sig = si.ssi_signo;
-            fprintf(stderr, "Jack main caught signal %d\n", sig);
         }
     #else
         sigwait(&sigmask->signals, &sig);
@@ -763,7 +807,11 @@ jackctl_wait_signals(jackctl_sigmask_t * sigmask)
 
 #ifdef __linux__
 fail:
-    close(pfd.fd);
+    for(int i = 0; i < JackFDCount; i++) {
+        if(pfd[i].fd != 0) {
+            close(pfd[i].fd);
+        }
+    }
 #endif
 
 }
@@ -985,6 +1033,7 @@ SERVER_EXPORT jackctl_server_t * jackctl_server_create2(
     JackServerGlobals::on_device_acquire = on_device_acquire;
     JackServerGlobals::on_device_release = on_device_release;
     JackServerGlobals::on_device_reservation_loop = on_device_reservation_loop;
+    JackServerGlobals::on_failure = on_failure;
 
     if (!jackctl_drivers_load(server_ptr))
     {

--- a/common/JackFormatConverter.cpp
+++ b/common/JackFormatConverter.cpp
@@ -20,11 +20,16 @@
 */
 
 #include <cstring>
+#include <math.h>
 #include <jack/jack.h>
 #include <jack/format_converter.h>
 #include "JackCompilerDeps.h"
 #include "JackError.h"
 #include "memops.h"
+
+#define SAMPLE_32BIT_SCALING    0x7FFFFFFF
+#define NORMALIZED_FLOAT_MIN    -1.0f
+#define NORMALIZED_FLOAT_MAX    1.0f
 
 
 class BaseJackPortConverter : public IJackPortConverter {
@@ -92,6 +97,40 @@ class IntegerJackPortConverter : public BaseJackPortConverter {
             return;
         }
 };
+
+static void sample_move_dS_s32(jack_default_audio_sample_t *dst, char *src,
+                               unsigned long nsamples, unsigned long src_skip)
+{
+    const jack_default_audio_sample_t scaling = 1.0 / SAMPLE_32BIT_SCALING;
+
+    while (nsamples--) {
+        const int32_t src32 = *((int32_t *) src);
+        *dst = src32 * scaling;
+        dst++;
+        src += src_skip;
+    }
+}
+
+static void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src,
+                                unsigned long nsamples, unsigned long dst_skip,
+                                void*)
+{
+    const int32_t scaling = SAMPLE_32BIT_SCALING;
+
+    while (nsamples--) {
+        int32_t* const dst32 = (int32_t*)dst;
+
+        if (*src <= NORMALIZED_FLOAT_MIN) {
+            *dst32 = -scaling;
+        } else if (*src >= NORMALIZED_FLOAT_MAX) {
+            *dst32 = scaling;
+        } else {
+            *dst32 = lrintf(*src * scaling);
+        }
+        dst += dst_skip;
+        src++;
+    }
+}
 
 LIB_EXPORT IJackPortConverter* jack_port_create_converter(jack_port_t* port, const std::type_info& dst_type, const bool init_output_silence)
 {

--- a/common/JackFormatConverter.cpp
+++ b/common/JackFormatConverter.cpp
@@ -1,0 +1,115 @@
+/*
+  Copyright (C) 2019 Laxmi Devi <laxmi.devi@in.bosch.com>
+  Copyright (C) 2019 Timo Wischer <twischer@de.adit-jv.com>
+
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include <cstring>
+#include <jack/jack.h>
+#include <jack/format_converter.h>
+#include "JackCompilerDeps.h"
+#include "JackError.h"
+#include "memops.h"
+
+
+class BaseJackPortConverter : public IJackPortConverter {
+    protected:
+        jack_port_t* const port;
+    public:
+        BaseJackPortConverter(jack_port_t* pt) : port(pt) {}
+};
+
+class ForwardJackPortConverter : public BaseJackPortConverter {
+    private:
+        void* buffer = NULL;
+    public:
+        ForwardJackPortConverter(jack_port_t* pt) : BaseJackPortConverter(pt) {}
+
+        virtual void* get( jack_nframes_t frames) {
+            buffer = jack_port_get_buffer(port, frames);
+            return buffer;
+        }
+
+        virtual void set(void* buf,  jack_nframes_t frames) {
+            if (buf == buffer)
+                return;
+            std::memcpy(jack_port_get_buffer(port, frames), buf, frames*sizeof(jack_default_audio_sample_t));
+        }
+};
+
+class IntegerJackPortConverter : public BaseJackPortConverter {
+    typedef void (*ReadCopyFunction)  (jack_default_audio_sample_t *dst, char *src,
+                                       unsigned long src_bytes,
+                                       unsigned long src_skip_bytes);
+    typedef void (*WriteCopyFunction) (char *dst, jack_default_audio_sample_t *src,
+                                       unsigned long src_bytes,
+                                       unsigned long dst_skip_bytes,
+                                       dither_state_t *state);
+
+    private:
+        int32_t buffer[BUFFER_SIZE_MAX + 8];
+        const ReadCopyFunction to_jack;
+        const WriteCopyFunction from_jack;
+        const size_t sample_size;
+
+        int32_t* GetBuffer()
+        {
+            return (int32_t*)((uintptr_t)buffer & ~31L) + 8;
+        }
+
+    public:
+        IntegerJackPortConverter(const ReadCopyFunction to_jack,
+                                 const WriteCopyFunction from_jack,
+                                 const size_t sample_size,
+                                 jack_port_t* pt) : BaseJackPortConverter(pt),
+        to_jack(to_jack), from_jack(from_jack), sample_size(sample_size) {}
+
+        virtual void* get(jack_nframes_t frames) {
+            int32_t * aligned_ptr = GetBuffer();
+            jack_default_audio_sample_t* src = (jack_default_audio_sample_t*) jack_port_get_buffer(port, frames);
+            from_jack ((char *)aligned_ptr, src, frames, sample_size, NULL);
+            return aligned_ptr;
+        }
+
+        virtual void set(void* src, jack_nframes_t frames) {
+            jack_default_audio_sample_t* dst = (jack_default_audio_sample_t*) jack_port_get_buffer(port, frames);
+            to_jack (dst,(char *) src, frames, sample_size);
+            return;
+        }
+};
+
+LIB_EXPORT IJackPortConverter* jack_port_create_converter(jack_port_t* port, const std::type_info& dst_type, const bool init_output_silence)
+{
+    if(dst_type == (typeid(jack_default_audio_sample_t))) {
+        return new ForwardJackPortConverter(port);
+    }
+    else if(dst_type == (typeid(int32_t))) {
+        return new IntegerJackPortConverter(sample_move_dS_s32,
+                                            sample_move_d32_sS, sizeof(int32_t),
+                                            port);
+    }
+    else if(dst_type == (typeid(int16_t))) {
+        return new IntegerJackPortConverter(sample_move_dS_s16,
+                                            sample_move_d16_sS,  sizeof(int16_t),
+                                            port);
+    }
+    else {
+        jack_error("jack_port_create_converter called with dst_type that is not supported");
+        return NULL;
+    }
+}

--- a/common/JackServerGlobals.cpp
+++ b/common/JackServerGlobals.cpp
@@ -37,6 +37,7 @@ std::map<std::string, int> JackServerGlobals::fInternalsList;
 bool (* JackServerGlobals::on_device_acquire)(const char * device_name) = NULL;
 void (* JackServerGlobals::on_device_release)(const char * device_name) = NULL;
 void (* JackServerGlobals::on_device_reservation_loop)(void) = NULL;
+void (* JackServerGlobals::on_failure)() = NULL;
 
 int JackServerGlobals::Start(const char* server_name,
                              jack_driver_desc_t* driver_desc,

--- a/common/JackServerGlobals.h
+++ b/common/JackServerGlobals.h
@@ -45,6 +45,7 @@ struct SERVER_EXPORT JackServerGlobals
     static bool (* on_device_acquire)(const char* device_name);
     static void (* on_device_release)(const char* device_name);
     static void (* on_device_reservation_loop)(void);
+    static void (* on_failure)(); /* Optional callback to be called from any thread on failure */
 
     JackServerGlobals();
     ~JackServerGlobals();

--- a/common/jack/format_converter.h
+++ b/common/jack/format_converter.h
@@ -1,0 +1,62 @@
+/*
+  Copyright (C) 2019 Laxmi Devi <laxmi.devi@in.bosch.com>
+  Copyright (C) 2019 Timo Wischer <twischer@de.adit-jv.com>
+
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __jack_format_converter_h__
+#define __jack_format_converter_h__
+
+#include <typeinfo>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <jack/weakmacros.h>
+
+
+class IJackPortConverter {
+
+    public:
+
+        virtual void* get(jack_nframes_t frames) = 0;
+        virtual void set(void* buf, jack_nframes_t frames) = 0;
+};
+
+/**
+ * This returns a pointer to the instance of the object IJackPortConverter based
+ * on the dst_type. Applications can use the get() and set()
+ * of this object to get and set the pointers to the memory area associated with the specified port.
+ * Currently Jack only supports Float, int32_t and int16_t.
+ *
+ * @param port jack_port_t pointer.
+ * @param dst_type type required by client.
+ * @param init_output_silence if true, jack will initialize the output port with silence
+ *
+ * @return ptr to IJackPortConverter on success, otherwise NULL if dst_type is not supported.
+ */
+
+IJackPortConverter* jack_port_create_converter(jack_port_t* port, const std::type_info& dst_type, const bool init_output_silence=true) JACK_OPTIONAL_WEAK_EXPORT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __jack_format_converter_h__

--- a/common/jack/systemdeps.h
+++ b/common/jack/systemdeps.h
@@ -107,7 +107,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #endif /* _WIN32 && !__CYGWIN__ && !GNU_WIN32 */
 
-#if defined(__APPLE__) || defined(__linux__) || defined(__sun__) || defined(sun) || defined(__unix__) || defined(__CYGWIN__) || defined(GNU_WIN32)
+#if defined(__APPLE__) || defined(__linux__) || defined(__sun__) || defined(sun) || defined(__unix__) || defined(__CYGWIN__) || defined(GNU_WIN32) || defined(__QNXNTO__)
 
     #if defined(__CYGWIN__) || defined(GNU_WIN32)
         #include <stdint.h>

--- a/common/memops.c
+++ b/common/memops.c
@@ -137,17 +137,6 @@
 		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
 	}
 
-/* call this when "s" has already been scaled (e.g. when dithering)
- */
-
-#define float_24u32_scaled(s, d)\
-        if ((s) <= SAMPLE_24BIT_MIN_F) {\
-		(d) = SAMPLE_24BIT_MIN << 8;\
-	} else if ((s) >= SAMPLE_24BIT_MAX_F) {	\
-		(d) = SAMPLE_24BIT_MAX << 8;		\
-	} else {\
-		(d) = f_round ((s)) << 8; \
-	}
 
 #define float_24(s, d) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
@@ -156,18 +145,6 @@
 		(d) = SAMPLE_24BIT_MAX;\
 	} else {\
 		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
-	}
-
-/* call this when "s" has already been scaled (e.g. when dithering)
- */
-
-#define float_24_scaled(s, d)\
-        if ((s) <= SAMPLE_24BIT_MIN_F) {\
-		(d) = SAMPLE_24BIT_MIN;\
-	} else if ((s) >= SAMPLE_24BIT_MAX_F) {	\
-		(d) = SAMPLE_24BIT_MAX;		\
-	} else {\
-		(d) = f_round ((s)); \
 	}
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -73,6 +73,7 @@
    So, for now (October 2008) we use 2^(N-1)-1 as the scaling factor.
 */
 
+#define SAMPLE_32BIT_SCALING  0x7FFFFFFF
 #define SAMPLE_24BIT_SCALING  8388607
 #define SAMPLE_16BIT_SCALING  32767
 
@@ -240,6 +241,8 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
    
    S      - sample is a jack_default_audio_sample_t, currently (October 2008) a 32 bit floating point value
    Ss     - like S but reverse endian from the host CPU
+   32     - sample is an signed 32 bit integer value
+   32s    - like 32 but reverse endian from the host CPU
    32u24  - sample is an signed 32 bit integer value, but data is in lower 24 bits only
    32u24s - like 32u24 but reverse endian from the host CPU
    24     - sample is an signed 24 bit integer value
@@ -306,6 +309,11 @@ static inline void sample_move_d32scal_sSs (char *dst, jack_default_audio_sample
 void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {
 	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
+void sample_move_d32_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_32BIT_SCALING);
 }
 
 
@@ -396,6 +404,11 @@ static inline void sample_move_d32scal_sS (char *dst, jack_default_audio_sample_
 void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {
 	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
+void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_32BIT_SCALING);
 }
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -83,8 +83,6 @@
 
 #define SAMPLE_24BIT_MAX  8388607  
 #define SAMPLE_24BIT_MIN  -8388607 
-#define SAMPLE_24BIT_MAX_F  8388607.0f  
-#define SAMPLE_24BIT_MIN_F  -8388607.0f 
 
 #define SAMPLE_16BIT_MAX  32767
 #define SAMPLE_16BIT_MIN  -32767
@@ -128,13 +126,13 @@
 	        (d) = f_round ((s));\
 	}
 
-#define float_24u32(s, d) \
+#define float_32(s, d, scale) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
-		(d) = SAMPLE_24BIT_MIN;\
+		(d) = -scale;\
 	} else if ((s) >= NORMALIZED_FLOAT_MAX) {\
-		(d) = SAMPLE_24BIT_MAX;\
+		(d) = scale;\
 	} else {\
-		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
+		(d) = f_round ((s) * scale);\
 	}
 
 
@@ -182,13 +180,13 @@ static inline float32x4_t clip(float32x4_t s, float32x4_t min, float32x4_t max)
 	return vminq_f32(max, vmaxq_f32(s, min));
 }
 
-static inline int32x4_t float_24_neon(float32x4_t s)
+static inline int32x4_t float_32_neon(float32x4_t s, const int32_t scaling)
 {
 	const float32x4_t upper_bound = vdupq_n_f32(NORMALIZED_FLOAT_MAX);
 	const float32x4_t lower_bound = vdupq_n_f32(NORMALIZED_FLOAT_MIN);
 
 	float32x4_t clipped = clip(s, lower_bound, upper_bound);
-	float32x4_t scaled = vmulq_f32(clipped, vdupq_n_f32(SAMPLE_24BIT_SCALING));
+	float32x4_t scaled = vmulq_f32(clipped, vdupq_n_f32(scaling));
 	return vcvtq_s32_f32(scaled);
 }
 
@@ -256,7 +254,7 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
 
 /* functions for native integer sample data */
 
-void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+static inline void sample_move_d32scal_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state, const int32_t scaling)
 {
 #if defined (__ARM_NEON__) || defined (__ARM_NEON)
 	unsigned long unrolled = nsamples / 4;
@@ -264,7 +262,7 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, scaling);
 		converted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(converted)));
 
 		switch(dst_skip) {
@@ -287,7 +285,7 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 
 	while (nsamples--) {
 
-		float_24u32 (*src, z);
+		float_32 (*src, z, scaling);
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 		dst[0]=(char)(z>>24);
@@ -303,12 +301,18 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 		dst += dst_skip;
 		src++;
 	}
-}	
+}
 
-void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sSs (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
+
+static inline void sample_move_d32scal_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state, const int32_t scaling)
 {
 #if defined (__SSE2__) && !defined (__sun__)
-	__m128 int_max = _mm_set1_ps(SAMPLE_24BIT_MAX_F);
+	__m128 int_max = _mm_set1_ps(scaling);
 	__m128 int_min = _mm_sub_ps(_mm_setzero_ps(), int_max);
 	__m128 factor = int_max;
 
@@ -361,7 +365,7 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, scaling);
 
 		switch(dst_skip) {
 			case 4:
@@ -382,12 +386,18 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 
 #if !defined (__SSE2__)
 	while (nsamples--) {
-		float_24u32 (*src, *((int32_t*) dst));
+		float_32 (*src, *((int32_t*) dst), scaling);
 		dst += dst_skip;
 		src++;
 	}
 #endif
-}	
+}
+
+void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
+{
+	sample_move_d32scal_sS (dst, src, nsamples, dst_skip, state, SAMPLE_24BIT_SCALING);
+}
+
 
 void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
@@ -533,7 +543,7 @@ void sample_move_d24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned 
 		int i;
 		int32_t z[4];
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, SAMPLE_24BIT_SCALING);
 		converted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(converted)));
 		vst1q_s32(z, converted);
 
@@ -604,7 +614,7 @@ void sample_move_d24_sS (char *dst, jack_default_audio_sample_t *src, unsigned l
 		int i;
 		int32_t z[4];
 		float32x4_t samples = vld1q_f32(src);
-		int32x4_t converted = float_24_neon(samples);
+		int32x4_t converted = float_32_neon(samples, SAMPLE_24BIT_SCALING);
 		vst1q_s32(z, converted);
 
 		for (i = 0; i != 4; ++i) {

--- a/common/memops.c
+++ b/common/memops.c
@@ -489,6 +489,11 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, true);
 }
 
+void sample_move_dS_s32s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+{
+	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, false);
+}
+
 
 static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
 {
@@ -572,6 +577,11 @@ static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst,
 void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
 	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, true);
+}
+
+void sample_move_dS_s32 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+{
+	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, false);
 }
 
 

--- a/common/memops.c
+++ b/common/memops.c
@@ -29,6 +29,7 @@
 #include <memory.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <limits.h>
 #ifdef __linux__
 #include <endian.h>
@@ -412,9 +413,10 @@ void sample_move_d32_sS (char *dst, jack_default_audio_sample_t *src, unsigned l
 }
 
 
-void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+static inline void sample_move_dS_s32s_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
 {
-	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
+	const jack_default_audio_sample_t scaling_divisor = do_signext ? (SAMPLE_24BIT_SCALING << 8) : SAMPLE_32BIT_SCALING;
+	const jack_default_audio_sample_t scaling = 1.0 / scaling_divisor;
 
 #if defined (__ARM_NEON__) || defined (__ARM_NEON)
 	float32x4_t factor = vdupq_n_f32(scaling);
@@ -437,9 +439,11 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 				break;
 		}
 		src128 = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(src128)));
-		/* sign extension - left shift will be reverted by scaling */
-		int32x4_t shifted = vshlq_n_s32(src128, 8);
-		float32x4_t as_float = vcvtq_f32_s32(shifted);
+		if (do_signext) {
+			/* sign extension - left shift will be reverted by scaling */
+			src128 = vshlq_n_s32(src128, 8);
+		}
+		float32x4_t as_float = vcvtq_f32_s32(src128);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
 
@@ -470,16 +474,26 @@ void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsign
 		x <<= 8;
 		x |= (unsigned char)(src[0]);
 #endif
-		/* sign extension - left shift will be reverted by scaling */
-		*dst = (x << 8) * scaling;
+		if (do_signext) {
+			/* sign extension - left shift will be reverted by scaling */
+			x <<= 8;
+		}
+		*dst = x * scaling;
 		dst++;
 		src += src_skip;
 	}
 }	
 
-void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+void sample_move_dS_s32u24s (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
 {
-	const jack_default_audio_sample_t scaling = 1.0 / (SAMPLE_24BIT_SCALING << 8);
+	sample_move_dS_s32s_signext (dst, src, nsamples, src_skip, true);
+}
+
+
+static inline void sample_move_dS_s32_signext (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip, const bool do_signext)
+{
+	const jack_default_audio_sample_t scaling_divisor = do_signext ? (SAMPLE_24BIT_SCALING << 8) : SAMPLE_32BIT_SCALING;
+	const jack_default_audio_sample_t scaling = 1.0 / scaling_divisor;
 
 #if defined (__SSE2__) && !defined (__sun__)
 	unsigned long unrolled = nsamples / 4;
@@ -495,11 +509,12 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 		int i4 = *((int *) src);
 		src+= src_skip;
 
-		__m128i src = _mm_set_epi32(i4, i3, i2, i1);
-		/* sign extension - left shift will be reverted by scaling */
-		__m128i shifted = _mm_slli_epi32(src, 8);
-
-		__m128 as_float = _mm_cvtepi32_ps(shifted);
+		__m128i src128 = _mm_set_epi32(i4, i3, i2, i1);
+		if (do_signext) {
+			/* sign extension - left shift will be reverted by scaling */
+			src128 = _mm_slli_epi32(src128, 8);
+		}
+		__m128 as_float = _mm_cvtepi32_ps(src128);
 		__m128 divided = _mm_mul_ps(as_float, factor);
 
 		_mm_storeu_ps(dst, divided);
@@ -526,9 +541,11 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 				src128 = vld1q_lane_s32((int32_t*)(src+3*src_skip), src128, 3);
 				break;
 		}
-		/* sign extension  - left shift will be reverted by scaling */
-		int32x4_t shifted = vshlq_n_s32(src128, 8);
-		float32x4_t as_float = vcvtq_f32_s32(shifted);
+		if (do_signext) {
+			/* sign extension  - left shift will be reverted by scaling */
+			src128 = vshlq_n_s32(src128, 8);
+		}
+		float32x4_t as_float = vcvtq_f32_s32(src128);
 		float32x4_t divided = vmulq_f32(as_float, factor);
 		vst1q_f32(dst, divided);
 
@@ -541,12 +558,22 @@ void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigne
 	/* ALERT: signed sign-extension portability !!! */
 
 	while (nsamples--) {
-		/* sign extension  - left shift will be reverted by scaling */
-		*dst = (*((int *) src) << 8) * scaling;
+		int src32 = *((int *) src);
+		if (do_signext) {
+			/* sign extension  - left shift will be reverted by scaling */
+			src32 <<= 8;
+		}
+		*dst = src32 * scaling;
 		dst++;
 		src += src_skip;
 	}
 }	
+
+void sample_move_dS_s32u24 (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip)
+{
+	sample_move_dS_s32_signext (dst, src, nsamples, src_skip, true);
+}
+
 
 void sample_move_d24_sSs (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state)
 {

--- a/common/memops.c
+++ b/common/memops.c
@@ -130,11 +130,11 @@
 
 #define float_24u32(s, d) \
 	if ((s) <= NORMALIZED_FLOAT_MIN) {\
-		(d) = SAMPLE_24BIT_MIN << 8;\
+		(d) = SAMPLE_24BIT_MIN;\
 	} else if ((s) >= NORMALIZED_FLOAT_MAX) {\
-		(d) = SAMPLE_24BIT_MAX << 8;\
+		(d) = SAMPLE_24BIT_MAX;\
 	} else {\
-		(d) = f_round ((s) * SAMPLE_24BIT_SCALING) << 8;\
+		(d) = f_round ((s) * SAMPLE_24BIT_SCALING);\
 	}
 
 /* call this when "s" has already been scaled (e.g. when dithering)
@@ -265,7 +265,7 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
    
    S      - sample is a jack_default_audio_sample_t, currently (October 2008) a 32 bit floating point value
    Ss     - like S but reverse endian from the host CPU
-   32u24  - sample is an signed 32 bit integer value, but data is in upper 24 bits only
+   32u24  - sample is an signed 32 bit integer value, but data is in lower 24 bits only
    32u24s - like 32u24 but reverse endian from the host CPU
    24     - sample is an signed 24 bit integer value
    24s    - like 24 but reverse endian from the host CPU
@@ -288,18 +288,17 @@ void sample_move_d32u24_sSs (char *dst, jack_default_audio_sample_t *src, unsign
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
 		int32x4_t converted = float_24_neon(samples);
-		int32x4_t shifted = vshlq_n_s32(converted, 8);
-		shifted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(shifted)));
+		converted = vreinterpretq_s32_u8(vrev32q_u8(vreinterpretq_u8_s32(converted)));
 
 		switch(dst_skip) {
 			case 4:
-				vst1q_s32((int32_t*)dst, shifted);
+				vst1q_s32((int32_t*)dst, converted);
 				break;
 			default:
-				vst1q_lane_s32((int32_t*)(dst),            shifted, 0);
-				vst1q_lane_s32((int32_t*)(dst+dst_skip),   shifted, 1);
-				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), shifted, 2);
-                vst1q_lane_s32((int32_t*)(dst+3*dst_skip), shifted, 3);
+				vst1q_lane_s32((int32_t*)(dst),            converted, 0);
+				vst1q_lane_s32((int32_t*)(dst+dst_skip),   converted, 1);
+				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), converted, 2);
+				vst1q_lane_s32((int32_t*)(dst+3*dst_skip), converted, 3);
 				break;
 		}
 		dst += 4*dst_skip;
@@ -345,19 +344,18 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 		__m128 clipped = clip(scaled, int_min, int_max);
 
 		__m128i y = _mm_cvttps_epi32(clipped);
-		__m128i shifted = _mm_slli_epi32(y, 8);
 
 #ifdef __SSE4_1__
-		*(int32_t*)dst              = _mm_extract_epi32(shifted, 0);
-		*(int32_t*)(dst+dst_skip)   = _mm_extract_epi32(shifted, 1);
-		*(int32_t*)(dst+2*dst_skip) = _mm_extract_epi32(shifted, 2);
-		*(int32_t*)(dst+3*dst_skip) = _mm_extract_epi32(shifted, 3);
+		*(int32_t*)dst              = _mm_extract_epi32(y, 0);
+		*(int32_t*)(dst+dst_skip)   = _mm_extract_epi32(y, 1);
+		*(int32_t*)(dst+2*dst_skip) = _mm_extract_epi32(y, 2);
+		*(int32_t*)(dst+3*dst_skip) = _mm_extract_epi32(y, 3);
 #else
-		__m128i shuffled1 = _mm_shuffle_epi32(shifted, _MM_SHUFFLE(0, 3, 2, 1));
-		__m128i shuffled2 = _mm_shuffle_epi32(shifted, _MM_SHUFFLE(1, 0, 3, 2));
-		__m128i shuffled3 = _mm_shuffle_epi32(shifted, _MM_SHUFFLE(2, 1, 0, 3));
+		__m128i shuffled1 = _mm_shuffle_epi32(y, _MM_SHUFFLE(0, 3, 2, 1));
+		__m128i shuffled2 = _mm_shuffle_epi32(y, _MM_SHUFFLE(1, 0, 3, 2));
+		__m128i shuffled3 = _mm_shuffle_epi32(y, _MM_SHUFFLE(2, 1, 0, 3));
 
-		_mm_store_ss((float*)dst, (__m128)shifted);
+		_mm_store_ss((float*)dst, (__m128)y);
 
 		_mm_store_ss((float*)(dst+dst_skip), (__m128)shuffled1);
 		_mm_store_ss((float*)(dst+2*dst_skip), (__m128)shuffled2);
@@ -374,7 +372,7 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 		__m128 clipped = _mm_min_ss(int_max, _mm_max_ss(scaled, int_min));
 
 		int y = _mm_cvttss_si32(clipped);
-		*((int *) dst) = y<<8;
+		*((int *) dst) = y;
 
 		dst += dst_skip;
 		src++;
@@ -387,17 +385,16 @@ void sample_move_d32u24_sS (char *dst, jack_default_audio_sample_t *src, unsigne
 	while (unrolled--) {
 		float32x4_t samples = vld1q_f32(src);
 		int32x4_t converted = float_24_neon(samples);
-		int32x4_t shifted = vshlq_n_s32(converted, 8);
 
 		switch(dst_skip) {
 			case 4:
-				vst1q_s32((int32_t*)dst, shifted);
+				vst1q_s32((int32_t*)dst, converted);
 				break;
 			default:
-				vst1q_lane_s32((int32_t*)(dst),            shifted, 0);
-				vst1q_lane_s32((int32_t*)(dst+dst_skip),   shifted, 1);
-				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), shifted, 2);
-                vst1q_lane_s32((int32_t*)(dst+3*dst_skip), shifted, 3);
+				vst1q_lane_s32((int32_t*)(dst),            converted, 0);
+				vst1q_lane_s32((int32_t*)(dst+dst_skip),   converted, 1);
+				vst1q_lane_s32((int32_t*)(dst+2*dst_skip), converted, 2);
+				vst1q_lane_s32((int32_t*)(dst+3*dst_skip), converted, 3);
 				break;
 		}
 		dst += 4*dst_skip;

--- a/common/memops.h
+++ b/common/memops.h
@@ -53,6 +53,8 @@ void sample_move_floatLE_sSs (jack_default_audio_sample_t *dst, char *src, unsig
 void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 
 /* integer functions */
+void sample_move_d32_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
+void sample_move_d32_sS              (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sSs          (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sS           (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d24_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);

--- a/common/memops.h
+++ b/common/memops.h
@@ -81,6 +81,8 @@ void sample_move_dither_tri_d16_sS        (char *dst, jack_default_audio_sample_
 void sample_move_dither_shaped_d16_sSs    (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_dither_shaped_d16_sS     (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 
+void sample_move_dS_s32s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
+void sample_move_dS_s32              (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24s          (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24           (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s24s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);

--- a/common/netjack_packet.c
+++ b/common/netjack_packet.c
@@ -428,7 +428,9 @@ netjack_poll (int sockfd, int timeout)
 
     action.sa_handler = SIG_DFL;
     action.sa_mask = sigmask;
+#ifndef __QNXNTO__
     action.sa_flags = SA_RESTART;
+#endif
 
     for (i = 1; i < NSIG; i++)
         if (sigismember (&sigmask, i))

--- a/common/shm.c
+++ b/common/shm.c
@@ -49,10 +49,15 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/shm.h>
 #include <sys/sem.h>
 #include <stdlib.h>
 #include "promiscuous.h"
+
+#ifdef __QNXNTO__
+#include <sys/mman.h>
+#else
+#include <sys/shm.h>
+#endif
 
 #endif
 

--- a/common/wscript
+++ b/common/wscript
@@ -69,6 +69,8 @@ def build(bld):
         'JackTools.cpp',
         'JackMessageBuffer.cpp',
         'JackEngineProfiling.cpp',
+        'memops.c',
+        'JackFormatConverter.cpp'
         ]
 
     includes = ['.', './jack']

--- a/common/wscript
+++ b/common/wscript
@@ -69,7 +69,6 @@ def build(bld):
         'JackTools.cpp',
         'JackMessageBuffer.cpp',
         'JackEngineProfiling.cpp',
-        'memops.c',
         'JackFormatConverter.cpp'
         ]
 

--- a/common/wscript
+++ b/common/wscript
@@ -28,6 +28,8 @@ def create_jack_process_obj(bld, target, sources, uselib = None, framework = Non
         env_includes = ['../macosx', '../posix', '../macosx/coreaudio']
     if bld.env['IS_LINUX']:
         env_includes = ['../linux', '../posix', '../linux/alsa']
+    if bld.env['IS_QNX']:
+        env_includes = ['../qnx', '../posix']
     if bld.env['IS_SUN']:
         env_includes = ['../solaris', '../posix', '../solaris/oss']
     if bld.env['IS_WINDOWS']:
@@ -36,7 +38,7 @@ def create_jack_process_obj(bld, target, sources, uselib = None, framework = Non
     process.name     = target
     process.target   = target
     process.source   = sources
-    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX'] or bld.env['IS_QNX']:
         process.env.append_value('CPPFLAGS', '-fvisibility=hidden')
     process.install_path = '${ADDON_DIR}/'
     process.use = [uselib.name]
@@ -91,6 +93,22 @@ def build(bld):
         includes = ['../linux', '../posix'] + includes
         uselib.append('RT')
         uselib.append('DL')
+
+    if bld.env['IS_QNX']:
+        common_libsources += [
+            'JackDebugClient.cpp',
+            'timestamps.c',
+            'promiscuous.c',
+            '../posix/JackPosixThread.cpp',
+            '../posix/JackPosixProcessSync.cpp',
+            '../posix/JackPosixMutex.cpp',
+            '../posix/JackSocket.cpp',
+            '../posix/JackFifo.cpp',
+            '../linux/JackLinuxTime.c',
+            ]
+        includes = ['../qnx', '../posix'] + includes
+        uselib.append('SOCKET')
+        # libdl and librt is included in libc in QNX
 
     if bld.env['IS_SUN']:
         common_libsources += [
@@ -159,7 +177,7 @@ def build(bld):
         'JackMetadata.cpp',
         ]
 
-    if bld.env['IS_LINUX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_QNX']:
         clientlib.source += [
             '../posix/JackSocketClientChannel.cpp',
             '../posix/JackPosixServerLaunch.cpp',
@@ -187,7 +205,7 @@ def build(bld):
 
     clientlib.vnum = bld.env['JACK_API_VERSION']
 
-    if bld.env['IS_LINUX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_QNX']:
         clientlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
     if bld.env['IS_MACOSX']:
@@ -253,7 +271,7 @@ def build(bld):
         'JackMetadata.cpp',
         ]
 
-    if bld.env['IS_LINUX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_QNX']:
         serverlib.source += [
             '../posix/JackSocketServerChannel.cpp',
             '../posix/JackSocketNotifyChannel.cpp',
@@ -289,7 +307,7 @@ def build(bld):
 
     serverlib.vnum = bld.env['JACK_API_VERSION']
 
-    if bld.env['IS_LINUX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_QNX']:
         serverlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
     if bld.env['IS_MACOSX']:
@@ -312,7 +330,7 @@ def build(bld):
              netlib.env['cxxshlib_PATTERN'] = 'lib%s.dll'
              netlib.install_path = '${BINDIR}'
              netlib.use += ['WS2_32', 'WINMM']
-        elif bld.env['IS_MACOSX']:
+        elif bld.env['IS_MACOSX'] or bld.env['IS_QNX']:
              netlib.install_path = '${LIBDIR}'
         else:
              netlib.use += ['RT']
@@ -328,7 +346,7 @@ def build(bld):
             'JackGlobals.cpp',
             'ringbuffer.c']
 
-        if bld.env['IS_LINUX']:
+        if bld.env['IS_LINUX'] or bld.env['IS_QNX']:
             netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../linux/JackLinuxTime.c']
             netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 

--- a/example-clients/alsa_in.c
+++ b/example-clients/alsa_in.c
@@ -95,9 +95,9 @@ typedef struct alsa_format {
 
 alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
-	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
+	{ SND_PCM_FORMAT_S32, 4, sample_move_d32_sS, sample_move_dS_s32, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/example-clients/alsa_out.c
+++ b/example-clients/alsa_out.c
@@ -96,9 +96,9 @@ typedef struct alsa_format {
 
 alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
-	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
+	{ SND_PCM_FORMAT_S32, 4, sample_move_d32_sS, sample_move_dS_s32, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/example-clients/inprocess_s32.cpp
+++ b/example-clients/inprocess_s32.cpp
@@ -1,0 +1,135 @@
+/** @file inprocess_s32.cpp
+ *
+ * @brief This demonstrates the basic concepts for writing a client
+ * that runs within the JACK server process for s32 format.
+ *
+ * For the sake of example, a port_converter_pair_t is allocated in
+ * jack_initialize(), passed to inprocess() as an argument, then freed
+ * in jack_finish().
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <memory.h>
+#include <typeinfo>
+#include <jack/jack.h>
+#include <jack/format_converter.h>
+
+/**
+ * For the sake of example, an instance of this struct is allocated in
+ * jack_initialize(), passed to inprocess() as an argument, then freed
+ * in jack_finish().
+ */
+typedef struct {
+	IJackPortConverter* input_port_converter;
+	IJackPortConverter* output_port_converter;
+} port_converter_pair_t;
+
+/**
+ * Called in the realtime thread on every process cycle.  The entry
+ * point name was passed to jack_set_process_callback() from
+ * jack_initialize().  Although this is an internal client, its
+ * process() interface is identical to @ref simple_client.c.
+ *
+ * @return 0 if successful; otherwise jack_finish() will be called and
+ * the client terminated immediately.
+ */
+int
+inprocess (jack_nframes_t nframes, void *arg)
+{
+	port_converter_pair_t *pp = (port_converter_pair_t *)arg;
+	int32_t *in_buffer;
+	int32_t *out_buffer;
+
+	in_buffer = (int32_t *) pp->input_port_converter->get(nframes);
+	out_buffer = (int32_t *) pp->output_port_converter->get(nframes);
+
+	/* This memcpy needs to be replaced with the actual processing */
+	memcpy (out_buffer, in_buffer, sizeof(int32_t) * nframes);
+
+	pp->output_port_converter->set(out_buffer, nframes);
+
+	return 0;
+}
+
+/**
+ * This required entry point is called after the client is loaded by
+ * jack_internal_client_load().
+ *
+ * @param client pointer to JACK client structure.
+ * @param load_init character string passed to the load operation.
+ *
+ * @return 0 if successful; otherwise jack_finish() will be called and
+ * the client terminated immediately.
+ */
+extern "C" int
+jack_initialize (jack_client_t *client, const char *load_init)
+{
+	jack_port_t *input_port;
+	jack_port_t *output_port;
+
+	port_converter_pair_t *pp = (port_converter_pair_t *) malloc (sizeof (port_converter_pair_t));
+	const char **ports;
+
+	if (pp == NULL)
+		return 1;		/* heap exhausted */
+
+	jack_set_process_callback (client, inprocess, pp);
+
+	/* create a pair of ports */
+	input_port = jack_port_register (client, "input",
+					     JACK_DEFAULT_AUDIO_TYPE,
+					     JackPortIsInput, 0);
+	output_port = jack_port_register (client, "output",
+					      JACK_DEFAULT_AUDIO_TYPE,
+					      JackPortIsOutput, 0);
+
+	pp->input_port_converter = jack_port_create_converter(input_port, typeid(int32_t), false);
+	pp->output_port_converter = jack_port_create_converter(output_port, typeid(int32_t), false);
+
+	/* join the process() cycle */
+	jack_activate (client);
+
+	ports = jack_get_ports (client, NULL, NULL,
+				JackPortIsPhysical|JackPortIsOutput);
+	if (ports == NULL) {
+		fprintf(stderr, "no physical capture ports\n");
+		return 1;		/* terminate client */
+	}
+
+	if (jack_connect (client, ports[0], jack_port_name (input_port))) {
+		fprintf (stderr, "cannot connect input ports\n");
+	}
+
+	jack_free (ports);
+
+	ports = jack_get_ports (client, NULL, NULL,
+				JackPortIsPhysical|JackPortIsInput);
+	if (ports == NULL) {
+		fprintf(stderr, "no physical playback ports\n");
+		return 1;		/* terminate client */
+	}
+
+	if (jack_connect (client, jack_port_name (output_port), ports[0])) {
+		fprintf (stderr, "cannot connect output ports\n");
+	}
+
+	jack_free (ports);
+
+	return 0;			/* success */
+}
+
+/**
+ * This required entry point is called immediately before the client
+ * is unloaded, which could happen due to a call to
+ * jack_internal_client_unload(), or a nonzero return from either
+ * jack_initialize() or inprocess().
+ *
+ * @param arg the same parameter provided to inprocess().
+ */
+extern "C" void
+jack_finish (void *arg)
+{
+	if (arg)
+		free ((port_converter_pair_t *) arg);
+}

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -35,6 +35,7 @@ example_programs = {
 
 example_libs = {
     'inprocess' : 'inprocess.c',
+    'inprocess_s32' : 'inprocess_s32.cpp',
     }
 
 def configure(conf):
@@ -138,9 +139,10 @@ def build(bld):
         prog.target = 'alsa_out'
 
     for example_lib, example_lib_source in list(example_libs.items()):
-        lib = bld(features = 'c cshlib')
+        lib = bld(features = 'c cxx cshlib cxxshlib')
         if not bld.env['IS_WINDOWS']:
             lib.env['cshlib_PATTERN'] = '%s.so'
+            lib.env['cxxshlib_PATTERN'] = '%s.so'
         lib.includes = os_incdir + ['../common/jack', '../common']
         lib.target = example_lib
         lib.source = example_lib_source

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -49,6 +49,8 @@ def build(bld):
         os_incdir = ['../linux', '../posix']
     if bld.env['IS_MACOSX']:
         os_incdir = ['../macosx', '../posix']
+    if bld.env['IS_QNX']:
+        os_incdir = ['../qnx', '../posix']
     if bld.env['IS_SUN']:
         os_incdir = ['../solaris', '../posix']
     if bld.env['IS_WINDOWS']:
@@ -76,7 +78,7 @@ def build(bld):
         prog.use = use
         if bld.env['IS_LINUX']:
             prog.use += ['RT', 'M']
-        if bld.env['IS_SUN']:
+        if bld.env['IS_SUN'] or bld.env['IS_QNX']:
             prog.use += ['M']
         #prog.cflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
         #prog.cxxflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
@@ -90,7 +92,7 @@ def build(bld):
         prog.use = ['clientlib']
         if bld.env['IS_LINUX']:
             prog.use += ['RT', 'READLINE']
-        if bld.env['IS_MACOSX']:
+        if bld.env['IS_MACOSX'] or bld.env['IS_QNX']:
             prog.use += ['READLINE']
         if bld.env['IS_WINDOWS']:
             prog.use += ['READLINE']
@@ -101,7 +103,7 @@ def build(bld):
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = 'capture_client.c'
         prog.use = ['clientlib']
-        if bld.env['IS_MACOSX']:
+        if bld.env['IS_MACOSX'] or bld.env['IS_QNX']:
             prog.use += ['SNDFILE']
         if bld.env['IS_LINUX']:
             prog.use += ['RT', 'SNDFILE']
@@ -111,7 +113,7 @@ def build(bld):
             prog.uselib = ['SNDFILE']
         prog.target = 'jack_rec'
 
-    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX']:
+    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX'] or bld.env['IS_QNX']:
         prog = bld(features = 'c cprogram')
         prog.includes = os_incdir + ['.', '..', '../common/jack', '../common']
         prog.source = ['netsource.c', '../common/netjack_packet.c']

--- a/linux/alsa/JackAlsaDriver.cpp
+++ b/linux/alsa/JackAlsaDriver.cpp
@@ -204,6 +204,8 @@ int JackAlsaDriver::Detach()
     return JackAudioDriver::Detach();
 }
 
+#ifndef __QNXNTO__
+/* del6kor : ToDo : why is strndup not avaiable despite the indludes*/
 extern "C" char* get_control_device_name(const char * device_name)
 {
     char * ctl_name;
@@ -233,7 +235,10 @@ extern "C" char* get_control_device_name(const char * device_name)
 
     return ctl_name;
 }
+#endif
 
+#ifndef __QNXNTO__
+/* del6kor : ToDo : is this needed ? */
 static int card_to_num(const char* device)
 {
     int err;
@@ -273,6 +278,7 @@ free:
 fail:
     return i;
 }
+#endif
 
 int JackAlsaDriver::Open(jack_nframes_t nframes,
                          jack_nframes_t user_nperiods,
@@ -301,6 +307,8 @@ int JackAlsaDriver::Open(jack_nframes_t nframes,
     }
 
     alsa_midi_t *midi = 0;
+
+#ifndef __QNXNTO__
 #ifndef __ANDROID__
     if (strcmp(midi_driver_name, "seq") == 0)
         midi = alsa_seqmidi_new((jack_client_t*)this, 0);
@@ -333,6 +341,7 @@ int JackAlsaDriver::Open(jack_nframes_t nframes,
             }
         }
     }
+#endif
 
     fDriver = alsa_driver_new ((char*)"alsa_pcm", (char*)playback_driver_name, (char*)capture_driver_name,
                                NULL,
@@ -356,12 +365,14 @@ int JackAlsaDriver::Open(jack_nframes_t nframes,
         // ALSA driver may have changed the in/out values
         fCaptureChannels = ((alsa_driver_t *)fDriver)->capture_nchannels;
         fPlaybackChannels = ((alsa_driver_t *)fDriver)->playback_nchannels;
+#ifndef __QNXNTO__
         if (JackServerGlobals::on_device_reservation_loop != NULL) {
             device_reservation_loop_running = true;
             if (JackPosixThread::StartImp(&fReservationLoopThread, 0, 0, on_device_reservation_loop, NULL) != 0) {
                 device_reservation_loop_running = false;
             }
         }
+#endif
         return 0;
     } else {
         Close();
@@ -378,6 +389,7 @@ int JackAlsaDriver::Close()
         alsa_driver_delete((alsa_driver_t*)fDriver);
     }
 
+#ifndef __QNXNTO__
     if (device_reservation_loop_running) {
         device_reservation_loop_running = false;
         JackPosixThread::StopImp(fReservationLoopThread);
@@ -398,6 +410,7 @@ int JackAlsaDriver::Close()
             JackServerGlobals::on_device_release(audio_name);
         }
     }
+#endif
 
     return res;
 }
@@ -578,6 +591,7 @@ extern "C"
 {
 #endif
 
+#ifndef __QNXNTO__
 static
 jack_driver_param_constraint_desc_t *
 enum_alsa_devices()
@@ -667,6 +681,7 @@ fail:
     jack_constraint_free(constraint_ptr);
     return NULL;
 }
+#endif
 
 static int
 dither_opt (char c, DitherAlgorithm* dither)
@@ -705,11 +720,14 @@ SERVER_EXPORT const jack_driver_desc_t* driver_get_descriptor ()
     desc = jack_driver_descriptor_construct("alsa", JackDriverMaster, "Linux ALSA API based audio backend", &filler);
 
     strcpy(value.str, "hw:0");
+#ifndef __QNXNTO__
 #ifdef __ANDROID__
     jack_driver_descriptor_add_parameter(desc, &filler, "device", 'd', JackDriverParamString, &value, NULL, "ALSA device name", NULL);
 #else
     jack_driver_descriptor_add_parameter(desc, &filler, "device", 'd', JackDriverParamString, &value, enum_alsa_devices(), "ALSA device name", NULL);
 #endif
+#endif
+
 
     strcpy(value.str, "none");
     jack_driver_descriptor_add_parameter(desc, &filler, "capture", 'C', JackDriverParamString, &value, NULL, "Provide capture ports.  Optionally set device", NULL);

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -348,9 +348,19 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 				break;
 
 			case 4: /* NO DITHER */
-				driver->write_via_copy = driver->quirk_bswap?
-					sample_move_d32u24_sSs:
-					sample_move_d32u24_sS;
+				switch (driver->playback_sample_format) {
+				case SND_PCM_FORMAT_S24_LE:
+				case SND_PCM_FORMAT_S24_BE:
+					driver->write_via_copy = driver->quirk_bswap?
+						sample_move_d32u24_sSs:
+						sample_move_d32u24_sS;
+					break;
+				default:
+					driver->write_via_copy = driver->quirk_bswap?
+						sample_move_d32_sSs:
+						sample_move_d32_sS;
+					break;
+				}
 				break;
 
 			default:
@@ -377,9 +387,20 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 					sample_move_dS_s24;
 				break;
 			case 4:
-				driver->read_via_copy = driver->quirk_bswap?
-					sample_move_dS_s32u24s:
-					sample_move_dS_s32u24;
+				switch (driver->playback_sample_format) {
+				case SND_PCM_FORMAT_S24_LE:
+				case SND_PCM_FORMAT_S24_BE:
+					driver->read_via_copy = driver->quirk_bswap?
+						sample_move_dS_s32u24s:
+						sample_move_dS_s32u24;
+					break;
+				default:
+					driver->read_via_copy = driver->quirk_bswap?
+						sample_move_dS_s32s:
+						sample_move_dS_s32;
+					break;
+				}
+
 				break;
 			}
 		}

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -95,6 +95,23 @@ jack_driver_nt_init (jack_driver_nt_t * driver)
     driver->nt_run_cycle = 0;
 }
 
+static int
+alsa_driver_prepare (snd_pcm_t *handle, int is_capture)
+{
+	int res = 0;
+
+#ifndef __QNXNTO__
+	res = snd_pcm_prepare (handle);
+#else
+	res = snd_pcm_plugin_prepare(handle, is_capture);
+#endif
+	if (res < 0) {
+		jack_error("error preparing: %s", snd_strerror(res));
+	}
+
+	return res;
+}
+
 static void
 alsa_driver_release_channel_dependent_memory (alsa_driver_t *driver)
 {
@@ -110,6 +127,20 @@ alsa_driver_release_channel_dependent_memory (alsa_driver_t *driver)
 		free (driver->capture_addr);
 		driver->capture_addr = 0;
 	}
+
+#ifdef __QNXNTO__
+	if (driver->playback_areas_ptr) {
+		free(driver->playback_areas_ptr);
+		driver->playback_areas = NULL;
+		driver->playback_areas_ptr = NULL;
+	}
+
+	if (driver->capture_areas_ptr) {
+		free(driver->capture_areas_ptr);
+		driver->capture_areas = NULL;
+		driver->capture_areas_ptr = NULL;
+	}
+#endif
 
 	if (driver->playback_interleave_skip) {
 		free (driver->playback_interleave_skip);
@@ -131,6 +162,8 @@ alsa_driver_release_channel_dependent_memory (alsa_driver_t *driver)
 		driver->dither_state = 0;
 	}
 }
+
+#ifndef __QNXNTO__
 
 static int
 alsa_driver_check_capabilities (alsa_driver_t *driver)
@@ -266,6 +299,7 @@ alsa_driver_hw_specific (alsa_driver_t *driver, int hw_monitoring,
 
 	return 0;
 }
+#endif
 
 static void
 alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
@@ -352,6 +386,120 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 	}
 }
 
+#ifdef __QNXNTO__
+
+static int
+alsa_driver_allocate_buffer(alsa_driver_t *driver, int frames, int channels, bool is_capture)
+{
+	const long ALIGNMENT = 32;
+
+	// TODO driver->playback_sample_bytes
+	char* const fBuffer = malloc(channels * ((sizeof(alsa_driver_default_format_t)) * frames) + ALIGNMENT);
+	if(fBuffer) {
+		/* Provide an 32 byte aligned buffer */
+		char* const aligned_buffer = (char*)((uintptr_t)fBuffer & ~(ALIGNMENT-1)) + ALIGNMENT;
+
+		if(is_capture) {
+			driver->capture_areas_ptr = fBuffer;
+			driver->capture_areas = aligned_buffer;
+		} else {
+			driver->playback_areas_ptr = fBuffer;
+			driver->playback_areas = aligned_buffer;
+		}
+
+		return 0;
+	}
+
+	jack_error ("ALSA: could not allocate audio buffer");
+	alsa_driver_delete(driver);
+	return -1;
+}
+
+static int
+alsa_driver_get_setup (alsa_driver_t *driver, snd_pcm_channel_setup_t *setup, bool is_capture)
+{
+	int err = 0;
+
+	memset(setup, 0, sizeof(*setup));
+	setup->channel = is_capture;
+
+	if(is_capture) {
+		err = snd_pcm_plugin_setup(driver->capture_handle, setup);
+	} else {
+		err = snd_pcm_plugin_setup(driver->playback_handle, setup);
+	}
+	if (err < 0) {
+		jack_error("couldn't get channel setup for %s, err = %s ",
+			   is_capture ? driver->alsa_name_capture : driver->alsa_name_playback,
+			   strerror(err));
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+alsa_driver_configure_stream (alsa_driver_t *driver, char *device_name,
+			      const char *stream_name,
+			      snd_pcm_t *handle,
+			      unsigned int *nperiodsp,
+			      channel_t *nchns,
+			      unsigned long sample_width,
+			      bool is_capture)
+{
+	int err = 0;
+	snd_pcm_channel_info_t ch_info;
+	snd_pcm_channel_params_t ch_params;
+	const unsigned long sample_size = is_capture ? driver->capture_sample_bytes
+	                                             : driver->playback_sample_bytes;
+
+	memset(&ch_info, 0, sizeof(ch_info));
+	/*A pointer to a snd_pcm_channel_info_t structure that snd_pcm_plugin_info() fills in with information about the PCM channel.
+	 * Before calling snd_pcm_plugin_info(), set the info structure's channel member to specify the direction.
+	 * This function sets all the other members.*/
+	ch_info.channel = is_capture;
+	if ((err = snd_pcm_plugin_info(handle, &ch_info)) < 0) {
+		jack_error("couldn't get channel info for %s, %s, err = (%s)", stream_name, device_name,  snd_strerror(err));
+		alsa_driver_delete(driver);
+		return -1;
+	}
+
+	if (!*nchns) {
+		*nchns = ch_info.max_voices;
+	}
+
+	ch_params.mode = SND_PCM_MODE_BLOCK;
+	ch_params.start_mode = SND_PCM_START_GO;
+	ch_params.stop_mode = SND_PCM_STOP_STOP;
+	ch_params.buf.block.frag_size = driver->frames_per_cycle * *nchns * sample_size;
+
+	*nperiodsp = driver->user_nperiods;
+	ch_params.buf.block.frags_min = 1;
+	/* the maximal available periods (-1 due to one period is always processed
+	 * by DMA and therefore not free)
+	 */
+	ch_params.buf.block.frags_max = *nperiodsp - 1;
+	ch_params.format.interleave = 1;
+	ch_params.format.rate = driver->frame_rate;
+	ch_params.format.voices = *nchns;
+	ch_params.channel = is_capture;
+
+	ch_params.format.format = (sample_width == 4) ? SND_PCM_SFMT_S32_LE : SND_PCM_SFMT_S16_LE;
+	/*Set the configurable parameters for a PCM channel*/
+	if ((err = snd_pcm_plugin_params(handle, &ch_params)) < 0) {
+		jack_error("snd_pcm_plugin_params failed for %s %s with err = (%s)", snd_strerror(err), stream_name, device_name);
+		alsa_driver_delete(driver);
+		return -1;
+	}
+
+	/*
+	 * The buffer has to be able to hold a full HW audio buffer
+	 * (periods * period_size) because the silence prefill will fill the
+	 * complete buffer
+	 */
+	return alsa_driver_allocate_buffer(driver, driver->frames_per_cycle * *nperiodsp, *nchns, is_capture);
+}
+#else
 static int
 alsa_driver_configure_stream (alsa_driver_t *driver, char *device_name,
 			      const char *stream_name,
@@ -613,6 +761,58 @@ alsa_driver_configure_stream (alsa_driver_t *driver, char *device_name,
 
 	return 0;
 }
+#endif
+
+#ifdef __QNXNTO__
+static int
+alsa_driver_check_format (unsigned int format)
+{
+#else
+static int
+alsa_driver_check_format (snd_pcm_format_t format)
+{
+#endif
+
+	switch (format) {
+#ifndef __QNXNTO__
+	case SND_PCM_FORMAT_FLOAT_LE:
+	case SND_PCM_FORMAT_S24_3LE:
+	case SND_PCM_FORMAT_S24_3BE:
+	case SND_PCM_FORMAT_S24_LE:
+	case SND_PCM_FORMAT_S24_BE:
+	case SND_PCM_FORMAT_S32_BE:
+	case SND_PCM_FORMAT_S16_BE:
+#endif
+	case SND_PCM_FORMAT_S16_LE:
+	case SND_PCM_FORMAT_S32_LE:
+		break;
+	default:
+		jack_error ("format not supported %d", format);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void
+alsa_driver_set_sample_bytes (alsa_driver_t *driver)
+{
+#ifdef __QNXNTO__
+	driver->playback_sample_bytes =
+		snd_pcm_format_width (driver->playback_sample_format)
+		/ 8;
+	driver->capture_sample_bytes =
+		snd_pcm_format_width (driver->capture_sample_format)
+		/ 8;
+#else
+	driver->playback_sample_bytes =
+		snd_pcm_format_physical_width (driver->playback_sample_format)
+		/ 8;
+	driver->capture_sample_bytes =
+		snd_pcm_format_physical_width (driver->capture_sample_format)
+		/ 8;
+#endif
+}
 
 static int
 alsa_driver_set_parameters (alsa_driver_t *driver,
@@ -620,7 +820,14 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 			    jack_nframes_t user_nperiods,
 			    jack_nframes_t rate)
 {
+#ifdef __QNXNTO__
+	snd_pcm_channel_setup_t c_setup;
+	snd_pcm_channel_setup_t p_setup;
+	jack_nframes_t p_periods = 0;
+	jack_nframes_t c_periods = 0;
+#else
 	int dir;
+#endif
 	snd_pcm_uframes_t p_period_size = 0;
 	snd_pcm_uframes_t c_period_size = 0;
 	channel_t chn;
@@ -637,36 +844,89 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 		 rate, frames_per_cycle, (((float)frames_per_cycle / (float) rate) * 1000.0f), user_nperiods);
 
 	if (driver->capture_handle) {
-		if (alsa_driver_configure_stream (
-			    driver,
-			    driver->alsa_name_capture,
-			    "capture",
-			    driver->capture_handle,
-			    driver->capture_hw_params,
-			    driver->capture_sw_params,
-			    &driver->capture_nperiods,
-			    &driver->capture_nchannels,
-			    driver->capture_sample_bytes)) {
+#ifdef __QNXNTO__
+	    err = alsa_driver_configure_stream (
+		    driver,
+		    driver->alsa_name_capture,
+		    "capture",
+		    driver->capture_handle,
+		    &driver->capture_nperiods,
+		    &driver->capture_nchannels,
+		    driver->capture_sample_bytes,
+		    SND_PCM_CHANNEL_CAPTURE);
+#else
+	    err = alsa_driver_configure_stream (
+		    driver,
+		    driver->alsa_name_capture,
+		    "capture",
+		    driver->capture_handle,
+		    driver->capture_hw_params,
+		    driver->capture_sw_params,
+		    &driver->capture_nperiods,
+		    &driver->capture_nchannels,
+		    driver->capture_sample_bytes);
+#endif
+		if (err) {
 			jack_error ("ALSA: cannot configure capture channel");
 			return -1;
 		}
 	}
 
 	if (driver->playback_handle) {
-		if (alsa_driver_configure_stream (
-			    driver,
-			    driver->alsa_name_playback,
-			    "playback",
-			    driver->playback_handle,
-			    driver->playback_hw_params,
-			    driver->playback_sw_params,
-			    &driver->playback_nperiods,
-			    &driver->playback_nchannels,
-			    driver->playback_sample_bytes)) {
+#ifdef __QNXNTO__
+	    err = alsa_driver_configure_stream (
+		    driver,
+		    driver->alsa_name_playback,
+		    "playback",
+		    driver->playback_handle,
+		    &driver->playback_nperiods,
+		    &driver->playback_nchannels,
+		    driver->playback_sample_bytes,
+		    SND_PCM_CHANNEL_PLAYBACK);
+#else
+	    err = alsa_driver_configure_stream (
+		    driver,
+		    driver->alsa_name_playback,
+		    "playback",
+		    driver->playback_handle,
+		    driver->playback_hw_params,
+		    driver->playback_sw_params,
+		    &driver->playback_nperiods,
+		    &driver->playback_nchannels,
+		    driver->playback_sample_bytes);
+#endif
+		if (err) {
 			jack_error ("ALSA: cannot configure playback channel");
 			return -1;
 		}
 	}
+
+#ifdef __QNXNTO__
+	if (driver->capture_handle) {
+		err = alsa_driver_get_setup(driver, &c_setup, SND_PCM_CHANNEL_CAPTURE);
+		if(err < 0) {
+			return -1;
+		}
+		cr = c_setup.format.rate;
+		c_period_size = c_setup.buf.block.frag_size / driver->capture_nchannels
+		        / driver->capture_sample_bytes;
+		c_periods = c_setup.buf.block.frags;
+		driver->capture_sample_format = c_setup.format.format;
+		driver->capture_interleaved = c_setup.format.interleave;
+	}
+	if (driver->playback_handle) {
+		err = alsa_driver_get_setup(driver, &p_setup, SND_PCM_CHANNEL_PLAYBACK);
+		if(err < 0) {
+			return -1;
+		}
+		pr = p_setup.format.rate;
+		p_period_size = p_setup.buf.block.frag_size  / driver->playback_nchannels
+		        / driver->playback_sample_bytes;
+		p_periods = p_setup.buf.block.frags;
+		driver->playback_sample_format = p_setup.format.format;
+		driver->playback_interleaved = p_setup.format.interleave;
+	}
+#else
 
 	/* check the rate, since that's rather important */
 
@@ -679,6 +939,7 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 		snd_pcm_hw_params_get_rate (driver->capture_hw_params,
 					    &cr, &dir);
 	}
+#endif
 
 	if (driver->capture_handle && driver->playback_handle) {
 		if (cr != pr) {
@@ -716,6 +977,7 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 	/* check the fragment size, since that's non-negotiable */
 
 	if (driver->playback_handle) {
+#ifndef __QNXNTO__
  		snd_pcm_access_t access;
 
  		err = snd_pcm_hw_params_get_period_size (
@@ -728,7 +990,7 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
  		driver->playback_interleaved =
 			(access == SND_PCM_ACCESS_MMAP_INTERLEAVED)
 			|| (access == SND_PCM_ACCESS_MMAP_COMPLEX);
-
+#endif
 		if (p_period_size != driver->frames_per_cycle) {
 			jack_error ("alsa_pcm: requested an interrupt every %"
 				    PRIu32
@@ -736,9 +998,21 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 				    driver->frames_per_cycle, p_period_size);
 			return -1;
 		}
+#ifdef __QNXNTO__
+		if (p_periods != driver->user_nperiods) {
+			jack_error ("alsa_pcm: requested %"
+				    PRIu32
+				    " periods but got %"
+				    PRIu32
+				    " periods for playback",
+				    driver->user_nperiods, p_periods);
+			return -1;
+		}
+#endif
 	}
 
 	if (driver->capture_handle) {
+#ifndef __QNXNTO__
  		snd_pcm_access_t access;
 
  		err = snd_pcm_hw_params_get_period_size (
@@ -751,7 +1025,7 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
  		driver->capture_interleaved =
 			(access == SND_PCM_ACCESS_MMAP_INTERLEAVED)
 			|| (access == SND_PCM_ACCESS_MMAP_COMPLEX);
-
+#endif
 		if (c_period_size != driver->frames_per_cycle) {
 			jack_error ("alsa_pcm: requested an interrupt every %"
 				    PRIu32
@@ -759,56 +1033,44 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 				    driver->frames_per_cycle, p_period_size);
 			return -1;
 		}
+#ifdef __QNXNTO__
+		/* capture buffers can be configured bigger but it should fail
+		 * if they are smaller as expected
+		 */
+		if (c_periods < driver->user_nperiods) {
+			jack_error ("alsa_pcm: requested %"
+				    PRIu32
+				    " periods but got %"
+				    PRIu32
+				    " periods for capture",
+				    driver->user_nperiods, c_periods);
+			return -1;
+		}
+#endif
 	}
 
-	driver->playback_sample_bytes =
-		snd_pcm_format_physical_width (driver->playback_sample_format)
-		/ 8;
-	driver->capture_sample_bytes =
-		snd_pcm_format_physical_width (driver->capture_sample_format)
-		/ 8;
+	alsa_driver_set_sample_bytes(driver);
 
 	if (driver->playback_handle) {
-		switch (driver->playback_sample_format) {
-        case SND_PCM_FORMAT_FLOAT_LE:
-		case SND_PCM_FORMAT_S32_LE:
-		case SND_PCM_FORMAT_S24_3LE:
-		case SND_PCM_FORMAT_S24_3BE:
-		case SND_PCM_FORMAT_S24_LE:
-		case SND_PCM_FORMAT_S24_BE:
-		case SND_PCM_FORMAT_S16_LE:
-		case SND_PCM_FORMAT_S32_BE:
-		case SND_PCM_FORMAT_S16_BE:
-			break;
-
-		default:
+		err = alsa_driver_check_format(driver->playback_sample_format);
+		if(err < 0) {
 			jack_error ("programming error: unhandled format "
 				    "type for playback");
-			exit (1);
+			return -1;
 		}
 	}
 
 	if (driver->capture_handle) {
-		switch (driver->capture_sample_format) {
-        case SND_PCM_FORMAT_FLOAT_LE:
-		case SND_PCM_FORMAT_S32_LE:
-		case SND_PCM_FORMAT_S24_3LE:
-		case SND_PCM_FORMAT_S24_3BE:
-		case SND_PCM_FORMAT_S24_LE:
-		case SND_PCM_FORMAT_S24_BE:
-		case SND_PCM_FORMAT_S16_LE:
-		case SND_PCM_FORMAT_S32_BE:
-		case SND_PCM_FORMAT_S16_BE:
-			break;
-
-		default:
+		err = alsa_driver_check_format(driver->capture_sample_format);
+		if(err < 0) {
 			jack_error ("programming error: unhandled format "
 				    "type for capture");
-			exit (1);
+			return -1;
 		}
 	}
 
 	if (driver->playback_interleaved) {
+#ifndef __QNXNTO__
 		const snd_pcm_channel_area_t *my_areas;
 		snd_pcm_uframes_t offset, frames;
 		if (snd_pcm_mmap_begin(driver->playback_handle,
@@ -817,13 +1079,21 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 				    driver->alsa_name_playback);
 			return -1;
 		}
+
+		// TODO does not work for capture only
 		driver->interleave_unit =
 			snd_pcm_format_physical_width (
 				driver->playback_sample_format) / 8;
+#else
+		driver->interleave_unit = snd_pcm_format_width(
+		            driver->playback_sample_format) / 8;
+#endif
 	} else {
+
 		driver->interleave_unit = 0;  /* NOT USED */
 	}
 
+#ifndef __QNXNTO__
 	if (driver->capture_interleaved) {
 		const snd_pcm_channel_area_t *my_areas;
 		snd_pcm_uframes_t offset, frames;
@@ -834,7 +1104,7 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 			return -1;
 		}
 	}
-
+#endif
 	if (driver->playback_nchannels > driver->capture_nchannels) {
 		driver->max_nchannels = driver->playback_nchannels;
 		driver->user_nchannels = driver->capture_nchannels;
@@ -932,6 +1202,23 @@ alsa_driver_reset_parameters (alsa_driver_t *driver,
 					   user_nperiods, rate);
 }
 
+#ifdef __QNXNTO__
+static int
+snd_pcm_poll_descriptors_count(snd_pcm_t *pcm)
+{
+	return 1;
+}
+
+static int
+snd_pcm_poll_descriptors_revents(snd_pcm_t *pcm, struct pollfd *pfds,
+                                 unsigned int nfds, unsigned short *revents)
+{
+	*revents = pfds->revents;
+
+	return 0;
+}
+#endif
+
 static int
 alsa_driver_get_channel_addresses (alsa_driver_t *driver,
 				   snd_pcm_uframes_t *capture_avail,
@@ -939,10 +1226,11 @@ alsa_driver_get_channel_addresses (alsa_driver_t *driver,
 				   snd_pcm_uframes_t *capture_offset,
 				   snd_pcm_uframes_t *playback_offset)
 {
-	int err;
 	channel_t chn;
 
 	if (capture_avail) {
+#ifndef __QNXNTO__
+		int err;
 		if ((err = snd_pcm_mmap_begin (
 			     driver->capture_handle, &driver->capture_areas,
 			     (snd_pcm_uframes_t *) capture_offset,
@@ -959,9 +1247,25 @@ alsa_driver_get_channel_addresses (alsa_driver_t *driver,
 				+ ((a->first + a->step * *capture_offset) / 8);
 			driver->capture_interleave_skip[chn] = (unsigned long ) (a->step / 8);
 		}
+#else
+		for (chn = 0; chn < driver->capture_nchannels; chn++) {
+			char* const a = driver->capture_areas;
+			if (driver->capture_interleaved) {
+				driver->capture_addr[chn] = &a[chn * driver->capture_sample_bytes];
+				driver->capture_interleave_skip[chn] = driver->capture_nchannels *
+				        driver->capture_sample_bytes;
+			} else {
+				driver->capture_addr[chn] = &a[chn *
+				        driver->capture_sample_bytes * driver->frames_per_cycle];
+				driver->capture_interleave_skip[chn] = driver->capture_sample_bytes;
+			}
+		}
+#endif
 	}
 
 	if (playback_avail) {
+#ifndef __QNXNTO__
+		int err;
 		if ((err = snd_pcm_mmap_begin (
 			     driver->playback_handle, &driver->playback_areas,
 			     (snd_pcm_uframes_t *) playback_offset,
@@ -978,16 +1282,38 @@ alsa_driver_get_channel_addresses (alsa_driver_t *driver,
 				+ ((a->first + a->step * *playback_offset) / 8);
 			driver->playback_interleave_skip[chn] = (unsigned long ) (a->step / 8);
 		}
+#else
+		for (chn = 0; chn < driver->playback_nchannels; chn++) {
+			char* const a = driver->playback_areas;
+			if (driver->playback_interleaved) {
+				driver->playback_addr[chn] = &a[chn * driver->playback_sample_bytes];
+				driver->playback_interleave_skip[chn] = driver->playback_nchannels *
+				        driver->playback_sample_bytes;
+			} else {
+				driver->playback_addr[chn] = &a[chn *
+				        driver->playback_sample_bytes * driver->frames_per_cycle];
+				driver->playback_interleave_skip[chn] = driver->playback_sample_bytes;
+			}
+		}
+#endif
 	}
 
 	return 0;
 }
 
+#ifdef __QNXNTO__
+static int
+alsa_driver_stream_start(snd_pcm_t *pcm, bool is_capture)
+{
+	return snd_pcm_channel_go(pcm, is_capture);
+}
+#else
 static int
 alsa_driver_stream_start(snd_pcm_t *pcm, bool is_capture)
 {
 	return snd_pcm_start(pcm);
 }
+#endif
 
 int
 alsa_driver_start (alsa_driver_t *driver)
@@ -1000,7 +1326,7 @@ alsa_driver_start (alsa_driver_t *driver)
 	driver->poll_next = 0;
 
 	if (driver->playback_handle) {
-		if ((err = snd_pcm_prepare (driver->playback_handle)) < 0) {
+		if ((err = alsa_driver_prepare (driver->playback_handle, SND_PCM_STREAM_PLAYBACK)) < 0) {
 			jack_error ("ALSA: prepare error for playback on "
 				    "\"%s\" (%s)", driver->alsa_name_playback,
 				    snd_strerror(err));
@@ -1010,7 +1336,7 @@ alsa_driver_start (alsa_driver_t *driver)
 
 	if ((driver->capture_handle && driver->capture_and_playback_not_synced)
 	    || !driver->playback_handle) {
-		if ((err = snd_pcm_prepare (driver->capture_handle)) < 0) {
+		if ((err = alsa_driver_prepare (driver->capture_handle, SND_PCM_STREAM_CAPTURE)) < 0) {
 			jack_error ("ALSA: prepare error for capture on \"%s\""
 				    " (%s)", driver->alsa_name_capture,
 				    snd_strerror(err));
@@ -1058,17 +1384,20 @@ alsa_driver_start (alsa_driver_t *driver)
 		(driver->midi->start)(driver->midi);
 
 	if (driver->playback_handle) {
+		const jack_nframes_t silence_frames = driver->frames_per_cycle *
+		        driver->playback_nperiods;
 		/* fill playback buffer with zeroes, and mark
 		   all fragments as having data.
 		*/
 
+#ifndef __QNXNTO__
 		pavail = snd_pcm_avail_update (driver->playback_handle);
 
-		if (pavail !=
-		    driver->frames_per_cycle * driver->playback_nperiods) {
+		if (pavail != silence_frames) {
 			jack_error ("ALSA: full buffer not available at start");
 			return -1;
 		}
+#endif
 
 		if (alsa_driver_get_channel_addresses (driver,
 					0, &pavail, 0, &poffset)) {
@@ -1086,14 +1415,21 @@ alsa_driver_start (alsa_driver_t *driver)
 
 		for (chn = 0; chn < driver->playback_nchannels; chn++) {
 			alsa_driver_silence_on_channel (
-				driver, chn,
-				driver->user_nperiods
-				* driver->frames_per_cycle);
+				driver, chn, silence_frames);
 		}
 
-		snd_pcm_mmap_commit (driver->playback_handle, poffset,
-				     driver->user_nperiods
-				     * driver->frames_per_cycle);
+#ifdef __QNXNTO__
+		const size_t bytes = silence_frames * driver->playback_nchannels *
+		        driver->playback_sample_bytes;
+		if ((err = snd_pcm_plugin_write(driver->playback_handle,
+					       driver->playback_areas, bytes)) < bytes) {
+			jack_error ("ALSA: could not complete write of %"
+				PRIu32 " frames: error = %d", silence_frames, err);
+			return -1;
+		}
+#else
+		snd_pcm_mmap_commit (driver->playback_handle, poffset, silence_frames);
+#endif
 
 		if ((err = alsa_driver_stream_start (driver->playback_handle, SND_PCM_STREAM_PLAYBACK)) < 0) {
 			jack_error ("ALSA: could not start playback (%s)",
@@ -1144,7 +1480,12 @@ alsa_driver_stop (alsa_driver_t *driver)
     ClearOutput();
 
 	if (driver->playback_handle) {
-		if ((err = snd_pcm_drop (driver->playback_handle)) < 0) {
+#ifdef __QNXNTO__
+		err = snd_pcm_plugin_flush(driver->playback_handle, SND_PCM_CHANNEL_PLAYBACK);
+#else
+		err = snd_pcm_drop (driver->playback_handle);
+#endif
+		if (err < 0) {
 			jack_error ("ALSA: channel flush for playback "
 				    "failed (%s)", snd_strerror (err));
 			return -1;
@@ -1154,7 +1495,12 @@ alsa_driver_stop (alsa_driver_t *driver)
 	if (!driver->playback_handle
 	    || driver->capture_and_playback_not_synced) {
 		if (driver->capture_handle) {
-			if ((err = snd_pcm_drop (driver->capture_handle)) < 0) {
+#ifdef __QNXNTO__
+			err = snd_pcm_plugin_flush(driver->capture_handle, SND_PCM_CHANNEL_CAPTURE);
+#else
+			err = snd_pcm_drop (driver->capture_handle);
+#endif
+			if (err < 0) {
 				jack_error ("ALSA: channel flush for "
 					    "capture failed (%s)",
 					    snd_strerror (err));
@@ -1194,60 +1540,90 @@ alsa_driver_restart (alsa_driver_t *driver)
 }
 
 static int
+alsa_driver_get_status (alsa_driver_t *driver)
+{
+	int res;
+	snd_pcm_t *pcm_handle;
+
+#ifdef __QNXNTO__
+	snd_pcm_channel_status_t status;
+#else
+	snd_pcm_status_t *status;
+	snd_pcm_status_alloca(&status);
+#endif
+	if (driver->capture_handle) {
+		pcm_handle = driver->capture_handle;
+	} else {
+		pcm_handle = driver->playback_handle;
+	}
+#ifdef __QNXNTO__
+	/* ToDo : ldevi : Can be moved a different func? s*/
+	memset (&status, 0, sizeof (status));
+	status.channel = driver->capture_handle ? SND_PCM_CHANNEL_CAPTURE :
+	                                          SND_PCM_CHANNEL_PLAYBACK;
+	res = snd_pcm_plugin_status(pcm_handle, &status);
+#else
+	res = snd_pcm_status(pcm_handle, status);
+#endif
+	if (res < 0) {
+		jack_error("status error: %s", snd_strerror(res));
+		return -1;
+	}
+#ifdef __QNXNTO__
+	return status.status;
+#else
+	return snd_pcm_status_get_state(status);
+#endif
+}
+
+static int
 alsa_driver_xrun_recovery (alsa_driver_t *driver, float *delayed_usecs)
 {
-	snd_pcm_status_t *status;
+	int status;
 	int res;
 
-	snd_pcm_status_alloca(&status);
-
-	if (driver->capture_handle) {
-		if ((res = snd_pcm_status(driver->capture_handle, status))
-		    < 0) {
-			jack_error("status error: %s", snd_strerror(res));
-		}
-	} else {
-		if ((res = snd_pcm_status(driver->playback_handle, status))
-		    < 0) {
-			jack_error("status error: %s", snd_strerror(res));
-		}
-	}
-
-	if (snd_pcm_status_get_state(status) == SND_PCM_STATE_SUSPENDED)
-	{
-		jack_log("**** alsa_pcm: pcm in suspended state, resuming it" );
+	status = alsa_driver_get_status(driver);
+	if (status == SND_PCM_STATE_SUSPENDED) {
 		if (driver->capture_handle) {
-			if ((res = snd_pcm_prepare(driver->capture_handle))
+			if ((res = alsa_driver_prepare(driver->capture_handle, SND_PCM_STREAM_CAPTURE))
 			    < 0) {
 				jack_error("error preparing after suspend: %s", snd_strerror(res));
 			}
 		} 
 		if (driver->playback_handle) {
-			if ((res = snd_pcm_prepare(driver->playback_handle))
+			if ((res = alsa_driver_prepare(driver->playback_handle, SND_PCM_STREAM_PLAYBACK))
 			    < 0) {
 				jack_error("error preparing after suspend: %s", snd_strerror(res));
 			}
 		}
 	}
 
-	if (snd_pcm_status_get_state(status) == SND_PCM_STATE_XRUN
+	// TODO overrun
+	if (status == SND_PCM_STATE_XRUN
 	    && driver->process_count > XRUN_REPORT_DELAY) {
-		struct timeval now, diff, tstamp;
 		driver->xrun_count++;
+#ifdef __QNXNTO__
+		/* ldevi : ToDo Check if there is a replacement*/
+		*delayed_usecs = 0;
+#else
+		struct timeval now, diff, tstamp;
 		snd_pcm_status_get_tstamp(status,&now);
 		snd_pcm_status_get_trigger_tstamp(status, &tstamp);
 		timersub(&now, &tstamp, &diff);
 		*delayed_usecs = diff.tv_sec * 1000000.0 + diff.tv_usec;
+#endif
 		jack_log("**** alsa_pcm: xrun of at least %.3f msecs",*delayed_usecs / 1000.0);
 		if (driver->capture_handle) {
 			jack_log("Repreparing capture");
-			if ((res = snd_pcm_prepare(driver->capture_handle)) < 0) {
+			if ((res = alsa_driver_prepare(driver->capture_handle,
+			                               SND_PCM_STREAM_CAPTURE)) < 0) {
 				jack_error("error preparing after xrun: %s", snd_strerror(res));
 			}
 		}
 		if (driver->playback_handle) {
 			jack_log("Repreparing playback");
-			if ((res = snd_pcm_prepare(driver->playback_handle)) < 0) {
+			if ((res = alsa_driver_prepare(driver->playback_handle,
+			                               SND_PCM_STREAM_PLAYBACK)) < 0) {
 				jack_error("error preparing after xrun: %s", snd_strerror(res));
 			}
 		}
@@ -1259,7 +1635,7 @@ alsa_driver_xrun_recovery (alsa_driver_t *driver, float *delayed_usecs)
 	return 0;
 }
 
-void
+static void
 alsa_driver_silence_untouched_channels (alsa_driver_t *driver,
 					jack_nframes_t nframes)
 {
@@ -1278,14 +1654,39 @@ alsa_driver_silence_untouched_channels (alsa_driver_t *driver,
 	}
 }
 
-void
-alsa_driver_set_clock_sync_status (alsa_driver_t *driver, channel_t chn,
-				   ClockSyncStatus status)
+#ifdef __QNXNTO__
+static int
+alsa_driver_poll_descriptors(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int space, bool is_capture)
 {
-	driver->clock_sync_data[chn] = status;
-	alsa_driver_clock_sync_notify (driver, chn, status);
+	pfds->fd = snd_pcm_file_descriptor (pcm, is_capture);
+	pfds->events = POLLHUP|POLLNVAL;
+	pfds->events |= (is_capture == SND_PCM_STREAM_PLAYBACK) ? POLLOUT : POLLIN;
+
+	return 0;
 }
 
+static snd_pcm_sframes_t
+alsa_driver_avail(alsa_driver_t *driver, snd_pcm_t *pcm, bool is_capture)
+{
+	int err;
+	snd_pcm_channel_status_t status = {0, };
+
+    status.channel = is_capture;
+    err = snd_pcm_plugin_status (pcm, &status);
+	if (err < 0)
+		return err;
+
+	switch (status.status) {
+	case SND_PCM_STATUS_UNDERRUN:
+	case SND_PCM_STATUS_OVERRUN:
+	case SND_PCM_STATUS_UNSECURE:
+	case SND_PCM_STATUS_CHANGE:
+		return -EPIPE;
+	}
+
+	return driver->frames_per_cycle;
+}
+#else
 static int
 alsa_driver_poll_descriptors(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int space, bool is_capture)
 {
@@ -1297,6 +1698,7 @@ alsa_driver_avail(alsa_driver_t *driver, snd_pcm_t *pcm, bool is_capture)
 {
 	return snd_pcm_avail_update(pcm);
 }
+#endif
 
 static int under_gdb = FALSE;
 
@@ -1519,6 +1921,15 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 #endif
 			}
 		}
+
+		if (poll_result == 0) {
+			jack_error ("ALSA: poll time out, polled for %" PRIu64
+				    " usecs",
+				    poll_ret - poll_enter);
+			*status = -5;
+			return 0;
+		}
+
 	}
 
 	if (driver->capture_handle) {
@@ -1624,6 +2035,17 @@ alsa_driver_read (alsa_driver_t *driver, jack_nframes_t nframes)
 			    &offset, 0) < 0) {
 			return -1;
 		}
+
+#ifdef __QNXNTO__
+		const size_t bytes = contiguous * driver->capture_nchannels * driver->capture_sample_bytes;
+		if ((err = snd_pcm_plugin_read(driver->capture_handle,
+					       driver->capture_areas, bytes)) < bytes) {
+			jack_error ("ALSA: could not complete read of %"
+				    PRIu32 " frames: error = %d", contiguous, err);
+			return -1;
+		}
+#endif
+
 // JACK2
 /*
 		for (chn = 0, node = driver->capture_ports; node;
@@ -1642,12 +2064,14 @@ alsa_driver_read (alsa_driver_t *driver, jack_nframes_t nframes)
 */
         ReadInput(orig_nframes, contiguous, nread);
 
+#ifndef __QNXNTO__
 		if ((err = snd_pcm_mmap_commit (driver->capture_handle,
 				offset, contiguous)) < 0) {
 			jack_error ("ALSA: could not complete read of %"
 				PRIu32 " frames: error = %d", contiguous, err);
 			return -1;
 		}
+#endif
 
 		nframes -= contiguous;
 		nread += contiguous;
@@ -1765,6 +2189,15 @@ alsa_driver_write (alsa_driver_t* driver, jack_nframes_t nframes)
 								contiguous);
 		}
 
+#ifdef __QNXNTO__
+		const size_t bytes = contiguous * driver->playback_nchannels * driver->playback_sample_bytes;
+		if ((err = snd_pcm_plugin_write(driver->playback_handle,
+					       driver->playback_areas, bytes)) < bytes) {
+			jack_error ("ALSA: could not complete write of %"
+				PRIu32 " frames: error = %d", contiguous, err);
+			return -1;
+		}
+#else
 		if ((err = snd_pcm_mmap_commit (driver->playback_handle,
 				offset, contiguous)) < 0) {
 			jack_error ("ALSA: could not complete playback of %"
@@ -1772,6 +2205,7 @@ alsa_driver_write (alsa_driver_t* driver, jack_nframes_t nframes)
 			if (err != -EPIPE && err != -ESTRPIPE)
 				return -1;
 		}
+#endif
 
 		nframes -= contiguous;
 		nwritten += contiguous;
@@ -1857,6 +2291,7 @@ alsa_driver_delete (alsa_driver_t *driver)
 		driver->capture_handle = 0;
 	}
 
+#ifndef __QNXNTO__
 	if (driver->capture_hw_params) {
 		snd_pcm_hw_params_free (driver->capture_hw_params);
 		driver->capture_hw_params = 0;
@@ -1876,6 +2311,7 @@ alsa_driver_delete (alsa_driver_t *driver)
 		snd_pcm_sw_params_free (driver->playback_sw_params);
 		driver->playback_sw_params = 0;
 	}
+#endif
 
 	if (driver->pfd) {
 		free (driver->pfd);
@@ -1996,6 +2432,117 @@ discover_alsa_using_apps ()
         }
 }
 
+static int
+alsa_driver_open (alsa_driver_t *driver, bool is_capture)
+{
+	int err = 0;
+	char* current_apps;
+
+	if(is_capture) {
+#ifdef __QNXNTO__
+		err = snd_pcm_open_name (&driver->capture_handle,
+					 driver->alsa_name_capture,
+					 SND_PCM_OPEN_CAPTURE | SND_PCM_OPEN_NONBLOCK);
+#else
+		err = snd_pcm_open (&driver->capture_handle,
+				    driver->alsa_name_capture,
+				    SND_PCM_STREAM_CAPTURE,
+				    SND_PCM_NONBLOCK);
+#endif
+	} else {
+#ifdef __QNXNTO__
+		err = snd_pcm_open_name (&driver->playback_handle,
+					 driver->alsa_name_playback,
+					 SND_PCM_OPEN_PLAYBACK | SND_PCM_OPEN_NONBLOCK);
+#else
+		err = snd_pcm_open (&driver->playback_handle,
+				    driver->alsa_name_playback,
+				    SND_PCM_STREAM_PLAYBACK,
+				    SND_PCM_NONBLOCK);
+#endif
+	}
+	if (err < 0) {
+		switch (errno) {
+		case EBUSY:
+#ifdef __ANDROID__
+			jack_error ("\n\nATTENTION: The device \"%s\" is "
+				    "already in use. Please stop the"
+				    " application using it and "
+				    "run JACK again",
+				    is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+#else
+			current_apps = discover_alsa_using_apps ();
+			if (current_apps) {
+				jack_error ("\n\nATTENTION: The device \"%s\" is "
+					    "already in use. The following applications "
+					    " are using your soundcard(s) so you should "
+					    " check them and stop them as necessary before "
+					    " trying to start JACK again:\n\n%s",
+					    is_capture ? driver->alsa_name_capture : driver->alsa_name_playback,
+					    current_apps);
+				free (current_apps);
+			} else {
+				jack_error ("\n\nATTENTION: The device \"%s\" is "
+					    "already in use. Please stop the"
+					    " application using it and "
+					    "run JACK again",
+					    is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+			}
+#endif
+			break;
+
+		case EPERM:
+			jack_error ("you do not have permission to open "
+				    "the audio device \"%s\" for playback",
+				    is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+			break;
+
+		case EINVAL:
+			jack_error ("the state of handle or the mode is invalid "
+				"or invalid state change occured \"%s\" for playback",
+				is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+			break;
+
+		case ENOENT:
+			jack_error ("device \"%s\"  does not exist for playback",
+				is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+			break;
+
+		case ENOMEM:
+			jack_error ("Not enough memory available for allocation for \"%s\" for playback",
+				is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+			break;
+
+		case SND_ERROR_INCOMPATIBLE_VERSION:
+			jack_error ("Version mismatch \"%s\" for playback",
+				is_capture ? driver->alsa_name_capture : driver->alsa_name_playback);
+			break;
+		}
+		alsa_driver_delete (driver);
+		if(is_capture) {
+			driver->capture_handle = NULL;
+		} else {
+			driver->playback_handle = NULL;
+		}
+	}
+
+	if (is_capture && driver->capture_handle) {
+#ifdef __QNXNTO__
+		snd_pcm_nonblock_mode (driver->capture_handle, 0);
+#else
+		snd_pcm_nonblock (driver->capture_handle, 0);
+#endif
+	} else if(!is_capture && driver->playback_handle) {
+#ifdef __QNXNTO__
+		snd_pcm_nonblock_mode (driver->playback_handle, 0);
+#else
+		snd_pcm_nonblock (driver->playback_handle, 0);
+#endif
+	}
+
+	return err;
+}
+
 jack_driver_t *
 alsa_driver_new (char *name, char *playback_alsa_device,
 		 char *capture_alsa_device,
@@ -2019,7 +2566,6 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 		 )
 {
 	int err;
-    char* current_apps;
 	alsa_driver_t *driver;
 
 	jack_info ("creating alsa driver ... %s|%s|%" PRIu32 "|%" PRIu32
@@ -2068,6 +2614,12 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 	driver->capture_addr = 0;
 	driver->playback_interleave_skip = NULL;
 	driver->capture_interleave_skip = NULL;
+#ifdef __QNXNTO__
+	driver->playback_areas = NULL;
+	driver->playback_areas_ptr = NULL;
+	driver->capture_areas = NULL;
+	driver->capture_areas_ptr = NULL;
+#endif
 
 
 	driver->silent = 0;
@@ -2103,113 +2655,29 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 	driver->midi = midi_driver;
 	driver->xrun_recovery = 0;
 
+#ifndef __QNXNTO__
 	if (alsa_driver_check_card_type (driver)) {
 		alsa_driver_delete (driver);
 		return NULL;
 	}
 
 	alsa_driver_hw_specific (driver, hw_monitoring, hw_metering);
+#endif
 
 	if (playing) {
-		if (snd_pcm_open (&driver->playback_handle,
-				  playback_alsa_device,
-				  SND_PCM_STREAM_PLAYBACK,
-				  SND_PCM_NONBLOCK) < 0) {
-			switch (errno) {
-			case EBUSY:
-#ifdef __ANDROID__
-                jack_error ("\n\nATTENTION: The playback device \"%s\" is "
-                            "already in use. Please stop the"
-                            " application using it and "
-                            "run JACK again",
-                            playback_alsa_device);
-#else
-                current_apps = discover_alsa_using_apps ();
-                if (current_apps) {
-                        jack_error ("\n\nATTENTION: The playback device \"%s\" is "
-                                    "already in use. The following applications "
-                                    " are using your soundcard(s) so you should "
-                                    " check them and stop them as necessary before "
-                                    " trying to start JACK again:\n\n%s",
-                                    playback_alsa_device,
-                                    current_apps);
-                        free (current_apps);
-                } else {
-                        jack_error ("\n\nATTENTION: The playback device \"%s\" is "
-                                    "already in use. Please stop the"
-                                    " application using it and "
-                                    "run JACK again",
-                                    playback_alsa_device);
-                }
-#endif
-                alsa_driver_delete (driver);
-				return NULL;
-
-			case EPERM:
-				jack_error ("you do not have permission to open "
-					    "the audio device \"%s\" for playback",
-					    playback_alsa_device);
-				alsa_driver_delete (driver);
-				return NULL;
-				break;
-			}
-
-			driver->playback_handle = NULL;
-		}
-
-		if (driver->playback_handle) {
-			snd_pcm_nonblock (driver->playback_handle, 0);
+		err = alsa_driver_open(driver, SND_PCM_STREAM_PLAYBACK);
+		if(err < 0) {
+			jack_error ("\n\nATTENTION: Opening of the playback device \"%s\" failed.",
+				    playback_alsa_device);
+			return NULL;
 		}
 	}
-
-	if (capturing) {
-		if (snd_pcm_open (&driver->capture_handle,
-				  capture_alsa_device,
-				  SND_PCM_STREAM_CAPTURE,
-				  SND_PCM_NONBLOCK) < 0) {
-			switch (errno) {
-			case EBUSY:
-#ifdef __ANDROID__
-                jack_error ("\n\nATTENTION: The capture (recording) device \"%s\" is "
-                            "already in use",
-                            capture_alsa_device);
-#else
-                current_apps = discover_alsa_using_apps ();
-                if (current_apps) {
-                        jack_error ("\n\nATTENTION: The capture device \"%s\" is "
-                                    "already in use. The following applications "
-                                    " are using your soundcard(s) so you should "
-                                    " check them and stop them as necessary before "
-                                    " trying to start JACK again:\n\n%s",
-                                    capture_alsa_device,
-                                    current_apps);
-                        free (current_apps);
-                } else {
-                        jack_error ("\n\nATTENTION: The capture (recording) device \"%s\" is "
-                                    "already in use. Please stop the"
-                                    " application using it and "
-                                    "run JACK again",
-                                    capture_alsa_device);
-                }
-				alsa_driver_delete (driver);
-				return NULL;
-#endif
-				break;
-
-			case EPERM:
-				jack_error ("you do not have permission to open "
-					    "the audio device \"%s\" for capture",
-					    capture_alsa_device);
-				alsa_driver_delete (driver);
-				return NULL;
-				break;
-			}
-
-			driver->capture_handle = NULL;
-		}
-
-		if (driver->capture_handle) {
-			snd_pcm_nonblock (driver->capture_handle, 0);
+	if(capturing) {
+		err = alsa_driver_open(driver, SND_PCM_STREAM_CAPTURE);
+		if(err < 0) {
+			jack_error ("\n\nATTENTION: Opening of the capture device \"%s\" failed.",
+				    capture_alsa_device);
+			return NULL;
 		}
 	}
 
@@ -2251,6 +2719,7 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 		}
 	}
 
+#ifndef __QNXNTO__
 	driver->playback_hw_params = 0;
 	driver->capture_hw_params = 0;
 	driver->playback_sw_params = 0;
@@ -2291,7 +2760,7 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 			return NULL;
 		}
 	}
-
+#endif
 	if (alsa_driver_set_parameters (driver, frames_per_cycle,
 					user_nperiods, rate)) {
 		alsa_driver_delete (driver);
@@ -2310,25 +2779,6 @@ alsa_driver_new (char *name, char *playback_alsa_device,
 	driver->client = client;
 
 	return (jack_driver_t *) driver;
-}
-
-int
-alsa_driver_listen_for_clock_sync_status (alsa_driver_t *driver,
-					  ClockSyncListenerFunction func,
-					  void *arg)
-{
-	ClockSyncListener *csl;
-
-	csl = (ClockSyncListener *) malloc (sizeof (ClockSyncListener));
-	csl->function = func;
-	csl->arg = arg;
-	csl->id = driver->next_clock_sync_listener_id++;
-
-	pthread_mutex_lock (&driver->clock_sync_lock);
-	driver->clock_sync_listeners =
-		jack_slist_prepend (driver->clock_sync_listeners, csl);
-	pthread_mutex_unlock (&driver->clock_sync_lock);
-	return csl->id;
 }
 
 int
@@ -2353,22 +2803,6 @@ alsa_driver_stop_listening_to_clock_sync_status (alsa_driver_t *driver,
 	}
 	pthread_mutex_unlock (&driver->clock_sync_lock);
 	return ret;
-}
-
-void
-alsa_driver_clock_sync_notify (alsa_driver_t *driver, channel_t chn,
-			       ClockSyncStatus status)
-{
-	JSList *node;
-
-	pthread_mutex_lock (&driver->clock_sync_lock);
-	for (node = driver->clock_sync_listeners; node;
-	     node = jack_slist_next (node)) {
-		ClockSyncListener *csl = (ClockSyncListener *) node->data;
-		csl->function (chn, status, csl->arg);
-	}
-	pthread_mutex_unlock (&driver->clock_sync_lock);
-
 }
 
 /* DRIVER "PLUGIN" INTERFACE */

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -983,6 +983,12 @@ alsa_driver_get_channel_addresses (alsa_driver_t *driver,
 	return 0;
 }
 
+static int
+alsa_driver_stream_start(snd_pcm_t *pcm, bool is_capture)
+{
+	return snd_pcm_start(pcm);
+}
+
 int
 alsa_driver_start (alsa_driver_t *driver)
 {
@@ -1089,7 +1095,7 @@ alsa_driver_start (alsa_driver_t *driver)
 				     driver->user_nperiods
 				     * driver->frames_per_cycle);
 
-		if ((err = snd_pcm_start (driver->playback_handle)) < 0) {
+		if ((err = alsa_driver_stream_start (driver->playback_handle, SND_PCM_STREAM_PLAYBACK)) < 0) {
 			jack_error ("ALSA: could not start playback (%s)",
 				    snd_strerror (err));
 			return -1;
@@ -1098,7 +1104,7 @@ alsa_driver_start (alsa_driver_t *driver)
 
 	if ((driver->capture_handle && driver->capture_and_playback_not_synced)
 	    || !driver->playback_handle) {
-		if ((err = snd_pcm_start (driver->capture_handle)) < 0) {
+		if ((err = alsa_driver_stream_start (driver->capture_handle, SND_PCM_STREAM_CAPTURE)) < 0) {
 			jack_error ("ALSA: could not start capture (%s)",
 				    snd_strerror (err));
 			return -1;
@@ -1280,6 +1286,18 @@ alsa_driver_set_clock_sync_status (alsa_driver_t *driver, channel_t chn,
 	alsa_driver_clock_sync_notify (driver, chn, status);
 }
 
+static int
+alsa_driver_poll_descriptors(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int space, bool is_capture)
+{
+	return snd_pcm_poll_descriptors(pcm, pfds, space);
+}
+
+static snd_pcm_sframes_t
+alsa_driver_avail(alsa_driver_t *driver, snd_pcm_t *pcm, bool is_capture)
+{
+	return snd_pcm_avail_update(pcm);
+}
+
 static int under_gdb = FALSE;
 
 jack_nframes_t
@@ -1320,16 +1338,16 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 		nfds = 0;
 
 		if (need_playback) {
-			snd_pcm_poll_descriptors (driver->playback_handle,
+			alsa_driver_poll_descriptors (driver->playback_handle,
 						  &driver->pfd[0],
-						  driver->playback_nfds);
+						  driver->playback_nfds, SND_PCM_STREAM_PLAYBACK);
 			nfds += driver->playback_nfds;
 		}
 
 		if (need_capture) {
-			snd_pcm_poll_descriptors (driver->capture_handle,
+			alsa_driver_poll_descriptors (driver->capture_handle,
 						  &driver->pfd[nfds],
-						  driver->capture_nfds);
+						  driver->capture_nfds, SND_PCM_STREAM_CAPTURE);
 			ci = nfds;
 			nfds += driver->capture_nfds;
 		}
@@ -1504,8 +1522,8 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 	}
 
 	if (driver->capture_handle) {
-		if ((capture_avail = snd_pcm_avail_update (
-			     driver->capture_handle)) < 0) {
+		if ((capture_avail = alsa_driver_avail (driver,
+			     driver->capture_handle, SND_PCM_STREAM_CAPTURE)) < 0) {
 			if (capture_avail == -EPIPE) {
 				xrun_detected = TRUE;
 			} else {
@@ -1519,8 +1537,8 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 	}
 
 	if (driver->playback_handle) {
-		if ((playback_avail = snd_pcm_avail_update (
-			     driver->playback_handle)) < 0) {
+		if ((playback_avail = alsa_driver_avail (driver,
+			     driver->playback_handle, SND_PCM_STREAM_PLAYBACK)) < 0) {
 			if (playback_avail == -EPIPE) {
 				xrun_detected = TRUE;
 			} else {

--- a/linux/alsa/usx2y.h
+++ b/linux/alsa/usx2y.h
@@ -22,6 +22,8 @@
 #ifndef __jack_usx2y_h__
 #define __jack_usx2y_h__
 
+ #include <poll.h>
+
 #define USX2Y_MAXPACK		50
 #define USX2Y_MAXBUFFERMS	100
 #define USX2Y_MAXSTRIDE	3
@@ -51,7 +53,9 @@ typedef struct snd_usX2Y_hwdep_pcm_shm snd_usX2Y_hwdep_pcm_shm_t;
 typedef struct
 {
     alsa_driver_t *driver;
+#ifndef __QNXNTO__
     snd_hwdep_t *hwdep_handle;
+#endif
     struct pollfd pfds;
     struct snd_usX2Y_hwdep_pcm_shm *hwdep_pcm_shm;
     int playback_iso_start;

--- a/posix/JackFifo.cpp
+++ b/posix/JackFifo.cpp
@@ -132,7 +132,7 @@ bool JackFifo::Allocate(const char* name, const char* server_name, int value)
     if (stat(fName, &statbuf) < 0) {
         if (errno == ENOENT || errno == EPERM) {
             if (mkfifo(fName, 0666) < 0) {
-                jack_error("Cannot create inter-client FIFO name = %s err = %s", name, strerror(errno));
+                jack_error("Cannot create inter-client FIFO name = %s err = %s", fName, strerror(errno));
                 return false;
             }
         } else {

--- a/posix/JackFifo.h
+++ b/posix/JackFifo.h
@@ -44,7 +44,7 @@ class SERVER_EXPORT JackFifo : public detail::JackSynchro
 
     protected:
 
-        void BuildName(const char* name, const char* server_name, char* res);
+        void BuildName(const char* name, const char* server_name, char* res, int size);
 
     public:
 

--- a/posix/JackNetUnixSocket.cpp
+++ b/posix/JackNetUnixSocket.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/time.h>
 
 using namespace std;
 

--- a/qnx/JackAtomic_os.h
+++ b/qnx/JackAtomic_os.h
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2004-2008 Grame
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackAtomic_linux__
+#define __JackAtomic_linux__
+
+#include "JackTypes.h"
+
+#ifdef __PPC__
+
+static inline int CAS(register UInt32 value, register UInt32 newvalue, register volatile void* addr)
+{
+    register int result;
+    register UInt32 tmp;
+    asm volatile (
+        "# CAS					\n"
+        "	lwarx	%4, 0, %1	\n"         // creates a reservation on addr
+        "	cmpw	%4, %2		\n"        //  test value at addr
+        "	bne-	1f          \n"
+        "	sync            	\n"         //  synchronize instructions
+        "	stwcx.	%3, 0, %1	\n"         //  if the reservation is not altered
+        //  stores the new value at addr
+        "	bne-	1f          \n"
+        "   li      %0, 1       \n"
+        "	b		2f          \n"
+        "1:                     \n"
+        "   li      %0, 0       \n"
+        "2:                     \n"
+        : "=r" (result)
+        : "r" (addr), "r" (value), "r" (newvalue), "r" (tmp)
+        );
+    return result;
+}
+
+#endif
+
+#if defined(__i386__) || defined(__x86_64__)
+
+#define LOCK "lock ; "
+
+static inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void* addr)
+{
+    register char ret;
+    __asm__ __volatile__ (
+        "# CAS \n\t"
+        LOCK "cmpxchg %2, (%1) \n\t"
+        "sete %0               \n\t"
+        : "=a" (ret)
+        : "c" (addr), "d" (newvalue), "a" (value)
+        );
+    return ret;
+}
+
+#endif
+
+
+
+
+#if !defined(__i386__) && !defined(__x86_64__)  && !defined(__PPC__)
+
+
+static inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void* addr)
+{
+    return __sync_bool_compare_and_swap ((UInt32*)addr, value, newvalue);
+}
+#endif
+
+
+#endif
+

--- a/qnx/JackLinuxTime.c
+++ b/qnx/JackLinuxTime.c
@@ -1,0 +1,215 @@
+/*
+Copyright (C) 2001-2003 Paul Davis
+Copyright (C) 2005 Jussi Laako
+Copyright (C) 2004-2008 Grame
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackConstants.h"
+#include "JackTime.h"
+#include "JackTypes.h"
+#include "JackError.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+jack_time_t (*_jack_get_microseconds)(void) = 0;
+
+#if defined(__gnu_linux__) && (defined(__i386__) || defined(__x86_64__))
+#define HPET_SUPPORT
+#define HPET_MMAP_SIZE		1024
+#define HPET_CAPS			0x000
+#define HPET_PERIOD			0x004
+#define HPET_COUNTER		0x0f0
+#define HPET_CAPS_COUNTER_64BIT	(1 << 13)
+#if defined(__x86_64__)
+typedef uint64_t hpet_counter_t;
+#else
+typedef uint32_t hpet_counter_t;
+#endif
+static int hpet_fd;
+static unsigned char *hpet_ptr;
+static uint32_t hpet_period; /* period length in femto secs */
+static uint64_t hpet_offset = 0;
+static uint64_t hpet_wrap;
+static hpet_counter_t hpet_previous = 0;
+#endif /* defined(__gnu_linux__) && (__i386__ || __x86_64__) */
+
+#ifdef HPET_SUPPORT
+
+static int jack_hpet_init ()
+{
+	uint32_t hpet_caps;
+
+	hpet_fd = open("/dev/hpet", O_RDONLY);
+	if (hpet_fd < 0) {
+		jack_error ("This system has no accessible HPET device (%s)", strerror (errno));
+		return -1;
+	}
+
+	hpet_ptr = (unsigned char *) mmap(NULL, HPET_MMAP_SIZE,
+					  PROT_READ, MAP_SHARED, hpet_fd, 0);
+	if (hpet_ptr == MAP_FAILED) {
+		jack_error ("This system has no mappable HPET device (%s)", strerror (errno));
+		close (hpet_fd);
+		return -1;
+	}
+
+	/* this assumes period to be constant. if needed,
+	   it can be moved to the clock access function
+	*/
+	hpet_period = *((uint32_t *) (hpet_ptr + HPET_PERIOD));
+	hpet_caps = *((uint32_t *) (hpet_ptr + HPET_CAPS));
+	hpet_wrap = ((hpet_caps & HPET_CAPS_COUNTER_64BIT) &&
+		(sizeof(hpet_counter_t) == sizeof(uint64_t))) ?
+		0 : ((uint64_t) 1 << 32);
+
+	return 0;
+}
+
+static jack_time_t jack_get_microseconds_from_hpet (void)
+{
+	hpet_counter_t hpet_counter;
+	long double hpet_time;
+
+	hpet_counter = *((hpet_counter_t *) (hpet_ptr + HPET_COUNTER));
+	if (hpet_counter < hpet_previous)
+		hpet_offset += hpet_wrap;
+	hpet_previous = hpet_counter;
+	hpet_time = (long double) (hpet_offset + hpet_counter) *
+		(long double) hpet_period * (long double) 1e-9;
+	return ((jack_time_t) (hpet_time + 0.5));
+}
+
+#else
+
+static int jack_hpet_init ()
+{
+	jack_error ("This version of JACK or this computer does not have HPET support.\n"
+		    "Please choose a different clock source.");
+	return -1;
+}
+
+static jack_time_t jack_get_microseconds_from_hpet (void)
+{
+	/* never called */
+	return 0;
+}
+
+#endif /* HPET_SUPPORT */
+
+#define HAVE_CLOCK_GETTIME 1
+
+#ifndef HAVE_CLOCK_GETTIME
+
+static jack_time_t jack_get_microseconds_from_system (void)
+{
+	jack_time_t jackTime;
+	struct timeval tv;
+
+	gettimeofday (&tv, NULL);
+	jackTime = (jack_time_t) tv.tv_sec * 1000000 + (jack_time_t) tv.tv_usec;
+	return jackTime;
+}
+
+#else
+
+static jack_time_t jack_get_microseconds_from_system (void)
+{
+	jack_time_t jackTime;
+	struct timespec time;
+
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	jackTime = (jack_time_t) time.tv_sec * 1e6 +
+		(jack_time_t) time.tv_nsec / 1e3;
+	return jackTime;
+}
+
+#endif /* HAVE_CLOCK_GETTIME */
+
+
+SERVER_EXPORT void JackSleep(long usec)
+{
+	usleep(usec);
+}
+
+SERVER_EXPORT void InitTime()
+{
+	/* nothing to do on a generic system - we use the system clock */
+}
+
+SERVER_EXPORT void EndTime()
+{}
+
+void SetClockSource(jack_timer_type_t source)
+{
+    jack_log("Clock source : %s", ClockSourceName(source));
+
+	switch (source)
+	{
+        case JACK_TIMER_HPET:
+            if (jack_hpet_init () == 0) {
+                _jack_get_microseconds = jack_get_microseconds_from_hpet;
+            } else {
+                _jack_get_microseconds = jack_get_microseconds_from_system;
+            }
+            break;
+
+        case JACK_TIMER_SYSTEM_CLOCK:
+            default:
+            _jack_get_microseconds = jack_get_microseconds_from_system;
+            break;
+	}
+}
+
+const char* ClockSourceName(jack_timer_type_t source)
+{
+	switch (source) {
+        case JACK_TIMER_HPET:
+            return "hpet";
+        case JACK_TIMER_SYSTEM_CLOCK:
+        #ifdef HAVE_CLOCK_GETTIME
+            return "system clock via clock_gettime";
+        #else
+            return "system clock via gettimeofday";
+        #endif
+	}
+
+	/* what is wrong with gcc ? */
+	return "unknown";
+}
+
+SERVER_EXPORT jack_time_t GetMicroSeconds()
+{
+	return _jack_get_microseconds();
+}
+
+SERVER_EXPORT jack_time_t jack_get_microseconds()
+{
+	return _jack_get_microseconds();
+}
+

--- a/qnx/JackPlatformPlug_os.h
+++ b/qnx/JackPlatformPlug_os.h
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2004-2008 Grame
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackPlatformPlug_linux__
+#define __JackPlatformPlug_linux__
+
+#define jack_server_dir "/dev/shm"
+#define jack_client_dir "/dev/shm"
+#define JACK_DEFAULT_DRIVER "alsa"
+
+namespace Jack
+{
+    struct JackRequest;
+    struct JackResult;
+
+    class JackPosixMutex;
+    class JackPosixThread;
+    class JackFifo;
+    class JackSocketServerChannel;
+    class JackSocketClientChannel;
+    class JackSocketServerNotifyChannel;
+    class JackSocketNotifyChannel;
+    class JackClientSocket;
+    class JackNetUnixSocket;
+}
+
+/* __JackPlatformMutex__ */
+#include "JackPosixMutex.h"
+namespace Jack {typedef JackPosixMutex JackMutex; }
+
+/* __JackPlatformThread__ */
+#include "JackPosixThread.h"
+namespace Jack { typedef JackPosixThread JackThread; }
+
+#include "JackFifo.h"
+namespace Jack { typedef JackFifo JackSynchro; }
+
+
+/* __JackPlatformChannelTransaction__ */
+/*
+#include "JackSocket.h"
+namespace Jack { typedef JackClientSocket JackChannelTransaction; }
+*/
+
+/* __JackPlatformProcessSync__ */
+#include "JackPosixProcessSync.h"
+namespace Jack { typedef JackPosixProcessSync JackProcessSync; }
+
+/* __JackPlatformServerChannel__ */
+#include "JackSocketServerChannel.h"
+namespace Jack { typedef JackSocketServerChannel JackServerChannel; }
+
+/* __JackPlatformClientChannel__ */
+#include "JackSocketClientChannel.h"
+namespace Jack { typedef JackSocketClientChannel JackClientChannel; }
+
+/* __JackPlatformServerNotifyChannel__ */
+#include "JackSocketServerNotifyChannel.h"
+namespace Jack { typedef JackSocketServerNotifyChannel JackServerNotifyChannel; }
+
+/* __JackPlatformNotifyChannel__ */
+#include "JackSocketNotifyChannel.h"
+namespace Jack { typedef JackSocketNotifyChannel JackNotifyChannel; }
+
+/* __JackPlatformNetSocket__ */
+#include "JackNetUnixSocket.h"
+namespace Jack { typedef JackNetUnixSocket JackNetSocket; }
+
+#endif

--- a/qnx/driver.h
+++ b/qnx/driver.h
@@ -1,0 +1,300 @@
+/*
+   Copyright (C) 2001 Paul Davis
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+   $Id: driver.h,v 1.2 2005/11/23 11:24:29 letz Exp $
+*/
+
+#ifndef __jack_driver_h__
+#define __jack_driver_h__
+
+#include <pthread.h>
+#include "types.h"
+#include "jslist.h"
+#include "driver_interface.h"
+
+typedef float gain_t;
+typedef long channel_t;
+
+typedef	enum {
+    Lock = 0x1,
+    NoLock = 0x2,
+    Sync = 0x4,
+    NoSync = 0x8
+} ClockSyncStatus;
+
+typedef void (*ClockSyncListenerFunction)(channel_t, ClockSyncStatus, void*);
+
+typedef struct
+{
+    unsigned long id;
+    ClockSyncListenerFunction function;
+    void *arg;
+}
+ClockSyncListener;
+
+struct _jack_engine;
+struct _jack_driver;
+
+typedef int (*JackDriverAttachFunction)(struct _jack_driver *,
+                                        struct _jack_engine *);
+typedef int (*JackDriverDetachFunction)(struct _jack_driver *,
+                                        struct _jack_engine *);
+typedef int (*JackDriverReadFunction)(struct _jack_driver *,
+                                      jack_nframes_t nframes);
+typedef int (*JackDriverWriteFunction)(struct _jack_driver *,
+                                       jack_nframes_t nframes);
+typedef int (*JackDriverNullCycleFunction)(struct _jack_driver *,
+        jack_nframes_t nframes);
+typedef int (*JackDriverStopFunction)(struct _jack_driver *);
+typedef int (*JackDriverStartFunction)(struct _jack_driver *);
+typedef int	(*JackDriverBufSizeFunction)(struct _jack_driver *,
+        jack_nframes_t nframes);
+/*
+   Call sequence summary:
+
+     1) engine loads driver via runtime dynamic linking
+	 - calls jack_driver_load
+	 - we call dlsym for "driver_initialize" and execute it
+     2) engine attaches to driver
+     3) engine starts driver
+     4) driver runs its own thread, calling
+         while () {
+          driver->wait ();
+	  driver->engine->run_cycle ()
+         }
+     5) engine stops driver
+     6) engine detaches from driver
+     7) engine calls driver `finish' routine
+
+     Note that stop/start may be called multiple times in the event of an
+     error return from the `wait' function.
+*/
+
+typedef struct _jack_driver
+{
+
+    /* The _jack_driver structure fields are included at the beginning of
+       each driver-specific structure using the JACK_DRIVER_DECL macro,
+       which is defined below.  The comments that follow describe each
+       common field.
+      
+       The driver should set this to be the interval it expects to elapse
+       between returning from the `wait' function. if set to zero, it
+       implies that the driver does not expect regular periodic wakeups.
+     
+        jack_time_t period_usecs;
+     
+     
+       The driver should set this within its "wait" function to indicate
+       the UST of the most recent determination that the engine cycle
+       should run. it should not be set if the "extra_fd" argument of
+       the wait function is set to a non-zero value.
+     
+        jack_time_t last_wait_ust;
+     
+     
+       These are not used by the driver.  They should not be written to or
+       modified in any way
+     
+        void *handle;
+        struct _jack_internal_client *internal_client;
+     
+       This should perform any cleanup associated with the driver. it will
+       be called when jack server process decides to get rid of the
+       driver. in some systems, it may not be called at all, so the driver
+       should never rely on a call to this. it can set it to NULL if
+       it has nothing do do.
+     
+        void (*finish)(struct _jack_driver *);
+     
+     
+       The JACK engine will call this when it wishes to attach itself to
+       the driver. the engine will pass a pointer to itself, which the driver
+       may use in anyway it wishes to. the driver may assume that this
+       is the same engine object that will make `wait' calls until a
+       `detach' call is made.
+     
+        JackDriverAttachFunction attach;
+     
+     
+       The JACK engine will call this when it is finished using a driver.
+     
+        JackDriverDetachFunction detach;
+     
+     
+       The JACK engine will call this when it wants to wait until the 
+       driver decides that its time to process some data. the driver returns
+       a count of the number of audioframes that can be processed. 
+     
+       it should set the variable pointed to by `status' as follows:
+     
+       zero: the wait completed normally, processing may begin
+       negative: the wait failed, and recovery is not possible
+       positive: the wait failed, and the driver stopped itself.
+    	       a call to `start' will return the driver to	
+    	       a correct and known state.
+     
+       the driver should also fill out the `delayed_usecs' variable to
+       indicate any delay in its expected periodic execution. for example,
+       if it discovers that its return from poll(2) is later than it
+       expects it to be, it would place an estimate of the delay
+       in this variable. the engine will use this to decide if it 
+       plans to continue execution.
+     
+        JackDriverWaitFunction wait;
+     
+     
+       The JACK engine will call this to ask the driver to move
+       data from its inputs to its output port buffers. it should
+       return 0 to indicate successful completion, negative otherwise. 
+     
+       This function will always be called after the wait function (above).
+     
+        JackDriverReadFunction read;
+     
+     
+       The JACK engine will call this to ask the driver to move
+       data from its input port buffers to its outputs. it should
+       return 0 to indicate successful completion, negative otherwise. 
+     
+       this function will always be called after the read function (above).
+     
+        JackDriverWriteFunction write;
+     
+     
+       The JACK engine will call this after the wait function (above) has
+       been called, but for some reason the engine is unable to execute
+       a full "cycle". the driver should do whatever is necessary to
+       keep itself running correctly, but cannot reference ports
+       or other JACK data structures in any way.
+     
+        JackDriverNullCycleFunction null_cycle;
+     
+        
+       The engine will call this when it plans to stop calling the `wait'
+       function for some period of time. the driver should take
+       appropriate steps to handle this (possibly no steps at all).
+       NOTE: the driver must silence its capture buffers (if any)
+       from within this function or the function that actually
+       implements the change in state.
+     
+        JackDriverStopFunction stop;
+     
+     
+       The engine will call this to let the driver know that it plans
+       to start calling the `wait' function on a regular basis. the driver
+       should take any appropriate steps to handle this (possibly no steps
+       at all). NOTE: The driver may wish to silence its playback buffers
+       (if any) from within this function or the function that actually
+       implements the change in state.
+       
+        JackDriverStartFunction start;
+     
+       The engine will call this to let the driver know that some client
+       has requested a new buffer size.  The stop function will be called
+       prior to this, and the start function after this one has returned.
+     
+        JackDriverBufSizeFunction bufsize;
+    */
+
+    /* define the fields here... */
+#define JACK_DRIVER_DECL \
+    jack_time_t period_usecs; \
+    jack_time_t last_wait_ust; \
+    void *handle; \
+    struct _jack_client_internal * internal_client; \
+    void (*finish)(struct _jack_driver *);\
+    JackDriverAttachFunction attach; \
+    JackDriverDetachFunction detach; \
+    JackDriverReadFunction read; \
+    JackDriverWriteFunction write; \
+    JackDriverNullCycleFunction null_cycle; \
+    JackDriverStopFunction stop; \
+    JackDriverStartFunction start; \
+    JackDriverBufSizeFunction bufsize;
+
+    JACK_DRIVER_DECL			/* expand the macro */
+}
+jack_driver_t;
+
+void jack_driver_init (jack_driver_t *);
+void jack_driver_release (jack_driver_t *);
+
+jack_driver_t *jack_driver_load (int argc, char **argv);
+void jack_driver_unload (jack_driver_t *);
+
+/****************************
+ *** Non-Threaded Drivers ***
+ ****************************/
+
+/*
+   Call sequence summary:
+
+     1) engine loads driver via runtime dynamic linking
+	 - calls jack_driver_load
+	 - we call dlsym for "driver_initialize" and execute it
+         - driver_initialize calls jack_driver_nt_init
+     2) nt layer attaches to driver
+     3) nt layer starts driver
+     4) nt layer runs a thread, calling
+         while () {
+           driver->nt_run_ctcle();
+         }
+     5) nt layer stops driver
+     6) nt layer detaches driver
+     7) engine calls driver `finish' routine which calls jack_driver_nt_finish
+
+     Note that stop/start may be called multiple times in the event of an
+     error return from the `wait' function.
+*/
+
+struct _jack_driver_nt;
+
+typedef int (*JackDriverNTAttachFunction)(struct _jack_driver_nt *);
+typedef int (*JackDriverNTDetachFunction)(struct _jack_driver_nt *);
+typedef int (*JackDriverNTStopFunction)(struct _jack_driver_nt *);
+typedef int (*JackDriverNTStartFunction)(struct _jack_driver_nt *);
+typedef int	(*JackDriverNTBufSizeFunction)(struct _jack_driver_nt *,
+        jack_nframes_t nframes);
+typedef int (*JackDriverNTRunCycleFunction)(struct _jack_driver_nt *);
+
+typedef struct _jack_driver_nt
+{
+#define JACK_DRIVER_NT_DECL \
+    JACK_DRIVER_DECL \
+    struct _jack_engine * engine; \
+    volatile int nt_run; \
+    pthread_t nt_thread; \
+    pthread_mutex_t nt_run_lock; \
+    JackDriverNTAttachFunction nt_attach; \
+    JackDriverNTDetachFunction nt_detach; \
+    JackDriverNTStopFunction nt_stop; \
+    JackDriverNTStartFunction nt_start; \
+    JackDriverNTBufSizeFunction nt_bufsize; \
+    JackDriverNTRunCycleFunction nt_run_cycle;
+#define nt_read read
+#define nt_write write
+#define nt_null_cycle null_cycle
+
+    JACK_DRIVER_NT_DECL
+}
+jack_driver_nt_t;
+
+void jack_driver_nt_init (jack_driver_nt_t * driver);
+void jack_driver_nt_finish (jack_driver_nt_t * driver);
+
+#endif /* __jack_driver_h__ */

--- a/solaris/oss/JackBoomerDriver.cpp
+++ b/solaris/oss/JackBoomerDriver.cpp
@@ -87,7 +87,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32u24(dst, (char*)s32src, nframes, byte_skip);
+            sample_move_dS_s32(dst, (char*)s32src, nframes, byte_skip);
 			break;
         }
 	}
@@ -112,7 +112,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32u24_sS((char*)s32dst, src, nframes, byte_skip, NULL);
+            sample_move_d32_sS((char*)s32dst, src, nframes, byte_skip, NULL);
 			break;
         }
 	}

--- a/solaris/oss/JackOSSAdapter.cpp
+++ b/solaris/oss/JackOSSAdapter.cpp
@@ -52,7 +52,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32u24(dst, (char*)s32src, nframes, chcount<<2);
+            sample_move_dS_s32(dst, (char*)s32src, nframes, chcount<<2);
 			break;
         }
 	}
@@ -77,7 +77,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32u24_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
+            sample_move_d32_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
 			break;
         }
 	}

--- a/solaris/oss/JackOSSDriver.cpp
+++ b/solaris/oss/JackOSSDriver.cpp
@@ -86,7 +86,7 @@ static inline void CopyAndConvertIn(jack_sample_t *dst, void *src, size_t nframe
 		case 32: {
 			signed int *s32src = (signed int*)src;
             s32src += channel;
-            sample_move_dS_s32u24(dst, (char*)s32src, nframes, chcount<<2);
+            sample_move_dS_s32(dst, (char*)s32src, nframes, chcount<<2);
 			break;
         }
 	}
@@ -111,7 +111,7 @@ static inline void CopyAndConvertOut(void *dst, jack_sample_t *src, size_t nfram
 		case 32: {
             signed int *s32dst = (signed int*)dst;
             s32dst += channel;
-            sample_move_d32u24_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
+            sample_move_d32_sS((char*)s32dst, src, nframes, chcount<<2, NULL);
 			break;
         }
 	}

--- a/tests/wscript
+++ b/tests/wscript
@@ -20,6 +20,8 @@ def build(bld):
             prog.includes = ['..','../macosx', '../posix', '../common/jack', '../common']
         if bld.env['IS_LINUX']:
             prog.includes = ['..','../linux', '../posix', '../common/jack', '../common']
+        if bld.env['IS_QNX']:
+            prog.includes = ['..','../qnx', '../posix', '../common/jack', '../common']
         if bld.env['IS_SUN']:
             prog.includes = ['..','../solaris', '../posix', '../common/jack', '../common']
         prog.source = test_program_sources


### PR DESCRIPTION
Hello,

these fixes add compatibility for QNX. They are part of more change requests that are being prepared at the moment. The changes are tested on QNX and linux/aarch64 based board and used in production.

Compatibility on QNX in this case is achieved by modifying jack to be able to compile on QNX and using JackAlsaDriver to interface with QNX tinyalsa library implementation.

Tested working:
```
jackd -n acoustic -R -P 80 -d alsa -C "hw:card" -P "hw:card" -p 96 -r 48000 -n 6
jack_lsp -s acoustic
jack_connect -s acoustic system:capture_1 system:playback_2
jack_lsp -s acoustic -c
jack_disconnect -s acoustic system:capture_1 system:playback_2
jack_lsp -s acoustic -c
jack_simple_client cl acoustic
```

Verification of changes is done on:
 - qnx platform
 - linux/aarch64 platform

Adam