### PR TITLE
JackLinuxFutex: treat maximum TimedWait() as Wait() and retry on EINTR

### DIFF
--- a/common/JackClient.cpp
+++ b/common/JackClient.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include <math.h>
 #include <string>
 #include <algorithm>
+#include <climits>
 
 using namespace std;
 
@@ -636,7 +637,7 @@ inline int JackClient::CallProcessCallback()
 inline bool JackClient::WaitSync()
 {
     // Suspend itself: wait on the input synchro
-    if (GetGraphManager()->SuspendRefNum(GetClientControl(), fSynchroTable, 0x7FFFFFFF) < 0) {
+    if (GetGraphManager()->SuspendRefNum(GetClientControl(), fSynchroTable, LONG_MAX) < 0) {
         jack_error("SuspendRefNum error");
         return false;
     } else {


### PR DESCRIPTION
FUTEX_WAIT may be interrupted by a signal and return EINTR. If a client
process takes a signal while on the futex, the jack client may error out
with no way to recover despite the signal being safe. Instead, retry if
errno is set to EINTR.