### PR TITLE
Fix jack_control handling of dbus bytes

### DIFF
--- a/example-clients/jack_control
+++ b/example-clients/jack_control
@@ -43,7 +43,7 @@ def python_type_to_jackdbus_type(value, type_char):
     if type_char == "b":
         return bool_convert(value);
     elif type_char == "y":
-        return dbus.Byte(value);
+        return dbus.Byte(ord(value));
     elif type_char == "i":
         return dbus.Int32(value)
     elif type_char == "u":


### PR DESCRIPTION
Prior to this, `jack_control dps dither s` would return an error.