### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report 🐞
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!-- NOTE: Bugs reported here are exclusively for jack2. -->
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Environment
+
+* **JACK Version:** Which version of jack2 are you using? (e.g. the output of `jackd --version` or a git commit checksum)
+* **Operating System:** What operating system or distribution in which version are you using? (e.g. Linux, macOS, Windows)
+* **Installation:** How did you install jack2? (e.g. package manager, from source)
+
+## Steps To Reproduce
+
+```bash
+# Paste a minimal code example here (e.g. about how you started JACK)
+```
+
+### Expected vs. actual behavior
+
+A clear and concise description of what you expected to happen vs. what happened.
+
+<!-- Paste error messages in code blocks in their entirety. Use gist if very long or attach log files. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request 💡
+about: Suggest a new idea for the project.
+labels: enhancement
+---
+
+<!-- NOTE: Feature requests suggested here are exclusively for jack2. -->
+
+## Summary
+
+Brief explanation of the feature.
+
+### Basic example
+
+If the proposal involves a new feature or change in behavior, include a basic code example. Omit this section if it's not applicable.
+
+### Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+<!-- We are always happy about new contributors. If you can provide a pull request yourself for the feature that you are proposing, please say so! -->


### PR DESCRIPTION
.github/ISSUE_TEMPLATE/bug_report.md:
Add a github issue template for reporting bugs, which tracks what
operating system the user has, which version of JACK is in use and makes
suggestions around how to provide information.

.github/ISSUE_TEMPLATE/feature_request.md:
Add a github issue template for suggesting new features.