### PR TITLE
[RFC][WIP] posix: Set mutex type to PTHREAD_MUTEX_ERRORCHECK

### DIFF
--- a/posix/JackPosixMutex.cpp
+++ b/posix/JackPosixMutex.cpp
@@ -28,7 +28,10 @@ namespace Jack
     JackBasePosixMutex::JackBasePosixMutex(const char* name)
         :fOwner(0)
     {
-        int res = pthread_mutex_init(&fMutex, NULL);
+        pthread_mutexattr_t attr;
+        pthread_mutexattr_init(&attr);
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+        int res = pthread_mutex_init(&fMutex, &attr);
         ThrowIf(res != 0, JackException("JackBasePosixMutex: could not init the mutex"));
     }
 


### PR DESCRIPTION
When looking for a way to debug the deadlock in https://github.com/jackaudio/jack2/issues/395 I stumbled across this advisory:

https://wiki.sei.cmu.edu/confluence/display/c/POS04-C.+Avoid+using+PTHREAD_MUTEX_NORMAL+type+mutex+locks

In the end it didn't detect the deadlock (which is not a proof of it not existing) but I'll leave the PR here for your consideration. Might be helpful in the future..