### PR TITLE
use feature test macro correctly

### DIFF
--- a/posix/JackPosixSemaphore.cpp
+++ b/posix/JackPosixSemaphore.cpp
@@ -17,6 +17,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
 
+#define _POSIX_C_SOURCE 200112L
+
 #include "JackPosixSemaphore.h"
 #include "JackTools.h"
 #include "JackConstants.h"
@@ -111,8 +113,6 @@ bool JackPosixSemaphore::Wait()
     return (res == 0);
 }
 
-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) // glibc feature test
-
 bool JackPosixSemaphore::TimedWait(long usec)
 {
 	int res;
@@ -139,15 +139,6 @@ bool JackPosixSemaphore::TimedWait(long usec)
     }
     return (res == 0);
 }
-
-#else
-#warning "JackPosixSemaphore::TimedWait is not supported: Jack in SYNC mode with JackPosixSemaphore will not run properly !!"
-
-bool JackPosixSemaphore::TimedWait(long usec)
-{
-	return Wait();
-}
-#endif
 
 // Server side : publish the semaphore in the global namespace
 bool JackPosixSemaphore::Allocate(const char* name, const char* server_name, int value)


### PR DESCRIPTION
The feature test macro should be defined, not tested. See [Feature Test Macros](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html):
>    Macro: _POSIX_C_SOURCE

>    Define this macro to a positive integer to control which POSIX functionality is made available. The greater the value of this macro, the more functionality is made available.
>    ....
>    If you define this macro to a value greater than or equal to 200112L, then the functionality from the 2001 edition of the POSIX standard (IEEE Standard 1003.1-2001) is made available. 

sem_timedwait is defined if _POSIX_C_SOURCE >= 200112L, so define it as such. If a system does not support this, it will be undefined and there will be a compilation error.