### PR TITLE
posix: remove frequent log in verbose mode

### DIFF
--- a/posix/JackSocketServerChannel.cpp
+++ b/posix/JackSocketServerChannel.cpp
@@ -230,7 +230,6 @@ bool JackSocketServerChannel::Execute()
             // Poll all clients
             for (unsigned int i = 1; i < fSocketTable.size() + 1; i++) {
                 int fd = fPollTable[i].fd;
-                jack_log("JackSocketServerChannel::Execute : fPollTable i = %ld fd = %ld", i, fd);
                 if (fPollTable[i].revents & ~POLLIN) {
                     jack_log("JackSocketServerChannel::Execute : poll client error err = %s", strerror(errno));
                     ClientKill(fd);


### PR DESCRIPTION
debug log with no additional informational benefit spams
output in verbose mode, therefore remove