### PR TITLE
Fix segFault in case func returns -1

### DIFF
--- a/example-clients/property.c
+++ b/example-clients/property.c
@@ -264,7 +264,7 @@ int main (int argc, char* argv[])
                                 return -1;
                         }
 
-                        if ((cnt = jack_get_properties (uuid, &description)) < 0) {
+                        if ((int)(cnt = jack_get_properties (uuid, &description)) < 0) {
                                 fprintf (stderr, "could not retrieve properties for %s\n", subject);
                                 exit (1);
                         }


### PR DESCRIPTION
jack_get_properties can return -1. But since size_t is unsigned, it is not <0.
It leads to a "segmentation fault (core dumped)  jack_property -l 4294967300"

Not sure if it is the best way to fix it.