### PR TITLE
Change returncodes of jackd on all successes to 0

### DIFF
--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -253,8 +253,6 @@ void print_version()
     printf( "jackdmp version " VERSION " tmpdir "
             jack_server_dir " protocol %d" "\n",
             JACK_PROTOCOL_VERSION);
-    exit(-1);
-
 }
 
 int main(int argc, char** argv)
@@ -269,6 +267,7 @@ int main(int argc, char** argv)
     for(int a = 1; a < argc; ++a) {
         if( !strcmp(argv[a], "--version") || !strcmp(argv[a], "-V") ) {
             print_version();
+            return 0;
         }
     }
     const char *options = "-d:X:I:P:uvshrRL:STFl:t:mn:p:C:"
@@ -495,11 +494,13 @@ int main(int argc, char** argv)
                 }
                 break;
 
+            case 'h':
+                usage(stdout, server_ctl);
+                return_value = 0;
+                goto destroy_server;
+
             default:
                 fprintf(stderr, "unknown option character %c\n", optopt);
-                /*fallthru*/
-
-            case 'h':
                 usage(stdout, server_ctl);
                 goto destroy_server;
         }


### PR DESCRIPTION
`--help` and `--version` do not result in server failures.
Instead of returning the default `-1`, return a more reasonable `0`.

Closes #663.