### PR TITLE
jack: remove unnecessary GPL include from LGPL code

### DIFF
--- a/posix/JackSocketServerChannel.cpp
+++ b/posix/JackSocketServerChannel.cpp
@@ -22,7 +22,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackServer.h"
 #include "JackLockedEngine.h"
 #include "JackGlobals.h"
-#include "JackServerGlobals.h"
 #include "JackClient.h"
 #include "JackTools.h"
 #include "JackNotification.h"

--- a/posix/JackSocketServerNotifyChannel.cpp
+++ b/posix/JackSocketServerNotifyChannel.cpp
@@ -22,7 +22,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackRequest.h"
 #include "JackConstants.h"
 #include "JackNotification.h"
-#include "JackServerGlobals.h"
 
 namespace Jack
 {


### PR DESCRIPTION
in this case LGPL code is compiled into one library with GPL code, but
the include is not necessary and may cause problems in case
these files are separated into their own library

Change-Id: I9fc2499d60d8f25a8714c7c39b7b36206d5c5cf5
Signed-off-by: Adam Miartus <external.adam.miartus@de.bosch.com>