### PR TITLE
Multi server by same client support

### DIFF
--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -348,8 +348,7 @@ LIB_EXPORT void* jack_port_get_buffer(jack_port_t* port, jack_nframes_t frames)
 {
     JackGlobals::CheckContext("jack_port_get_buffer");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_buffer called with an incorrect port %ld", myport);
         return NULL;
@@ -363,8 +362,7 @@ LIB_EXPORT jack_uuid_t jack_port_uuid(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_uuid");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_uuid called with an incorrect port %ld", myport);
         return 0;
@@ -377,8 +375,7 @@ LIB_EXPORT const char* jack_port_name(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_name");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_name called with an incorrect port %ld", myport);
         return NULL;
@@ -392,8 +389,7 @@ LIB_EXPORT const char* jack_port_short_name(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_short_name");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_short_name called with an incorrect port %ld", myport);
         return NULL;
@@ -407,8 +403,7 @@ LIB_EXPORT int jack_port_flags(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_flags");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_flags called with an incorrect port %ld", myport);
         return -1;
@@ -422,8 +417,7 @@ LIB_EXPORT const char* jack_port_type(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_type");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_flags called an incorrect port %ld", myport);
         return NULL;
@@ -437,8 +431,7 @@ LIB_EXPORT jack_port_type_id_t jack_port_type_id(const jack_port_t *port)
 {
     JackGlobals::CheckContext("jack_port_type_id");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_type_id called an incorrect port %ld", myport);
         return 0;
@@ -452,8 +445,7 @@ LIB_EXPORT int jack_port_connected(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_connected");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_connected called with an incorrect port %ld", myport);
         return -1;
@@ -468,8 +460,7 @@ LIB_EXPORT int jack_port_connected_to(const jack_port_t* port, const char* port_
 {
     JackGlobals::CheckContext("jack_port_connected_to");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t src = (jack_port_id_t)port_aux;
+    jack_port_id_t src = JackGlobals::PortId(port);
     if (!CheckPort(src)) {
         jack_error("jack_port_connected_to called with an incorrect port %ld", src);
         return -1;
@@ -493,14 +484,12 @@ LIB_EXPORT int jack_port_tie(jack_port_t* src, jack_port_t* dst)
 {
     JackGlobals::CheckContext("jack_port_tie");
 
-    uintptr_t src_aux = (uintptr_t)src;
-    jack_port_id_t mysrc = (jack_port_id_t)src_aux;
+    jack_port_id_t mysrc = JackGlobals::PortId(src);
     if (!CheckPort(mysrc)) {
         jack_error("jack_port_tie called with a NULL src port");
         return -1;
     }
-    uintptr_t dst_aux = (uintptr_t)dst;
-    jack_port_id_t mydst = (jack_port_id_t)dst_aux;
+    jack_port_id_t mydst = JackGlobals::PortId(dst);
     if (!CheckPort(mydst)) {
         jack_error("jack_port_tie called with a NULL dst port");
         return -1;
@@ -518,8 +507,7 @@ LIB_EXPORT int jack_port_untie(jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_untie");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_untie called with an incorrect port %ld", myport);
         return -1;
@@ -533,8 +521,7 @@ LIB_EXPORT jack_nframes_t jack_port_get_latency(jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_get_latency");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_latency called with an incorrect port %ld", myport);
         return 0;
@@ -549,8 +536,7 @@ LIB_EXPORT void jack_port_set_latency(jack_port_t* port, jack_nframes_t frames)
 {
     JackGlobals::CheckContext("jack_port_set_latency");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_set_latency called with an incorrect port %ld", myport);
     } else {
@@ -564,8 +550,7 @@ LIB_EXPORT void jack_port_get_latency_range(jack_port_t *port, jack_latency_call
 {
     JackGlobals::CheckContext("jack_port_get_latency_range");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_latency_range called with an incorrect port %ld", myport);
     } else {
@@ -580,8 +565,7 @@ LIB_EXPORT void jack_port_set_latency_range(jack_port_t *port, jack_latency_call
 {
     JackGlobals::CheckContext("jack_port_set_latency_range");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_set_latency_range called with an incorrect port %ld", myport);
     } else {
@@ -598,8 +582,7 @@ LIB_EXPORT int jack_recompute_total_latency(jack_client_t* ext_client, jack_port
 
 
     JackClient* client = (JackClient*)ext_client;
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (client == NULL) {
         jack_error("jack_recompute_total_latency called with a NULL client");
         return -1;
@@ -647,8 +630,7 @@ LIB_EXPORT int jack_port_rename(jack_client_t* ext_client, jack_port_t* port, co
     JackGlobals::CheckContext("jack_port_rename");
 
     JackClient* client = (JackClient*)ext_client;
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (client == NULL) {
         jack_error("jack_port_rename called with a NULL client");
         return -1;
@@ -667,8 +649,7 @@ LIB_EXPORT int jack_port_set_alias(jack_port_t* port, const char* name)
 {
     JackGlobals::CheckContext("jack_port_set_alias");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_set_alias called with an incorrect port %ld", myport);
         return -1;
@@ -685,8 +666,7 @@ LIB_EXPORT int jack_port_unset_alias(jack_port_t* port, const char* name)
 {
     JackGlobals::CheckContext("jack_port_unset_alias");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_unset_alias called with an incorrect port %ld", myport);
         return -1;
@@ -703,8 +683,7 @@ LIB_EXPORT int jack_port_get_aliases(const jack_port_t* port, char* const aliase
 {
     JackGlobals::CheckContext("jack_port_get_aliases");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_aliases called with an incorrect port %ld", myport);
         return -1;
@@ -718,8 +697,7 @@ LIB_EXPORT int jack_port_request_monitor(jack_port_t* port, int onoff)
 {
     JackGlobals::CheckContext("jack_port_request_monitor");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_request_monitor called with an incorrect port %ld", myport);
         return -1;
@@ -755,8 +733,7 @@ LIB_EXPORT int jack_port_ensure_monitor(jack_port_t* port, int onoff)
 {
     JackGlobals::CheckContext("jack_port_ensure_monitor");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_ensure_monitor called with an incorrect port %ld", myport);
         return -1;
@@ -770,8 +747,7 @@ LIB_EXPORT int jack_port_monitoring_input(jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_monitoring_input");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_monitoring_input called with an incorrect port %ld", myport);
         return -1;
@@ -1108,8 +1084,7 @@ LIB_EXPORT int jack_port_unregister(jack_client_t* ext_client, jack_port_t* port
         jack_error("jack_port_unregister called with a NULL client");
         return -1;
     }
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_unregister called with an incorrect port %ld", myport);
         return -1;
@@ -1126,8 +1101,7 @@ LIB_EXPORT int jack_port_is_mine(const jack_client_t* ext_client, const jack_por
         jack_error("jack_port_is_mine called with a NULL client");
         return -1;
     }
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_is_mine called with an incorrect port %ld", myport);
         return -1;
@@ -1139,8 +1113,7 @@ LIB_EXPORT const char** jack_port_get_connections(const jack_port_t* port)
 {
     JackGlobals::CheckContext("jack_port_get_connections");
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_connections called with an incorrect port %ld", myport);
         return NULL;
@@ -1162,8 +1135,7 @@ LIB_EXPORT const char** jack_port_get_all_connections(const jack_client_t* ext_c
         return NULL;
     }
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_all_connections called with an incorrect port %ld", myport);
         return NULL;
@@ -1184,8 +1156,7 @@ LIB_EXPORT jack_nframes_t jack_port_get_total_latency(jack_client_t* ext_client,
         return 0;
     }
 
-    uintptr_t port_aux = (uintptr_t)port;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(port);
     if (!CheckPort(myport)) {
         jack_error("jack_port_get_total_latency called with an incorrect port %ld", myport);
         return 0;
@@ -1242,8 +1213,7 @@ LIB_EXPORT int jack_port_disconnect(jack_client_t* ext_client, jack_port_t* src)
         jack_error("jack_port_disconnect called with a NULL client");
         return -1;
     }
-    uintptr_t port_aux = (uintptr_t)src;
-    jack_port_id_t myport = (jack_port_id_t)port_aux;
+    jack_port_id_t myport = JackGlobals::PortId(src);
     if (!CheckPort(myport)) {
         jack_error("jack_port_disconnect called with an incorrect port %ld", myport);
         return -1;

--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -1699,10 +1699,12 @@ LIB_EXPORT int jack_client_max_real_time_priority(jack_client_t* ext_client)
 
 LIB_EXPORT int jack_acquire_real_time_scheduling(jack_native_thread_t thread, int priority)
 {
-    JackEngineControl* control = GetEngineControl();
-    return (control
-        ? JackThread::AcquireRealTimeImp(thread, priority, control->fPeriod, control->fComputation, control->fConstraint)
-        : -1);
+    jack_error("jack_acquire_real_time_scheduling is not implemented");
+    abort();
+//    JackEngineControl* control = GetEngineControl();
+//    return (control
+//        ? JackThread::AcquireRealTimeImp(thread, priority, control->fPeriod, control->fComputation, control->fConstraint)
+//        : -1);
 }
 
 LIB_EXPORT int jack_client_create_thread(jack_client_t* client,

--- a/common/JackAudioAdapterFactory.cpp
+++ b/common/JackAudioAdapterFactory.cpp
@@ -60,9 +60,15 @@ extern "C"
         jack_nframes_t buffer_size = jack_get_buffer_size(jack_client);
         jack_nframes_t sample_rate = jack_get_sample_rate(jack_client);
 
+
+        if (jack_client == NULL) {
+            jack_error("jack_internal_initialize called with NULL jack_client");
+            return 1;
+        }
+
         try {
 
-            adapter = new Jack::JackAudioAdapter(jack_client, new Jack::JackPlatformAdapter(buffer_size, sample_rate, params), params);
+            adapter = new Jack::JackAudioAdapter(jack_client, new Jack::JackPlatformAdapter(*((JackClient*) jack_client), buffer_size, sample_rate, params), params);
             assert(adapter);
 
             if (adapter->Open() == 0) {

--- a/common/JackAudioPort.cpp
+++ b/common/JackAudioPort.cpp
@@ -154,9 +154,9 @@ static void AudioBufferMixdown(void* mixbuffer, void** src_buffers, int src_coun
     }
 }
 
-static size_t AudioBufferSize()
+static size_t AudioBufferSize(JackGlobals *global)
 {
-    return GetEngineControl()->fBufferSize * sizeof(jack_default_audio_sample_t);
+    return global->GetEngineControl()->fBufferSize * sizeof(jack_default_audio_sample_t);
 }
 
 const JackPortType gAudioPortType =

--- a/common/JackClient.cpp
+++ b/common/JackClient.cpp
@@ -39,9 +39,10 @@ namespace Jack
 
 #define IsRealTime() ((fProcess != NULL) | (fThreadFun != NULL) | (fSync != NULL) | (fTimebase != NULL))
 
-JackClient::JackClient(JackSynchro* table):fThread(this)
+JackClient::JackClient(JackGlobals* globals):JackGlobalsInterface(globals),
+    fThread(this)
 {
-    fSynchroTable = table;
+    fSynchroTable = globals->GetSynchroTable();
     fProcess = NULL;
     fGraphOrder = NULL;
     fXrun = NULL;
@@ -114,11 +115,12 @@ int JackClient::Close()
     fChannel->ClientClose(GetClientControl()->fRefNum, &result);
   
     fChannel->Close();
-    assert(JackGlobals::fSynchroMutex);
-    JackGlobals::fSynchroMutex->Lock();
+    assert(GetGlobal());
+    assert(GetGlobal()->fSynchroMutex);
+    GetGlobal()->fSynchroMutex->Lock();
     fSynchroTable[GetClientControl()->fRefNum].Disconnect();
-    JackGlobals::fSynchroMutex->Unlock();
-    JackGlobals::fClientTable[GetClientControl()->fRefNum] = NULL;
+    GetGlobal()->fSynchroMutex->Unlock();
+    GetGlobal()->fClientTable[GetClientControl()->fRefNum] = nullptr;
     return result;
 }
 
@@ -1344,7 +1346,6 @@ int JackClient::PropertyChangeNotify(jack_uuid_t subject, const char* key, jack_
     fChannel->PropertyChangeNotify(subject, key, change, &result);
     return result;
 }
-
 
 } // end of namespace
 

--- a/common/JackClient.h
+++ b/common/JackClient.h
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackChannel.h"
 #include "JackRequest.h"
 #include "JackMetadata.h"
+#include "JackGlobals.h"
 #include "varargs.h"
 #include <list>
 
@@ -45,7 +46,7 @@ struct JackEngineControl;
 \brief The base class for clients: share part of the implementation for JackInternalClient and JackLibClient.
 */
 
-class SERVER_EXPORT JackClient : public JackClientInterface, public JackRunnableInterface
+class SERVER_EXPORT JackClient : public JackClientInterface, public JackRunnableInterface, public JackGlobalsInterface
 {
         friend class JackDebugClient;
 
@@ -128,7 +129,7 @@ class SERVER_EXPORT JackClient : public JackClientInterface, public JackRunnable
 
     public:
 
-        JackClient(JackSynchro* table);
+        JackClient(JackGlobals* globals);
         virtual ~JackClient();
         
         char* GetServerName() { return fServerName; }

--- a/common/JackConnectionManager.cpp
+++ b/common/JackConnectionManager.cpp
@@ -57,7 +57,7 @@ bool JackConnectionManager::IsLoopPathAux(int ref1, int ref2) const
 {
     jack_log("JackConnectionManager::IsLoopPathAux ref1 = %ld ref2 = %ld", ref1, ref2);
 
-    if (ref1 < GetEngineControl()->fDriverNum || ref2 < GetEngineControl()->fDriverNum) {
+    if (ref1 < GetGlobal()->GetEngineControl()->fDriverNum || ref2 < GetGlobal()->GetEngineControl()->fDriverNum) {
         return false;
     } else if (ref1 == ref2) {	// Same refnum
         return true;

--- a/common/JackConnectionManager.h
+++ b/common/JackConnectionManager.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackConstants.h"
 #include "JackActivationCount.h"
 #include "JackError.h"
+#include "JackGlobals.h"
 #include "JackCompilerDeps.h"
 #include <vector>
 #include <assert.h>
@@ -408,7 +409,7 @@ struct JackClientTiming
 */
 
 PRE_PACKED_STRUCTURE
-class SERVER_EXPORT JackConnectionManager
+class SERVER_EXPORT JackConnectionManager : public JackGlobalsInterface
 {
 
     private:

--- a/common/JackConstants.h
+++ b/common/JackConstants.h
@@ -57,6 +57,12 @@
 #define PORT_NUM_FOR_CLIENT 768
 #endif
 
+// used by JackLib when process has mulitple clients connecting to different Jack Servers
+#define PORT_SERVER_CONTEXT_BITS (8)
+#define PORT_SERVER_CONTEXT_MAX ((1 << PORT_SERVER_CONTEXT_BITS) - 1)
+#define PORT_SERVER_CONTEXT_SHIFT (sizeof(jack_port_id_t) * 8 - PORT_SERVER_CONTEXT_BITS)
+#define PORT_SERVER_CONTEXT_MASK (PORT_SERVER_CONTEXT_MAX << PORT_SERVER_CONTEXT_SHIFT)
+
 #define FIRST_AVAILABLE_PORT 1
 
 #define CONNECTION_NUM_FOR_PORT PORT_NUM_FOR_CLIENT

--- a/common/JackControlAPI.cpp
+++ b/common/JackControlAPI.cpp
@@ -1052,6 +1052,12 @@ jackctl_server_open(
             goto fail;
         }
 
+        JackServerGlobals *global = JackGlobalsManager::Instance()->CreateGlobal<JackServerGlobals>(server_ptr->name.str);
+        if (global == nullptr) {
+            jack_error("Failed to create global context");
+            goto fail;
+        }
+
         /* get the engine/driver started */
         server_ptr->engine = new JackServer(
             server_ptr->sync.b,
@@ -1063,7 +1069,8 @@ jackctl_server_open(
             server_ptr->verbose.b,
             (jack_timer_type_t)server_ptr->clock_source.ui,
             server_ptr->self_connect_mode.c,
-            server_ptr->name.str);
+            server_ptr->name.str,
+            global);
         if (server_ptr->engine == NULL)
         {
             jack_error("Failed to create new JackServer object");

--- a/common/JackDebugClient.cpp
+++ b/common/JackDebugClient.cpp
@@ -35,7 +35,7 @@ namespace Jack
 {
 
 JackDebugClient::JackDebugClient(JackClient * client)
-  : JackClient(client->fSynchroTable)
+  : JackClient(client->GetGlobal())
 {
     fTotalPortNumber = 1;       // The total number of port opened and maybe closed. Historical view.
     fOpenPortNumber = 0;        // The current number of opened port.

--- a/common/JackDriver.h
+++ b/common/JackDriver.h
@@ -126,6 +126,7 @@ typedef std::list<std::pair<std::string, std::pair<std::string, std::string> > >
 
 class SERVER_EXPORT JackDriver : public JackDriverClientInterface
 {
+    friend class JackThreadedDriver;
 
     protected:
 

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -92,7 +92,11 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     JackEngineProfiling fProfiler;
 #endif
 
-    JackEngineControl(bool sync, bool temporary, long timeout, bool rt, long priority, bool verbose, jack_timer_type_t clock, const char* server_name)
+    JackEngineControl(bool sync, bool temporary, long timeout, bool rt, long priority, bool verbose, jack_timer_type_t clock, const char* server_name, JackGlobals *global)
+        : fTransport(global)
+#ifdef JACK_MONITOR
+        , fProfiler(global)
+#endif
     {
         fBufferSize = 512;
         fSampleRate = 48000;

--- a/common/JackEngineProfiling.cpp
+++ b/common/JackEngineProfiling.cpp
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 namespace Jack
 {
 
-JackEngineProfiling::JackEngineProfiling():fAudioCycle(0),fMeasuredClient(0)
+JackEngineProfiling::JackEngineProfiling(JackGlobals *global):fGlobal(global), fAudioCycle(0),fMeasuredClient(0)
 {
     jack_info("Engine profiling activated, beware %ld MBytes are needed to record profiling points...", sizeof(fProfileTable) / (1024 * 1024));
 
@@ -354,7 +354,7 @@ void JackEngineProfiling::Profile(JackClientInterface** table,
     fProfileTable[fAudioCycle].fPrevCycleEnd = prev_cycle_end;
     fProfileTable[fAudioCycle].fAudioCycle = fAudioCycle;
 
-    for (int i = GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
+    for (int i = fGlobal->GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
         JackClientInterface* client = table[i];
         JackClientTiming* timing = manager->GetClientTiming(i);
         if (client && client->GetClientControl()->fActive && client->GetClientControl()->fCallback[kRealTimeCallback]) {

--- a/common/JackEngineProfiling.h
+++ b/common/JackEngineProfiling.h
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackTypes.h"
 #include "JackConstants.h"
 #include "JackShmMem.h"
+#include "JackGlobals.h"
 
 namespace Jack
 {
@@ -111,6 +112,8 @@ class SERVER_EXPORT JackEngineProfiling
 
     private:
 
+        JackGlobals* fGlobal;
+
         JackTimingMeasure fProfileTable[TIME_POINTS];
         JackTimingClientInterval fIntervalTable[MEASURED_CLIENTS];
 
@@ -121,7 +124,7 @@ class SERVER_EXPORT JackEngineProfiling
 
     public:
 
-        JackEngineProfiling();
+        JackEngineProfiling(JackGlobals *global);
         ~JackEngineProfiling();
 
         void Profile(JackClientInterface** table, 

--- a/common/JackGenericClientChannel.cpp
+++ b/common/JackGenericClientChannel.cpp
@@ -25,8 +25,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 namespace Jack
 {
 
-JackGenericClientChannel::JackGenericClientChannel()
-{}
+JackGenericClientChannel::JackGenericClientChannel(JackGlobals *global)
+{
+    fGlobals = global;
+}
 
 JackGenericClientChannel::~JackGenericClientChannel()
 {}
@@ -52,8 +54,8 @@ void JackGenericClientChannel::ServerSyncCall(JackRequest* req, JackResult* res,
         *result = -1;
         return;
     }
-    
-    if (!JackGlobals::fServerRunning) {
+
+    if (!fGlobals->fServerRunning) {
         jack_error("Server is not running");
         *result = -1;
         return;
@@ -83,7 +85,7 @@ void JackGenericClientChannel::ServerAsyncCall(JackRequest* req, JackResult* res
         return;
     }
     
-    if (!JackGlobals::fServerRunning) {
+    if (!fGlobals->fServerRunning) {
         jack_error("Server is not running");
         *result = -1;
         return;

--- a/common/JackGenericClientChannel.h
+++ b/common/JackGenericClientChannel.h
@@ -27,6 +27,7 @@ namespace Jack
 
 struct JackRequest;
 struct JackResult;
+class JackGlobals;
 
 /*!
 \brief Generic JackClientChannel class.
@@ -37,6 +38,8 @@ class JackGenericClientChannel : public detail::JackClientChannelInterface
 
     protected:
 
+        JackGlobals *fGlobals;
+
         detail::JackClientRequestInterface* fRequest;
 
         void ServerSyncCall(JackRequest* req, JackResult* res, int* result);
@@ -44,7 +47,7 @@ class JackGenericClientChannel : public detail::JackClientChannelInterface
 
     public:
 
-        JackGenericClientChannel();
+        JackGenericClientChannel(JackGlobals *global);
         virtual ~JackGenericClientChannel();
 
         virtual int Open(const char* server_name, const char* name, jack_uuid_t uuid, char* name_res, JackClient* obj, jack_options_t options, jack_status_t* status) { return -1; }

--- a/common/JackGlobals.cpp
+++ b/common/JackGlobals.cpp
@@ -34,9 +34,8 @@ jack_tls_key JackGlobals::fKeyLogFunction;
 static bool fKeyLogFunctionInitialized = jack_tls_allocate_key(&JackGlobals::fKeyLogFunction);
 
 JackMutex* JackGlobals::fOpenMutex = new JackMutex();
-JackMutex* JackGlobals::fSynchroMutex = new JackMutex();
-volatile bool JackGlobals::fServerRunning = false;
-JackClient* JackGlobals::fClientTable[CLIENT_NUM] = {};
+
+JackGlobalsManager JackGlobalsManager::fInstance;
 
 #ifndef WIN32
 jack_thread_creator_t JackGlobals::fJackThreadCreator = pthread_create;
@@ -77,5 +76,17 @@ void JackGlobals::CheckContext(const char* name)
 {}
 
 #endif
+
+JackGlobals::JackGlobals(const std::string &server_name)
+    : fServerRunning(false)
+    , fSynchroMutex(new JackMutex)
+    , fServerName(server_name)
+{
+}
+
+JackGlobals::~JackGlobals()
+{
+    delete fSynchroMutex;
+}
 
 } // end of namespace

--- a/common/JackGlobals.h
+++ b/common/JackGlobals.h
@@ -57,6 +57,12 @@ class JackGlobals
 #endif
         static void CheckContext(const char* name);
 
+        inline static jack_port_id_t PortId(const jack_port_t* port)
+        {
+            uintptr_t port_aux = (uintptr_t)port;
+            jack_port_id_t port_id = (jack_port_id_t)port_aux;
+            return port_id;
+        }
 };
 
 // Each "side" server and client will implement this to get the shared graph manager, engine control and inter-process synchro table.

--- a/common/JackGlobals.h
+++ b/common/JackGlobals.h
@@ -35,24 +35,28 @@ namespace Jack
 {
 
 // Globals used for client management on server or library side.
-struct JackGlobals {
+class JackGlobals
+{
 
-    static jack_tls_key fRealTimeThread;
-    static jack_tls_key fNotificationThread;
-    static jack_tls_key fKeyLogFunction;
-    static JackMutex* fOpenMutex;
-    static JackMutex* fSynchroMutex;
-    static volatile bool fServerRunning;
-    static JackClient* fClientTable[CLIENT_NUM];
-    static bool fVerbose;
+    public:
+
+        static jack_tls_key fRealTimeThread;
+        static jack_tls_key fNotificationThread;
+        static jack_tls_key fKeyLogFunction;
+        static JackMutex* fOpenMutex;
+        static JackMutex* fSynchroMutex;
+        static volatile bool fServerRunning;
+        static JackClient* fClientTable[CLIENT_NUM];
+        static bool fVerbose;
 #ifndef WIN32
-    static jack_thread_creator_t fJackThreadCreator;
+        static jack_thread_creator_t fJackThreadCreator;
 #endif
 
 #ifdef __CLIENTDEBUG__
-    static std::ofstream* fStream;
+        static std::ofstream* fStream;
 #endif
-     static void CheckContext(const char* name);
+        static void CheckContext(const char* name);
+
 };
 
 // Each "side" server and client will implement this to get the shared graph manager, engine control and inter-process synchro table.

--- a/common/JackGlobals.h
+++ b/common/JackGlobals.h
@@ -20,9 +20,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #ifndef __JackGlobals__
 #define __JackGlobals__
 
+#include <memory>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <mutex>
+
 #include "JackPlatformPlug.h"
 #include "JackSystemDeps.h"
 #include "JackConstants.h"
+#include "JackError.h"
 
 #ifdef __CLIENTDEBUG__
 #include <iostream>
@@ -33,10 +40,49 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 namespace Jack
 {
+    class JackGlobals;
+    class JackGraphManager;
+    class JackServer;
+    struct JackEngineControl;
+
+// Globals used for client management on server or library side.
+class JackGlobalsManager
+{
+
+    /* This object is managed by JackGlobalsManager */
+    private:
+
+        static JackGlobalsManager fInstance;
+
+        JackGlobalsManager() {}
+        ~JackGlobalsManager() {}
+
+    public:
+
+        std::vector<JackGlobals*> fContexts;
+
+        inline static JackGlobalsManager* Instance()
+        {
+            return &fInstance;
+        }
+
+        template <class T>
+        inline T* CreateGlobal(const std::string &server_name);
+
+        inline void DestroyGlobal(const std::string &server_name);
+
+};
 
 // Globals used for client management on server or library side.
 class JackGlobals
 {
+
+    friend class JackGlobalsManager;
+
+    protected:
+
+        JackGlobals(const std::string &server_name);
+        virtual ~JackGlobals();
 
     public:
 
@@ -44,9 +90,6 @@ class JackGlobals
         static jack_tls_key fNotificationThread;
         static jack_tls_key fKeyLogFunction;
         static JackMutex* fOpenMutex;
-        static JackMutex* fSynchroMutex;
-        static volatile bool fServerRunning;
-        static JackClient* fClientTable[CLIENT_NUM];
         static bool fVerbose;
 #ifndef WIN32
         static jack_thread_creator_t fJackThreadCreator;
@@ -57,18 +100,179 @@ class JackGlobals
 #endif
         static void CheckContext(const char* name);
 
+        volatile bool fServerRunning;
+        JackMutex* fSynchroMutex;
+        std::mutex fMutex;
+        std::string fServerName;
+        JackClient* fClientTable[CLIENT_NUM];
+
+        /* is called each time a context for specific server is added */
+        virtual bool AddContext(const uint32_t &cntx_num, const std::string &server_name) = 0;
+
+        /* is called each time a context for specific server is removed */
+        virtual bool DelContext(const uint32_t &cntx_num) = 0;
+
+        virtual JackGraphManager* GetGraphManager() = 0;
+        virtual JackEngineControl* GetEngineControl() = 0;
+        virtual JackSynchro* GetSynchroTable() = 0;
+        virtual JackServer* GetServer() = 0;
+
         inline static jack_port_id_t PortId(const jack_port_t* port)
         {
             uintptr_t port_aux = (uintptr_t)port;
-            jack_port_id_t port_id = (jack_port_id_t)port_aux;
+            jack_port_id_t port_masked = (jack_port_id_t)port_aux;
+            jack_port_id_t port_id = port_masked & ~PORT_SERVER_CONTEXT_MASK;
             return port_id;
         }
+
+        inline static JackGlobals* PortGlobal(const jack_port_t* port)
+        {
+            jack_port_id_t context_id = PortContext(port);
+
+            if (context_id >= JackGlobalsManager::Instance()->fContexts.size())
+            {
+                jack_error("invalid context for port '%p' requested", port);
+                return nullptr;
+            }
+
+            return JackGlobalsManager::Instance()->fContexts[context_id];
+        }
+
+        inline static jack_port_id_t PortContext(const jack_port_t* port)
+        {
+            uintptr_t port_aux = (uintptr_t)port;
+            jack_port_id_t port_masked = (jack_port_id_t)port_aux;
+            jack_port_id_t port_context = (port_masked & PORT_SERVER_CONTEXT_MASK) >> PORT_SERVER_CONTEXT_SHIFT;
+            return port_context;
+        }
+
+        inline jack_port_id_t PortContext()
+        {
+            std::vector<JackGlobals*> &contexts = JackGlobalsManager::Instance()->fContexts;
+
+            auto it = std::find_if(contexts.begin(), contexts.end(), [this] (JackGlobals* i) {
+                return (i && i->fServerName.compare(this->fServerName) == 0);
+            });
+
+            if (it == contexts.end()) {
+                return PORT_SERVER_CONTEXT_MAX;
+            }
+
+            return it - contexts.begin();
+        }
+
+        inline jack_port_t* PortById(const jack_port_id_t &port_id)
+        {
+            jack_port_id_t context_id = PortContext();
+            if (context_id > PORT_SERVER_CONTEXT_MAX) {
+                return NULL;
+            }
+
+            /* cast to uintptr_t required to avoid [-Wint-to-pointer-cast] warning */
+            const uintptr_t port = ((context_id << PORT_SERVER_CONTEXT_SHIFT) | port_id);
+            return (jack_port_t*)port;
+
+
+        }
+
 };
 
-// Each "side" server and client will implement this to get the shared graph manager, engine control and inter-process synchro table.
-extern SERVER_EXPORT JackGraphManager* GetGraphManager();
-extern SERVER_EXPORT JackEngineControl* GetEngineControl();
-extern SERVER_EXPORT JackSynchro* GetSynchroTable();
+class JackGlobalsInterface
+{
+
+    private:
+
+        JackGlobals *fGlobal;
+
+    public:
+
+        JackGlobalsInterface(JackGlobals *global = nullptr)
+            : fGlobal(global)
+        {
+
+        }
+
+        ~JackGlobalsInterface()
+        {
+
+        }
+
+        inline JackGlobals* GetGlobal() const
+        {
+            return fGlobal;
+        }
+
+        inline void SetGlobal(JackGlobals *global)
+        {
+            fGlobal = global;
+        }
+
+};
+
+template <class T>
+inline T* JackGlobalsManager::CreateGlobal(const std::string &server_name)
+{
+    uint32_t context_num = fContexts.size();
+
+    std::vector<JackGlobals*>::iterator it = std::find_if(fContexts.begin(), fContexts.end(), [&server_name] (JackGlobals* i) {
+        return (i && (i->fServerName.compare(server_name) == 0));
+    });
+
+    T* global = nullptr;
+
+    if (it == fContexts.end()) {
+        global = new T(server_name);
+        it = std::find(fContexts.begin(), fContexts.end(), nullptr);
+        if (it == fContexts.end()) {
+            fContexts.push_back(static_cast<JackGlobals*>(global));
+        } else {
+            *it = global;
+        }
+    } else {
+        global = dynamic_cast<T*>(*it);
+    }
+
+    if (global == nullptr) {
+        return global;
+    }
+
+    bool success = false;
+    {
+        std::lock_guard<std::mutex> lock(global->fMutex);
+        success = global->AddContext(context_num, server_name);
+    }
+
+    if (success == false) {
+        DestroyGlobal(server_name);
+        return nullptr;
+    }
+
+    return global;
+}
+
+inline void JackGlobalsManager::DestroyGlobal(const std::string &server_name)
+{
+    std::vector<JackGlobals*>::iterator it = std::find_if(fContexts.begin(), fContexts.end(), [&server_name] (JackGlobals* i) {
+        return (i && (i->fServerName.compare(server_name) == 0));
+    });
+
+    if (it == fContexts.end()) {
+        return;
+    }
+
+    JackGlobals *global = *it;
+
+    {
+        std::lock_guard<std::mutex> lock(global->fMutex);
+
+        if (global->DelContext(fContexts.size()) == false) {
+            return;
+        }
+    }
+
+    delete global;
+    *it = nullptr;
+}
 
 } // end of namespace
 

--- a/common/JackGraphManager.cpp
+++ b/common/JackGraphManager.cpp
@@ -45,11 +45,12 @@ void JackGraphManager::AssertPort(jack_port_id_t port_index)
     }
 }
 
-JackGraphManager* JackGraphManager::Allocate(int port_max)
+JackGraphManager* JackGraphManager::Allocate(int port_max, JackGlobals* global)
 {
     // Using "Placement" new
     void* shared_ptr = JackShmMem::operator new(sizeof(JackGraphManager) + port_max * sizeof(JackPort));
-    return new(shared_ptr) JackGraphManager(port_max);
+    JackGraphManager *manager = new(shared_ptr) JackGraphManager(port_max, global);
+    return manager;
 }
 
 void JackGraphManager::Destroy(JackGraphManager* manager)
@@ -59,7 +60,7 @@ void JackGraphManager::Destroy(JackGraphManager* manager)
     JackShmMem::operator delete(manager);
 }
 
-JackGraphManager::JackGraphManager(int port_max)
+JackGraphManager::JackGraphManager(int port_max, JackGlobals *global)
 {
     assert(port_max <= PORT_NUM_MAX);
 
@@ -68,6 +69,8 @@ JackGraphManager::JackGraphManager(int port_max)
     }
 
     fPortMax = port_max;
+
+    ReadCurrentState()->SetGlobal(global);
 }
 
 JackPort* JackGraphManager::GetPort(jack_port_id_t port_index)

--- a/common/JackGraphManager.h
+++ b/common/JackGraphManager.h
@@ -32,6 +32,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 namespace Jack
 {
 
+class JackGlobals;
+
 /*!
 \brief Graph manager: contains the connection manager and the port array.
 */
@@ -57,7 +59,7 @@ class SERVER_EXPORT JackGraphManager : public JackShmMem, public JackAtomicState
 
     public:
 
-        JackGraphManager(int port_max);
+        JackGraphManager(int port_max, JackGlobals *global);
         ~JackGraphManager()
         {}
 
@@ -134,7 +136,7 @@ class SERVER_EXPORT JackGraphManager : public JackShmMem, public JackAtomicState
         void Save(JackConnectionManager* dst);
         void Restore(JackConnectionManager* src);
 
-        static JackGraphManager* Allocate(int port_max);
+        static JackGraphManager* Allocate(int port_max, JackGlobals *global);
         static void Destroy(JackGraphManager* manager);
 
 } POST_PACKED_STRUCTURE;

--- a/common/JackInternalClient.cpp
+++ b/common/JackInternalClient.cpp
@@ -37,25 +37,9 @@ namespace Jack
 JackGraphManager* JackInternalClient::fGraphManager = NULL;
 JackEngineControl* JackInternalClient::fEngineControl = NULL;
 
-// Used for external C API (JackAPI.cpp)
-SERVER_EXPORT JackGraphManager* GetGraphManager()
+JackInternalClient::JackInternalClient(JackServerGlobals *globals): JackClient(globals)
 {
-    return JackServerGlobals::fInstance->GetGraphManager();
-}
-
-SERVER_EXPORT JackEngineControl* GetEngineControl()
-{
-    return JackServerGlobals::fInstance->GetEngineControl();
-}
-
-SERVER_EXPORT JackSynchro* GetSynchroTable()
-{
-    return JackServerGlobals::fInstance->GetSynchroTable();
-}
-
-JackInternalClient::JackInternalClient(JackServer* server, JackSynchro* table): JackClient(table)
-{
-    fChannel = new JackInternalClientChannel(server);
+    fChannel = new JackInternalClientChannel(globals->fInstance);
 }
 
 JackInternalClient::~JackInternalClient()
@@ -101,8 +85,8 @@ int JackInternalClient::Open(const char* server_name, const char* name, jack_uui
     }
 
     SetupDriverSync(false);
-    JackGlobals::fClientTable[fClientControl.fRefNum] = this;
-    JackGlobals::fServerRunning = true;
+    GetGlobal()->fClientTable[fClientControl.fRefNum] = this;
+    GetGlobal()->fServerRunning = true;
     jack_log("JackInternalClient::Open name = %s refnum = %ld", name_res, fClientControl.fRefNum);
     return 0;
 
@@ -193,8 +177,8 @@ int JackLoadableInternalClient2::Init(const char* so_name)
     return 0;
 }
 
-JackLoadableInternalClient1::JackLoadableInternalClient1(JackServer* server, JackSynchro* table, const char* object_data)
-        : JackLoadableInternalClient(server, table)
+JackLoadableInternalClient1::JackLoadableInternalClient1(JackServerGlobals *global, const char* object_data)
+        : JackLoadableInternalClient(global)
 {
     if (object_data != NULL)
         strncpy(fObjectData, object_data, JACK_LOAD_INIT_LIMIT);
@@ -202,8 +186,8 @@ JackLoadableInternalClient1::JackLoadableInternalClient1(JackServer* server, Jac
         memset(fObjectData, 0, sizeof(fObjectData));
 }
 
-JackLoadableInternalClient2::JackLoadableInternalClient2(JackServer* server, JackSynchro* table, const JSList*  parameters)
-        : JackLoadableInternalClient(server, table)
+JackLoadableInternalClient2::JackLoadableInternalClient2(JackServerGlobals *global, const JSList*  parameters)
+        : JackLoadableInternalClient(global)
 {
     fParameters = parameters;
 }

--- a/common/JackInternalClient.h
+++ b/common/JackInternalClient.h
@@ -23,6 +23,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include "JackClient.h"
 #include "JackClientControl.h"
+#include "JackServerGlobals.h"
 #include "driver_interface.h"
 
 namespace Jack
@@ -43,7 +44,7 @@ class JackInternalClient : public JackClient
 
     public:
 
-        JackInternalClient(JackServer* server, JackSynchro* table);
+        JackInternalClient(JackServerGlobals *globals);
         virtual ~JackInternalClient();
 
         int Open(const char* server_name, const char* name, jack_uuid_t uuid, jack_options_t options, jack_status_t* status);
@@ -76,8 +77,8 @@ class JackLoadableInternalClient : public JackInternalClient
 
     public:
 
-        JackLoadableInternalClient(JackServer* server, JackSynchro* table)
-            :JackInternalClient(server, table), fHandle(NULL), fFinish(NULL), fDescriptor(NULL)
+        JackLoadableInternalClient(JackServerGlobals* global)
+            :JackInternalClient(global), fHandle(NULL), fFinish(NULL), fDescriptor(NULL)
         {}
         virtual ~JackLoadableInternalClient();
 
@@ -95,7 +96,7 @@ class JackLoadableInternalClient1 : public JackLoadableInternalClient
 
     public:
 
-        JackLoadableInternalClient1(JackServer* server, JackSynchro* table, const char* object_data);
+        JackLoadableInternalClient1(JackServerGlobals *global, const char* object_data);
         virtual ~JackLoadableInternalClient1()
         {}
 
@@ -114,7 +115,7 @@ class JackLoadableInternalClient2 : public JackLoadableInternalClient
 
     public:
 
-        JackLoadableInternalClient2(JackServer* server, JackSynchro* table, const JSList*  parameters);
+        JackLoadableInternalClient2(JackServerGlobals *global, const JSList*  parameters);
         virtual ~JackLoadableInternalClient2()
         {}
 

--- a/common/JackLibAPI.cpp
+++ b/common/JackLibAPI.cpp
@@ -229,93 +229,117 @@ LIB_EXPORT int jack_set_property(jack_client_t* ext_client, jack_uuid_t subject,
 {
     JackGlobals::CheckContext("jack_set_property");
 
-    JackClient* client = (JackClient*)ext_client;
-    jack_log("jack_set_property ext_client %x client %x ", ext_client, client);
-    if (client == NULL) {
-        jack_error("jack_set_property called with a NULL client");
-        return -1;
-    } else {
-        JackMetadata* metadata = GetMetadata();
-        return (metadata ? metadata->SetProperty(client, subject, key, value, type) : -1);
-    }
+    jack_error("jack_set_property is not implemented");
+    return -1;
+
+//    JackClient* client = (JackClient*)ext_client;
+//    jack_log("jack_set_property ext_client %x client %x ", ext_client, client);
+//    if (client == NULL) {
+//        jack_error("jack_set_property called with a NULL client");
+//        return -1;
+//    } else {
+//        JackMetadata* metadata = GetMetadata();
+//        return (metadata ? metadata->SetProperty(client, subject, key, value, type) : -1);
+//    }
 }
 
 LIB_EXPORT int jack_get_property(jack_uuid_t subject, const char* key, char** value, char** type)
 {
     JackGlobals::CheckContext("jack_get_property");
 
-    JackMetadata* metadata = GetMetadata();
-    return (metadata ? metadata->GetProperty(subject, key, value, type) : -1);
+    jack_error("jack_get_property is not implemented");
+    return -1;
+
+//    JackMetadata* metadata = GetMetadata();
+//    return (metadata ? metadata->GetProperty(subject, key, value, type) : -1);
 }
 
 LIB_EXPORT void jack_free_description(jack_description_t* desc, int free_actual_description_too)
 {
     JackGlobals::CheckContext("jack_free_description");
 
-    JackMetadata* metadata = GetMetadata();
-    if (metadata)
-        metadata->FreeDescription(desc, free_actual_description_too);
+    jack_error("jack_free_description is not implemented");
+    return;
+
+//    JackMetadata* metadata = GetMetadata();
+//    if (metadata)
+//        metadata->FreeDescription(desc, free_actual_description_too);
 }
 
 LIB_EXPORT int jack_get_properties(jack_uuid_t subject, jack_description_t* desc)
 {
     JackGlobals::CheckContext("jack_get_properties");
 
-    JackMetadata* metadata = GetMetadata();
-    return (metadata ? metadata->GetProperties(subject, desc) : -1);
+    jack_error("jack_get_properties is not implemented");
+    return -1;
+
+//    JackMetadata* metadata = GetMetadata();
+//    return (metadata ? metadata->GetProperties(subject, desc) : -1);
 }
 
 LIB_EXPORT int jack_get_all_properties(jack_description_t** descriptions)
 {
     JackGlobals::CheckContext("jack_get_all_properties");
 
-    JackMetadata* metadata = GetMetadata();
-    return (metadata ? metadata->GetAllProperties(descriptions) : -1);
+    jack_error("jack_get_all_properties is not implemented");
+    return -1;
+
+//    JackMetadata* metadata = GetMetadata();
+//    return (metadata ? metadata->GetAllProperties(descriptions) : -1);
 }
 
 LIB_EXPORT int jack_remove_property(jack_client_t* ext_client, jack_uuid_t subject, const char* key)
 {
     JackGlobals::CheckContext("jack_remove_property");
 
-    JackClient* client = (JackClient*)ext_client;
-    jack_log("jack_remove_property ext_client %x client %x ", ext_client, client);
-    if (client == NULL) {
-        jack_error("jack_remove_property called with a NULL client");
-        return -1;
-    } else {
-        JackMetadata* metadata = GetMetadata();
-        return (metadata ? metadata->RemoveProperty(client, subject, key) : -1);
-    }
+    jack_error("jack_remove_property is not implemented");
+    return -1;
+
+//    JackClient* client = (JackClient*)ext_client;
+//    jack_log("jack_remove_property ext_client %x client %x ", ext_client, client);
+//    if (client == NULL) {
+//        jack_error("jack_remove_property called with a NULL client");
+//        return -1;
+//    } else {
+//        JackMetadata* metadata = GetMetadata();
+//        return (metadata ? metadata->RemoveProperty(client, subject, key) : -1);
+//    }
 }
 
 LIB_EXPORT int jack_remove_properties(jack_client_t* ext_client, jack_uuid_t subject)
 {
     JackGlobals::CheckContext("jack_remove_properties");
 
-    JackClient* client = (JackClient*)ext_client;
-    jack_log("jack_remove_properties ext_client %x client %x ", ext_client, client);
-    if (client == NULL) {
-        jack_error("jack_remove_properties called with a NULL client");
-        return -1;
-    } else {
-        JackMetadata* metadata = GetMetadata();
-        return (metadata ? metadata->RemoveProperties(client, subject) : -1);
-    }
+    jack_error("jack_remove_properties is not implemented");
+    return -1;
+
+//    JackClient* client = (JackClient*)ext_client;
+//    jack_log("jack_remove_properties ext_client %x client %x ", ext_client, client);
+//    if (client == NULL) {
+//        jack_error("jack_remove_properties called with a NULL client");
+//        return -1;
+//    } else {
+//        JackMetadata* metadata = GetMetadata();
+//        return (metadata ? metadata->RemoveProperties(client, subject) : -1);
+//    }
 }
 
 LIB_EXPORT int jack_remove_all_properties(jack_client_t* ext_client)
 {
     JackGlobals::CheckContext("jack_remove_all_properties");
 
-    JackClient* client = (JackClient*)ext_client;
-    jack_log("jack_remove_all_properties ext_client %x client %x ", ext_client, client);
-    if (client == NULL) {
-        jack_error("jack_remove_all_properties called with a NULL client");
-        return -1;
-    } else {
-        JackMetadata* metadata = GetMetadata();
-        return (metadata ? metadata->RemoveAllProperties(client) : -1);
-    }
+    jack_error("jack_remove_all_properties is not implemented");
+    return -1;
+
+//    JackClient* client = (JackClient*)ext_client;
+//    jack_log("jack_remove_all_properties ext_client %x client %x ", ext_client, client);
+//    if (client == NULL) {
+//        jack_error("jack_remove_all_properties called with a NULL client");
+//        return -1;
+//    } else {
+//        JackMetadata* metadata = GetMetadata();
+//        return (metadata ? metadata->RemoveAllProperties(client) : -1);
+//    }
 }
 
 LIB_EXPORT int jack_set_property_change_callback(jack_client_t* ext_client, JackPropertyChangeCallback callback, void* arg)

--- a/common/JackLibClient.h
+++ b/common/JackLibClient.h
@@ -41,7 +41,7 @@ class JackLibClient : public JackClient
 
     public:
 
-        JackLibClient(JackSynchro* table);
+        JackLibClient(JackGlobals* global);
         virtual ~JackLibClient();
 
         int Open(const char* server_name, const char* name, jack_uuid_t uuid, jack_options_t options, jack_status_t* status);
@@ -53,9 +53,6 @@ class JackLibClient : public JackClient
         JackEngineControl* GetEngineControl() const;
         JackClientControl* GetClientControl() const;
 };
-
-// Used for client-side Metadata API (JackLibAPI.cpp)
-JackMetadata* GetMetadata();
 
 } // end of namespace
 

--- a/common/JackLibGlobals.h
+++ b/common/JackLibGlobals.h
@@ -50,30 +50,72 @@ class JackClient;
 \brief Global library static structure: singleton kind of pattern.
 */
 
-class JackLibGlobals
+class JackLibGlobals : public JackGlobals
 {
+
+    /* This object is managed by JackGlobalsManager */
+    friend class JackGlobalsManager;
+
+    private:
+
+        /* is called when first context for specific server is created */
+        JackLibGlobals(const std::string &server_name)
+            : JackGlobals(server_name)
+            , fMetadata(server_name.c_str())
+        {
+            fGraphManager = -1;
+            fEngineControl = -1;
+            fClientCount = 0;
+
+            InitTime();
+        }
+
+        /* is called when last context for specific server is removed */
+        ~JackLibGlobals() override
+        {
+            EndTime();
+
+            for (int i = 0; i < CLIENT_NUM; i++) {
+                fSynchroTable[i].Disconnect();
+            }
+        }
 
     public:
 
         JackShmReadWritePtr<JackGraphManager> fGraphManager;	/*! Shared memory Port manager */
         JackShmReadWritePtr<JackEngineControl> fEngineControl;	/*! Shared engine control */  // transport engine has to be writable
         JackSynchro fSynchroTable[CLIENT_NUM];                  /*! Shared synchro table */
-        JackMetadata *fMetadata;                                /*! Shared metadata base */
+        JackMetadata fMetadata;                                 /*! Shared metadata base */
         sigset_t fProcessSignals;
 
-        static int fClientCount;
-        static JackLibGlobals* fGlobals;
+        int fClientCount;
 
-        JackLibGlobals()
+        /* is called each time a context for specific server is added */
+        bool AddContext(const uint32_t &context_num, const std::string &server_name) override
         {
-            jack_log("JackLibGlobals");
-            if (!JackMessageBuffer::Create()) {
+            if (!fServerRunning && fClientCount > 0) {
+                // Cleanup remaining clients
+                jack_error("Jack server was closed but clients are still allocated, cleanup...");
+                for (int i = 0; i < CLIENT_NUM; i++) {
+                    JackClient* client = fClientTable[i];
+                    if (client) {
+                        jack_error("Cleanup client ref = %d", i);
+                        client->Close();
+                        delete client;
+                    }
+                }
+
+                // run destructors for all included objects, keeping the behaviour to previous revisions of JackGlobals source
+                this->~JackLibGlobals();
+                // construct in place
+                new(this) JackLibGlobals(server_name);
+            }
+
+            fClientCount++;
+
+            if (context_num == 0 && !JackMessageBuffer::Create()) {
                 jack_error("Cannot create message buffer");
             }
-            fGraphManager = -1;
-            fEngineControl = -1;
-
-            fMetadata = new JackMetadata(false);
 
             // Filter SIGPIPE to avoid having client get a SIGPIPE when trying to access a died server.
 #ifdef WIN32
@@ -84,65 +126,50 @@ class JackLibGlobals
             sigaddset(&signals, SIGPIPE);
             sigprocmask(SIG_BLOCK, &signals, &fProcessSignals);
 #endif
+            return true;
         }
 
-        ~JackLibGlobals()
+        /* is called each time a context for specific server is removed */
+        bool DelContext(const uint32_t &context_num) override
         {
-            jack_log("~JackLibGlobals");
-            for (int i = 0; i < CLIENT_NUM; i++) {
-                fSynchroTable[i].Disconnect();
-            }
-            JackMessageBuffer::Destroy();
-
-           delete fMetadata;
-           fMetadata = NULL;
-
-            // Restore old signal mask
 #ifdef WIN32
-            // TODO
+           // TODO
 #else
-            sigprocmask(SIG_BLOCK, &fProcessSignals, 0);
+            sigprocmask(SIG_BLOCK, &fProcessSignals, nullptr);
 #endif
+            if (context_num == 0 && !JackMessageBuffer::Destroy()) {
+                jack_error("Cannot destroy message buffer");
+            }
+
+            return --fClientCount == 0;
         }
 
-        static void Init()
+        JackGraphManager *GetGraphManager() override
         {
-            if (!JackGlobals::fServerRunning && fClientCount > 0) {
-
-                // Cleanup remaining clients
-                jack_error("Jack server was closed but clients are still allocated, cleanup...");
-                for (int i = 0; i < CLIENT_NUM; i++) {
-                    JackClient* client = JackGlobals::fClientTable[i];
-                    if (client) {
-                        jack_error("Cleanup client ref = %d", i);
-                        client->Close();
-                        delete client;
-                    }
-                }
-
-                // Cleanup global context
-                fClientCount = 0;
-                delete fGlobals;
-                fGlobals = NULL;
-            }
-
-            if (fClientCount++ == 0 && !fGlobals) {
-                jack_log("JackLibGlobals Init %x", fGlobals);
-                InitTime();
-                fGlobals = new JackLibGlobals();
-            }
+            return fGraphManager;
         }
 
-        static void Destroy()
+        JackEngineControl *GetEngineControl() override
         {
-            if (--fClientCount == 0 && fGlobals) {
-                jack_log("JackLibGlobals Destroy %x", fGlobals);
-                EndTime();
-                delete fGlobals;
-                fGlobals = NULL;
-            }
+            return fEngineControl;
         }
 
+        JackSynchro *GetSynchroTable() override
+        {
+            return fSynchroTable;
+        }
+
+        /* must not be used in JackLibGlobals */
+        JackServer *GetServer() override
+        {
+            assert(false);
+            return nullptr;
+        }
+
+        JackMetadata* GetMetadata()
+        {
+            return &fMetadata;
+        }
 };
 
 } // end of namespace

--- a/common/JackMidiPort.cpp
+++ b/common/JackMidiPort.cpp
@@ -146,8 +146,9 @@ static void MidiBufferMixdown(void* mixbuffer, void** src_buffers, int src_count
     mix->lost_events += event_count - events_done;
 }
 
-static size_t MidiBufferSize()
+static size_t MidiBufferSize(JackGlobals *global)
 {
+    (void)(global);
     return BUFFER_SIZE_MAX * sizeof(jack_default_audio_sample_t);
 }
 

--- a/common/JackMidiUtil.cpp
+++ b/common/JackMidiUtil.cpp
@@ -55,26 +55,32 @@ Jack::ApplyRunningStatus(jack_midi_event_t *event,
 jack_nframes_t
 Jack::GetCurrentFrame()
 {
-    jack_time_t time = GetMicroSeconds();
-    JackEngineControl *control = GetEngineControl();
-    JackTimer timer;
-    control->ReadFrameTime(&timer);
-    return timer.Time2Frames(time, control->fBufferSize);
+    jack_error("Jack::GetCurrentFrame is not implemented");
+    abort();
+//    jack_time_t time = GetMicroSeconds();
+//    JackEngineControl *control = GetEngineControl();
+//    JackTimer timer;
+//    control->ReadFrameTime(&timer);
+//    return timer.Time2Frames(time, control->fBufferSize);
 }
 
 jack_nframes_t
 Jack::GetFramesFromTime(jack_time_t time)
 {
-    JackEngineControl* control = GetEngineControl();
-    JackTimer timer;
-    control->ReadFrameTime(&timer);
-    return timer.Time2Frames(time, control->fBufferSize);
+    jack_error("Jack::GetFramesFromTime is not implemented");
+    abort();
+//    JackEngineControl* control = GetEngineControl();
+//    JackTimer timer;
+//    control->ReadFrameTime(&timer);
+//    return timer.Time2Frames(time, control->fBufferSize);
 }
 
 jack_nframes_t
 Jack::GetLastFrame()
 {
-    return GetEngineControl()->fFrameTimer.ReadCurrentState()->CurFrame();
+    jack_error("Jack::GetLastFrame is not implemented");
+    abort();
+//    return GetEngineControl()->fFrameTimer.ReadCurrentState()->CurFrame();
 }
 
 int
@@ -114,8 +120,10 @@ Jack::GetMessageLength(jack_midi_data_t status_byte)
 jack_time_t
 Jack::GetTimeFromFrames(jack_nframes_t frames)
 {
-    JackEngineControl* control = GetEngineControl();
-    JackTimer timer;
-    control->ReadFrameTime(&timer);
-    return timer.Frames2Time(frames, control->fBufferSize);
+    jack_error("Jack::GetTimeFromFrames is not implemented");
+    abort();
+//    JackEngineControl* control = GetEngineControl();
+//    JackTimer timer;
+//    control->ReadFrameTime(&timer);
+//    return timer.Frames2Time(frames, control->fBufferSize);
 }

--- a/common/JackNetAdapter.cpp
+++ b/common/JackNetAdapter.cpp
@@ -21,6 +21,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackServerGlobals.h"
 #include "JackEngineControl.h"
 #include "JackArgParser.h"
+#include "JackClient.h"
 #include <assert.h>
 
 namespace Jack
@@ -245,9 +246,10 @@ namespace Jack
         SetAdaptedSampleRate(fParams.fSampleRate);
 
         // Will do "something" on OSX only...
-        fThread.SetParams(GetEngineControl()->fPeriod, GetEngineControl()->fComputation, GetEngineControl()->fConstraint);
+        JackEngineControl *control = ((JackClient*)fClient)->GetGlobal()->GetEngineControl();
+        fThread.SetParams(control->fPeriod, control->fComputation, control->fConstraint);
 
-        if (fThread.AcquireSelfRealTime(GetEngineControl()->fClientPriority) < 0) {
+        if (fThread.AcquireSelfRealTime(control->fClientPriority) < 0) {
             jack_error("AcquireSelfRealTime error");
         } else {
             set_threaded_log_function();

--- a/common/JackPortType.cpp
+++ b/common/JackPortType.cpp
@@ -30,7 +30,7 @@ static const JackPortType* gPortTypes[] =
     &gMidiPortType,
 };
 
-jack_port_type_id_t PORT_TYPES_MAX = sizeof(gPortTypes) / sizeof(gPortTypes[0]);
+const jack_port_type_id_t PORT_TYPES_MAX = sizeof(gPortTypes) / sizeof(gPortTypes[0]);
 
 jack_port_type_id_t GetPortTypeId(const char* port_type)
 {

--- a/common/JackPortType.h
+++ b/common/JackPortType.h
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 namespace Jack
 {
 
-extern jack_port_type_id_t PORT_TYPES_MAX;
+extern const jack_port_type_id_t PORT_TYPES_MAX;
 
 struct JackPortType
 {

--- a/common/JackPortType.h
+++ b/common/JackPortType.h
@@ -27,12 +27,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 namespace Jack
 {
 
+class JackGlobals;
+
 extern const jack_port_type_id_t PORT_TYPES_MAX;
 
 struct JackPortType
 {
     const char* fName;
-    size_t (*size)();
+    size_t (*size)(JackGlobals *global);
     void (*init)(void* buffer, size_t buffer_size, jack_nframes_t nframes);
     void (*mixdown)(void *mixbuffer, void** src_buffers, int src_count, jack_nframes_t nframes);
 };

--- a/common/JackServer.h
+++ b/common/JackServer.h
@@ -26,7 +26,6 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackDriverLoader.h"
 #include "JackDriverInfo.h"
 #include "JackConnectionManager.h"
-#include "JackGlobals.h"
 #include "JackPlatformPlug.h"
 #include "jslist.h"
 
@@ -38,6 +37,7 @@ class JackDriverClientInterface;
 struct JackEngineControl;
 class JackLockedEngine;
 class JackLoadableInternalClient;
+class JackServerGlobals;
 
 /*!
 \brief The Jack server.
@@ -60,11 +60,13 @@ class SERVER_EXPORT JackServer
         JackSynchro fSynchroTable[CLIENT_NUM];
         bool fFreewheel;
 
+        JackServerGlobals *fGlobal;
+
         int InternalClientLoadAux(JackLoadableInternalClient* client, const char* so_name, const char* client_name, int options, int* int_ref, jack_uuid_t uuid, int* status);
 
     public:
 
-        JackServer(bool sync, bool temporary, int timeout, bool rt, int priority, int port_max, bool verbose, jack_timer_type_t clock, char self_connect_mode, const char* server_name);
+        JackServer(bool sync, bool temporary, int timeout, bool rt, int priority, int port_max, bool verbose, jack_timer_type_t clock, char self_connect_mode, const char* server_name, JackServerGlobals* global);
         ~JackServer();
 
         // Server control

--- a/common/JackServerGlobals.h
+++ b/common/JackServerGlobals.h
@@ -35,36 +35,39 @@ class JackClient;
 \brief Global server static structure: singleton kind of pattern.
 */
 
-struct SERVER_EXPORT JackServerGlobals
+class SERVER_EXPORT JackServerGlobals
 {
-    static JackServer* fInstance;
-    static unsigned int fUserCount;
-    static std::map<std::string, JackDriverInfo*> fSlavesList;
-    static std::map<std::string, int> fInternalsList;
 
-    static bool (* on_device_acquire)(const char* device_name);
-    static void (* on_device_release)(const char* device_name);
-    static void (* on_device_reservation_loop)(void);
+    public:
 
-    JackServerGlobals();
-    ~JackServerGlobals();
+        static JackServer* fInstance;
+        static unsigned int fUserCount;
+        static std::map<std::string, JackDriverInfo*> fSlavesList;
+        static std::map<std::string, int> fInternalsList;
 
-    static bool Init();
-    static void Destroy();
-    static int Start(const char* server_name,
-                     jack_driver_desc_t* driver_desc,
-                     JSList* driver_params,
-                     int sync,
-                     int temporary,
-                     int time_out_ms,
-                     int rt,
-                     int priority,
-                     int port_max,
-                     int verbose,
-                     jack_timer_type_t clock,
-                     char self_connect_mode);
-    static void Stop();
-    static void Delete();
+        static bool (* on_device_acquire)(const char* device_name);
+        static void (* on_device_release)(const char* device_name);
+        static void (* on_device_reservation_loop)(void);
+
+        JackServerGlobals();
+        ~JackServerGlobals();
+
+        static bool Init();
+        static void Destroy();
+        static int Start(const char* server_name,
+                         jack_driver_desc_t* driver_desc,
+                         JSList* driver_params,
+                         int sync,
+                         int temporary,
+                         int time_out_ms,
+                         int rt,
+                         int priority,
+                         int port_max,
+                         int verbose,
+                         jack_timer_type_t clock,
+                         char self_connect_mode);
+        static void Stop();
+        static void Delete();
 };
 
 } // end of namespace

--- a/common/JackServerGlobals.h
+++ b/common/JackServerGlobals.h
@@ -24,6 +24,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackDriverLoader.h"
 #include "JackCompilerDeps.h"
 #include "JackServer.h"
+#include "JackGlobals.h"
 #include <map>
 
 namespace Jack
@@ -35,8 +36,16 @@ class JackClient;
 \brief Global server static structure: singleton kind of pattern.
 */
 
-class SERVER_EXPORT JackServerGlobals
+class SERVER_EXPORT JackServerGlobals : public JackGlobals
 {
+
+    /* This object is managed by JackGlobalsManager */
+    friend class JackGlobalsManager;
+
+    private:
+
+    JackServerGlobals(const std::string &server_name) : JackGlobals(server_name) {}
+    ~JackServerGlobals() override {}
 
     public:
 
@@ -49,25 +58,38 @@ class SERVER_EXPORT JackServerGlobals
         static void (* on_device_release)(const char* device_name);
         static void (* on_device_reservation_loop)(void);
 
-        JackServerGlobals();
-        ~JackServerGlobals();
+        bool Init();
+        void Deinit();
+        int Start(const char* server_name,
+                  jack_driver_desc_t* driver_desc,
+                  JSList* driver_params,
+                  int sync,
+                  int temporary,
+                  int time_out_ms,
+                  int rt,
+                  int priority,
+                  int port_max,
+                  int verbose,
+                  jack_timer_type_t clock,
+                  char self_connect_mode);
+        void Stop();
+        void Destroy();
 
-        static bool Init();
-        static void Destroy();
-        static int Start(const char* server_name,
-                         jack_driver_desc_t* driver_desc,
-                         JSList* driver_params,
-                         int sync,
-                         int temporary,
-                         int time_out_ms,
-                         int rt,
-                         int priority,
-                         int port_max,
-                         int verbose,
-                         jack_timer_type_t clock,
-                         char self_connect_mode);
-        static void Stop();
-        static void Delete();
+        bool AddContext(const uint32_t &context_num, const std::string &server_name) override
+        {
+            return true;
+        }
+
+        bool DelContext(const uint32_t &context_num) override
+        {
+            return true;
+        }
+
+        JackGraphManager* GetGraphManager() override;
+        JackEngineControl* GetEngineControl() override;
+        JackSynchro* GetSynchroTable() override;
+        JackServer* GetServer() override;
+
 };
 
 } // end of namespace

--- a/common/JackThreadedDriver.cpp
+++ b/common/JackThreadedDriver.cpp
@@ -259,10 +259,10 @@ void JackThreadedDriver::SetRealTime()
     if (fDriver->IsRealTime()) {
         jack_log("JackThreadedDriver::Init real-time");
         // Will do "something" on OSX only...
-        GetEngineControl()->fPeriod = GetEngineControl()->fConstraint = GetEngineControl()->fPeriodUsecs * 1000;
-        GetEngineControl()->fComputation = JackTools::ComputationMicroSec(GetEngineControl()->fBufferSize) * 1000;
-        fThread.SetParams(GetEngineControl()->fPeriod, GetEngineControl()->fComputation, GetEngineControl()->fConstraint);
-        if (fThread.AcquireSelfRealTime(GetEngineControl()->fServerPriority) < 0) {
+        fDriver->fEngineControl->fPeriod = fDriver->fEngineControl->fConstraint = fDriver->fEngineControl->fPeriodUsecs * 1000;
+        fDriver->fEngineControl->fComputation = JackTools::ComputationMicroSec(fDriver->fEngineControl->fBufferSize) * 1000;
+        fThread.SetParams(fDriver->fEngineControl->fPeriod, fDriver->fEngineControl->fComputation, fDriver->fEngineControl->fConstraint);
+        if (fThread.AcquireSelfRealTime(fDriver->fEngineControl->fServerPriority) < 0) {
             jack_error("AcquireSelfRealTime error");
         } else {
             set_threaded_log_function();

--- a/common/JackTransportEngine.cpp
+++ b/common/JackTransportEngine.cpp
@@ -34,7 +34,9 @@ using namespace std;
 namespace Jack
 {
 
-JackTransportEngine::JackTransportEngine(): JackAtomicArrayState<jack_position_t>()
+JackTransportEngine::JackTransportEngine(JackGlobals *global)
+    : JackAtomicArrayState<jack_position_t>()
+    , JackGlobalsInterface(global)
 {
     fTransportState = JackTransportStopped;
     fTransportCmd = fPreviousCmd = TransportCommandStop;
@@ -92,7 +94,7 @@ int JackTransportEngine::SetTimebaseMaster(int refnum, bool conditionnal)
 // RT
 bool JackTransportEngine::CheckAllRolling(JackClientInterface** table)
 {
-    for (int i = GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
+    for (int i = GetGlobal()->GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
         JackClientInterface* client = table[i];
         if (client && client->GetClientControl()->fTransportState != JackTransportRolling) {
             jack_log("CheckAllRolling ref = %ld is not rolling", i);
@@ -106,7 +108,7 @@ bool JackTransportEngine::CheckAllRolling(JackClientInterface** table)
 // RT
 void JackTransportEngine::MakeAllStartingLocating(JackClientInterface** table)
 {
-    for (int i = GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
+    for (int i = GetGlobal()->GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
         JackClientInterface* client = table[i];
         if (client) {
             JackClientControl* control = client->GetClientControl();
@@ -122,7 +124,7 @@ void JackTransportEngine::MakeAllStartingLocating(JackClientInterface** table)
 // RT
 void JackTransportEngine::MakeAllStopping(JackClientInterface** table)
 {
-    for (int i = GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
+    for (int i = GetGlobal()->GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
         JackClientInterface* client = table[i];
         if (client) {
             JackClientControl* control = client->GetClientControl();
@@ -137,7 +139,7 @@ void JackTransportEngine::MakeAllStopping(JackClientInterface** table)
 // RT
 void JackTransportEngine::MakeAllLocating(JackClientInterface** table)
 {
-    for (int i = GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
+    for (int i = GetGlobal()->GetEngineControl()->fDriverNum; i < CLIENT_NUM; i++) {
         JackClientInterface* client = table[i];
         if (client) {
             JackClientControl* control = client->GetClientControl();

--- a/common/JackTransportEngine.h
+++ b/common/JackTransportEngine.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #include "JackAtomicArrayState.h"
 #include "JackCompilerDeps.h"
+#include "JackGlobals.h"
 #include "types.h"
 
 namespace Jack
@@ -90,7 +91,7 @@ We have:
 class JackClientInterface;
 
 PRE_PACKED_STRUCTURE
-class SERVER_EXPORT JackTransportEngine : public JackAtomicArrayState<jack_position_t>
+class SERVER_EXPORT JackTransportEngine : public JackAtomicArrayState<jack_position_t>, public JackGlobalsInterface
 {
 
     private:
@@ -115,7 +116,7 @@ class SERVER_EXPORT JackTransportEngine : public JackAtomicArrayState<jack_posit
 
     public:
 
-        JackTransportEngine();
+        JackTransportEngine(JackGlobals *global);
 
         ~JackTransportEngine()
         {}

--- a/common/shm.c
+++ b/common/shm.c
@@ -79,17 +79,17 @@ static int GetPID()
 }
 
 #ifdef USE_POSIX_SHM
-static jack_shmtype_t jack_shmtype = shm_POSIX;
+static const jack_shmtype_t jack_shmtype = shm_POSIX;
 #elif WIN32
-static jack_shmtype_t jack_shmtype = shm_WIN32;
+static const jack_shmtype_t jack_shmtype = shm_WIN32;
 #else
-static jack_shmtype_t jack_shmtype = shm_SYSV;
+static const jack_shmtype_t jack_shmtype = shm_SYSV;
 #endif
 
 /* interface-dependent forward declarations */
 static int	jack_access_registry (jack_shm_info_t *ri);
 static int	jack_create_registry (jack_shm_info_t *ri);
-static void	jack_remove_shm (jack_shm_id_t *id);
+static void	jack_remove_shm (const jack_shm_id_t id);
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * common interface-independent section
@@ -103,7 +103,13 @@ static void	jack_remove_shm (jack_shm_id_t *id);
  */
 
 /* per-process global data for the SHM interfaces */
+#ifdef USE_POSIX_SHM
+static const jack_shm_id_t registry_id = "/jack-shm-registry";
+#elif WIN32
+static const jack_shm_id_t registry_id = "jack-shm-registry";
+#else
 static jack_shm_id_t   registry_id;	/* SHM id for the registry */
+#endif
 
 #ifdef WIN32
 static jack_shm_info_t registry_info = {/* SHM info for the registry */
@@ -120,7 +126,6 @@ static jack_shm_info_t registry_info = { /* SHM info for the registry */
 /* pointers to registry header and array */
 static jack_shm_header_t   *jack_shm_header = NULL;
 static jack_shm_registry_t *jack_shm_registry = NULL;
-static char jack_shm_server_prefix[JACK_SERVER_NAME_SIZE+1] = "";
 
 /* jack_shm_lock_registry() serializes updates to the shared memory
  * segment JACK uses to keep track of the SHM segments allocated to
@@ -315,16 +320,16 @@ jack_shm_validate_registry ()
  * name, in the interest of portability we use colons instead.
  */
 static void
-jack_set_server_prefix (const char *server_name)
+jack_get_server_prefix (const char* const server_name, char* const prefix, const size_t size)
 {
 #ifdef WIN32
     char buffer[UNLEN+1]={0};
     DWORD len = UNLEN+1;
     GetUserName(buffer, &len);
-    snprintf (jack_shm_server_prefix, sizeof (jack_shm_server_prefix),
+    snprintf (prefix, size,
 		  "jack-%s:%s:", buffer, server_name);
 #else
-    snprintf (jack_shm_server_prefix, sizeof (jack_shm_server_prefix),
+    snprintf (prefix, size,
 		  "jack-%d:%s:", GetUID(), server_name);
 #endif
 }
@@ -349,7 +354,7 @@ jack_server_initialize_shm (int new_registry)
 	rc = jack_access_registry (&registry_info);
 
 	if (new_registry) {
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		rc = ENOENT;
 	}
 
@@ -365,7 +370,7 @@ jack_server_initialize_shm (int new_registry)
 		/* Apparently, this registry was created by an older
 		 * JACK version.  Delete it so we can try again. */
 		jack_release_shm (&registry_info);
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		if ((rc = jack_create_registry (&registry_info)) != 0) {
 			jack_error ("incompatible shm registry (%s)",
 				    strerror (errno));
@@ -394,11 +399,12 @@ int
 jack_initialize_shm (const char *server_name)
 {
 	int rc;
+	char server_prefix[JACK_SERVER_NAME_SIZE+1];
 
 	if (jack_shm_header)
 		return 0;		/* already initialized */
 
-	jack_set_server_prefix (server_name);
+	jack_get_server_prefix (server_name, server_prefix, sizeof(server_prefix));
 
 	if (jack_shm_lock_registry () < 0) {
         jack_error ("jack_shm_lock_registry fails...");
@@ -429,7 +435,7 @@ jack_destroy_shm (jack_shm_info_t* si)
 	if (si->index == JACK_SHM_NULL_INDEX)
 		return;			/* segment not allocated */
 
-	jack_remove_shm (&jack_shm_registry[si->index].id);
+	jack_remove_shm (jack_shm_registry[si->index].id);
 	jack_release_shm_info (si->index);
 }
 
@@ -490,8 +496,9 @@ int
 jack_register_server (const char *server_name, int new_registry)
 {
 	int i, res = 0;
+	char server_prefix[JACK_SERVER_NAME_SIZE+1];
 
-	jack_set_server_prefix (server_name);
+	jack_get_server_prefix (server_name, server_prefix, sizeof(server_prefix));
 
 	if (jack_server_initialize_shm (new_registry))
 		return ENOMEM;
@@ -507,8 +514,8 @@ jack_register_server (const char *server_name, int new_registry)
 	for (i = 0; i < MAX_SERVERS; i++) {
 
 		if (strncmp (jack_shm_header->server[i].name,
-			     jack_shm_server_prefix,
-			     JACK_SERVER_NAME_SIZE) != 0)
+			     server_prefix,
+			     sizeof(server_prefix)) != 0)
 			continue;	/* no match */
 
 		if (jack_shm_header->server[i].pid == GetPID()){
@@ -548,8 +555,8 @@ jack_register_server (const char *server_name, int new_registry)
 	/* claim it */
 	jack_shm_header->server[i].pid = GetPID();
 	strncpy (jack_shm_header->server[i].name,
-		 jack_shm_server_prefix,
-		 JACK_SERVER_NAME_SIZE);
+		 server_prefix,
+		 sizeof(server_prefix));
 
  unlock:
 	jack_shm_unlock_registry ();
@@ -630,7 +637,7 @@ jack_cleanup_shm ()
 			int index = copy.index;
 
 			if ((index >= 0)  && (index < MAX_SHM_ID)) {
-				jack_remove_shm (&jack_shm_registry[index].id);
+				jack_remove_shm (jack_shm_registry[index].id);
 				jack_release_shm_entry (index);
 			}
 			r->size = 0;
@@ -715,8 +722,6 @@ jack_access_registry (jack_shm_info_t *ri)
 	/* registry must be locked */
 	int shm_fd;
 
-	strncpy (registry_id, "/jack-shm-registry", sizeof (registry_id));
-
 	/* try to open an existing segment */
 	if ((shm_fd = shm_open (registry_id, O_RDWR, 0666)) < 0) {
 		int rc = errno;
@@ -759,8 +764,6 @@ jack_create_registry (jack_shm_info_t *ri)
 	/* registry must be locked */
 	int shm_fd;
 
-	strncpy (registry_id, "/jack-shm-registry", sizeof (registry_id));
-
 	if ((shm_fd = shm_open (registry_id, O_RDWR|O_CREAT, 0666)) < 0) {
 		int rc = errno;
 		jack_error ("Cannot create shm registry segment (%s)",
@@ -779,7 +782,7 @@ jack_create_registry (jack_shm_info_t *ri)
 	if (ftruncate (shm_fd, JACK_SHM_REGISTRY_SIZE) < 0) {
 		int rc = errno;
 		jack_error ("Cannot set registry size (%s)", strerror (errno));
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		close (shm_fd);
 		return rc;
 	}
@@ -789,7 +792,7 @@ jack_create_registry (jack_shm_info_t *ri)
 				     MAP_SHARED, shm_fd, 0)) == MAP_FAILED) {
 		jack_error ("Cannot mmap shm registry segment (%s)",
 			    strerror (errno));
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		close (shm_fd);
 		return EINVAL;
 	}
@@ -806,10 +809,10 @@ jack_create_registry (jack_shm_info_t *ri)
 }
 
 static void
-jack_remove_shm (jack_shm_id_t *id)
+jack_remove_shm (const jack_shm_id_t id)
 {
 	/* registry may or may not be locked */
-	shm_unlink ((char *) id);
+	shm_unlink (id);
 }
 
 void
@@ -955,7 +958,6 @@ jack_access_registry (jack_shm_info_t *ri)
 {
 	/* registry must be locked */
 	HANDLE shm_fd;
-	strncpy (registry_id, "jack-shm-registry", sizeof (registry_id));
 
 	/* try to open an existing segment */
 
@@ -969,7 +971,7 @@ jack_access_registry (jack_shm_info_t *ri)
 
 	if ((ri->ptr.attached_at = MapViewOfFile (shm_fd, FILE_MAP_ALL_ACCESS, 0, 0, JACK_SHM_REGISTRY_SIZE)) == NULL) {
 		jack_error ("Cannot mmap shm registry segment (%ld)", GetLastError());
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		CloseHandle (shm_fd);
 		return EINVAL;
 	}
@@ -989,8 +991,6 @@ jack_create_registry (jack_shm_info_t *ri)
 	/* registry must be locked */
 	HANDLE shm_fd;
 
-	strncpy (registry_id, "jack-shm-registry", sizeof (registry_id));
-
 	if ((shm_fd = CreateFileMapping(INVALID_HANDLE_VALUE,
 									0, PAGE_READWRITE,
 									0, JACK_SHM_REGISTRY_SIZE,
@@ -1002,7 +1002,7 @@ jack_create_registry (jack_shm_info_t *ri)
 
 	if ((ri->ptr.attached_at = MapViewOfFile (shm_fd, FILE_MAP_ALL_ACCESS, 0, 0, JACK_SHM_REGISTRY_SIZE)) == NULL) {
 		jack_error ("Cannot mmap shm registry segment (%ld)", GetLastError());
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		CloseHandle (shm_fd);
 		return EINVAL;
 	}
@@ -1020,7 +1020,7 @@ jack_create_registry (jack_shm_info_t *ri)
 }
 
 static void
-jack_remove_shm (jack_shm_id_t *id)
+jack_remove_shm (jack_shm_id_t id)
 {
 	/* nothing to do */
 }
@@ -1102,7 +1102,7 @@ jack_attach_shm (jack_shm_info_t* si)
 
 	if ((si->ptr.attached_at = MapViewOfFile (shm_fd, FILE_MAP_ALL_ACCESS, 0, 0, registry->size)) == NULL) {
 		jack_error ("Cannot mmap shm segment (%ld)", GetLastError());
-		jack_remove_shm (&registry_id);
+		jack_remove_shm (registry_id);
 		CloseHandle (shm_fd);
 		return -1;
 	}
@@ -1125,7 +1125,7 @@ jack_attach_shm_read (jack_shm_info_t* si)
 
 	if ((si->ptr.attached_at = MapViewOfFile (shm_fd, FILE_MAP_READ, 0, 0, registry->size)) == NULL) {
 		jack_error("Cannot mmap shm segment (%ld)", GetLastError());
-		jack_remove_shm(&registry_id);
+		jack_remove_shm(registry_id);
 		CloseHandle(shm_fd);
 		return -1;
 	}
@@ -1224,10 +1224,10 @@ jack_create_registry (jack_shm_info_t *ri)
 }
 
 static void
-jack_remove_shm (jack_shm_id_t *id)
+jack_remove_shm (jack_shm_id_t id)
 {
 	/* registry may or may not be locked */
-	shmctl (*id, IPC_RMID, NULL);
+	shmctl (id, IPC_RMID, NULL);
 }
 
 void

--- a/linux/alsa/JackAlsaAdapter.cpp
+++ b/linux/alsa/JackAlsaAdapter.cpp
@@ -24,14 +24,16 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackAlsaAdapter.h"
 #include "JackGlobals.h"
 #include "JackEngineControl.h"
+#include "JackClient.h"
 
 namespace Jack
 {
 
-    JackAlsaAdapter::JackAlsaAdapter ( jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params ) :
+    JackAlsaAdapter::JackAlsaAdapter ( JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params ) :
             JackAudioAdapterInterface ( buffer_size, sample_rate ),
             fThread ( this ),
-            fAudioInterface ( buffer_size, sample_rate )
+            fAudioInterface ( buffer_size, sample_rate ),
+            fClient( jack_client )
     {
         const JSList* node;
         const jack_driver_param_t* param;
@@ -110,7 +112,7 @@ namespace Jack
         fAudioInterface.longinfo();
 
         //turn the thread realtime
-        fThread.AcquireRealTime(GetEngineControl()->fClientPriority);
+        fThread.AcquireRealTime(fClient.GetGlobal()->GetEngineControl()->fClientPriority);
         return 0;
     }
 

--- a/linux/alsa/JackAlsaAdapter.h
+++ b/linux/alsa/JackAlsaAdapter.h
@@ -602,9 +602,10 @@ namespace Jack
         private:
             JackThread fThread;
             AudioInterface fAudioInterface;
+            JackClient &fClient;
 
         public:
-            JackAlsaAdapter ( jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params );
+            JackAlsaAdapter ( JackClient &client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params );
             ~JackAlsaAdapter()
             {}
 

--- a/macosx/coreaudio/JackCoreAudioAdapter.h
+++ b/macosx/coreaudio/JackCoreAudioAdapter.h
@@ -150,7 +150,7 @@ class JackCoreAudioAdapter : public JackAudioAdapterInterface
 
     public:
 
-        JackCoreAudioAdapter(jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params);
+        JackCoreAudioAdapter(JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params);
         ~JackCoreAudioAdapter()
         {}
 

--- a/macosx/coreaudio/JackCoreAudioAdapter.mm
+++ b/macosx/coreaudio/JackCoreAudioAdapter.mm
@@ -321,7 +321,7 @@ OSStatus JackCoreAudioAdapter::Render(AudioUnitRenderActionFlags *ioActionFlags,
     }
 }
 
-JackCoreAudioAdapter::JackCoreAudioAdapter(jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params)
+JackCoreAudioAdapter::JackCoreAudioAdapter(JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params)
                 :JackAudioAdapterInterface(buffer_size, sample_rate), fInputData(0), fCapturing(false), fPlaying(false), fState(false)
 {
     const JSList* node;

--- a/posix/JackPosixServerLaunch.cpp
+++ b/posix/JackPosixServerLaunch.cpp
@@ -242,7 +242,7 @@ static int start_server(const char* server_name, jack_options_t options)
 
 static int server_connect(char* server_name)
 {
-    JackClientChannel channel;
+    JackClientChannel channel(nullptr);
     int res = channel.ServerCheck(server_name);
     channel.Close();
     JackSleep(2000); // Added by JE - 02-01-2009 (gives

--- a/posix/JackSocketClientChannel.cpp
+++ b/posix/JackSocketClientChannel.cpp
@@ -26,8 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 namespace Jack
 {
 
-JackSocketClientChannel::JackSocketClientChannel()
-    :JackGenericClientChannel(), fThread(this)
+JackSocketClientChannel::JackSocketClientChannel(JackGlobals *global)
+    :JackGenericClientChannel(global), fThread(this)
 {
     fRequest = new JackClientSocket();
     fNotificationSocket = NULL;
@@ -53,7 +53,7 @@ int JackSocketClientChannel::Open(const char* server_name, const char* name, jac
     }
     
     // OK so server is there...
-    JackGlobals::fServerRunning = true;
+    client->GetGlobal()->fServerRunning = true;
 
     // Check name in server
     ClientCheck(name, uuid, name_res, JACK_PROTOCOL_VERSION, (int)options, (int*)status, &result, true);

--- a/posix/JackSocketClientChannel.h
+++ b/posix/JackSocketClientChannel.h
@@ -46,7 +46,7 @@ class JackSocketClientChannel : public JackGenericClientChannel, public JackRunn
 
     public:
 
-        JackSocketClientChannel();
+        JackSocketClientChannel(JackGlobals *global);
         virtual ~JackSocketClientChannel();
 
         int Open(const char* server_name, const char* name, jack_uuid_t uuid, char* name_res, JackClient* client, jack_options_t options, jack_status_t* status);

--- a/solaris/oss/JackOSSAdapter.cpp
+++ b/solaris/oss/JackOSSAdapter.cpp
@@ -20,6 +20,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include "JackOSSAdapter.h"
 #include "JackServerGlobals.h"
 #include "JackEngineControl.h"
+#include "JackClient.h"
 #include "memops.h"
 
 #include <sys/ioctl.h>
@@ -103,13 +104,14 @@ void JackOSSAdapter::SetSampleFormat()
     }
 }
 
-JackOSSAdapter::JackOSSAdapter(jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params)
+JackOSSAdapter::JackOSSAdapter(JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params)
                 :JackAudioAdapterInterface(buffer_size, sample_rate)
                 ,fThread(this),
                 fInFD(-1), fOutFD(-1), fBits(OSS_DRIVER_DEF_BITS),
                 fSampleFormat(0), fNperiods(OSS_DRIVER_DEF_NPERIODS), fRWMode(0), fIgnoreHW(true), fExcl(false),
                 fInputBufferSize(0), fOutputBufferSize(0),
-                fInputBuffer(NULL), fOutputBuffer(NULL), fFirstCycle(true)
+                fInputBuffer(NULL), fOutputBuffer(NULL), fFirstCycle(true),
+                fClient(jack_client)
 {
     const JSList* node;
     const jack_driver_param_t* param;
@@ -496,7 +498,7 @@ int JackOSSAdapter::Open()
     }
 
     //turn the thread realtime
-    fThread.AcquireRealTime(JackServerGlobals::fInstance->GetEngineControl()->fClientPriority);
+    fThread.AcquireRealTime(fClient.GetGlobal()->GetEngineControl()->fClientPriority);
     return 0;
 
 error:

--- a/solaris/oss/JackOSSAdapter.h
+++ b/solaris/oss/JackOSSAdapter.h
@@ -32,6 +32,8 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 namespace Jack
 {
 
+class JackClient;
+
 typedef jack_default_audio_sample_t jack_sample_t;
 
 #define OSS_DRIVER_DEF_DEV	"/dev/dsp"
@@ -86,9 +88,11 @@ class JackOSSAdapter : public JackAudioAdapterInterface, public JackRunnableInte
         void SetSampleFormat();
         void DisplayDeviceInfo();
 
+        JackClient &fClient;
+
     public:
 
-        JackOSSAdapter(jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params);
+        JackOSSAdapter(JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params);
         ~JackOSSAdapter()
         {}
 

--- a/windows/JackWinNamedPipeClientChannel.cpp
+++ b/windows/JackWinNamedPipeClientChannel.cpp
@@ -27,8 +27,8 @@
 namespace Jack
 {
 
-JackWinNamedPipeClientChannel::JackWinNamedPipeClientChannel()
-    :JackGenericClientChannel(),fThread(this)
+JackWinNamedPipeClientChannel::JackWinNamedPipeClientChannel(JackGlobals *global)
+    :JackGenericClientChannel(global),fThread(this)
 {
      fRequest = new JackWinNamedPipeClient();
 }
@@ -60,7 +60,7 @@ int JackWinNamedPipeClientChannel::Open(const char* server_name, const char* nam
     }
     
     // OK so server is there...
-    JackGlobals::fServerRunning = true;
+    client->GetGlobal()->fServerRunning = true;
 
     // Check name in server
     ClientCheck(name, uuid, name_res, JACK_PROTOCOL_VERSION, (int)options, (int*)status, &result, true);

--- a/windows/JackWinNamedPipeClientChannel.h
+++ b/windows/JackWinNamedPipeClientChannel.h
@@ -29,6 +29,7 @@
 namespace Jack
 {
 
+class JackGlobals;
 class JackClient;
 
 /*!
@@ -46,7 +47,7 @@ class JackWinNamedPipeClientChannel : public JackGenericClientChannel, public Ja
 
     public:
 
-        JackWinNamedPipeClientChannel();
+        JackWinNamedPipeClientChannel(JackGlobals *global);
         virtual ~JackWinNamedPipeClientChannel();
 
         int Open(const char* server_name, const char* name, jack_uuid_t uuid, char* name_res, JackClient* client, jack_options_t options, jack_status_t* status);

--- a/windows/portaudio/JackPortAudioAdapter.cpp
+++ b/windows/portaudio/JackPortAudioAdapter.cpp
@@ -34,7 +34,7 @@ namespace Jack
         return paContinue;
     }
 
-    JackPortAudioAdapter::JackPortAudioAdapter(jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params)
+    JackPortAudioAdapter::JackPortAudioAdapter(JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params)
             : JackAudioAdapterInterface(buffer_size, sample_rate)
     {
         jack_log("JackPortAudioAdapter::JackPortAudioAdapter buffer_size = %d, sample_rate = %d", buffer_size, sample_rate);

--- a/windows/portaudio/JackPortAudioAdapter.h
+++ b/windows/portaudio/JackPortAudioAdapter.h
@@ -26,6 +26,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 namespace Jack
 {
+    class JackClient;
 
     /*!
     \brief Audio adapter using PortAudio API.
@@ -49,7 +50,7 @@ namespace Jack
 
     public:
 
-        JackPortAudioAdapter(jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params);
+        JackPortAudioAdapter(JackClient &jack_client, jack_nframes_t buffer_size, jack_nframes_t sample_rate, const JSList* params);
         ~JackPortAudioAdapter()
         {}
 


### PR DESCRIPTION
These PR add support for Jack "multi client" mode. By multi client I mean allowing to create multiple clients who connect to different servers from one process.

In current Jack version this would result in overwriting synchronization and signalling primitives of shared memory. Each created client would overwrite client before, so that previous client would not be able to accept process and other callbacks and notify server of graph competition.

The patch introduces "global context" reference that holds instance of global and shared memory variables for each created client. This global context reference is then passed to all objects who require it.

Please note this PR disables functionality of metadata - this area is still under development and requires some architectural decisions on how to pass the global pointer to metadata.

It replaces https://github.com/jackaudio/jack2/pull/547