### PR TITLE
Fix bug stopping jack_control doing many ops per execution

### DIFF
--- a/tools/jack_control
+++ b/tools/jack_control
@@ -397,7 +397,7 @@ def main():
             print("DBus exception: %s" % str(e))
             return 1
 
-        return 0
+    return 0
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
This bug was introduced here: https://github.com/jackaudio/jack2/commit/5d80e06c08019aaceca01fa34f0cfa3b3fb73653#diff-7d08f37916cbe03a6368b218295081808a648cfe8d849d5b29326eb9228ed501R400

We use this script loads. Could I become the "maintainer" of it? If so, what the versions of Python does jack2 support?

Fixes issue: https://github.com/jackaudio/jack2/issues/652

Thanks, Pete.