### PR TITLE
__STDC_FORMAT_MACROS needs to be first

### DIFF
--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -18,6 +18,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 */
 
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
 #include "JackClient.h"
 #include "JackError.h"
 #include "JackGraphManager.h"
@@ -27,8 +29,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackTime.h"
 #include "JackPortType.h"
 #include <math.h>
-#define __STDC_FORMAT_MACROS 1
-#include <inttypes.h>
 
 using namespace Jack;
 


### PR DESCRIPTION
With some compilers and platforms `__STDC_FORMAT_MACROS` needs to be defined before anything else, as stated in the notes of the C++ refence: https://en.cppreference.com/w/cpp/types/integer#Notes. 

I was seeing issues on gcc like those of #408 and https://stackoverflow.com/questions/52715250/strange-compiler-behavior-with-priu64-in-c