### PR TITLE
fix a deadlock issue in midi_dump

### DIFF
--- a/tools/midi_dump.c
+++ b/tools/midi_dump.c
@@ -112,6 +112,11 @@ process (jack_nframes_t frames, void* arg)
 static void wearedone(int sig) {
 	fprintf(stderr, "Shutting down\n");
 	keeprunning = 0;
+	/* main loop might be blocked by data_ready when jack server dies. */
+	if (pthread_mutex_trylock (&msg_thread_lock) == 0) {
+		pthread_cond_signal (&data_ready);
+		pthread_mutex_unlock (&msg_thread_lock);
+	}
 }
 
 static void usage (int status) {


### PR DESCRIPTION
The main loop might be blocked by `data_ready` when JACK server dies
while the program is running.

To reproduce the problem:

1. Start JACK server
2. Run `jack_midi_dump`
3. Stop JACK server
4. Press Ctrl-C in `jack_midi_dump` to send SIGINT.
5. Observe that the program doesn't stop and stuck in the main loop.

This patch forces the `data_ready` to be signaled in the signal handler
to prevent indefinite waiting.