### PR TITLE
Fix alignment of fields for atomic accesses

### DIFF
--- a/common/JackActivationCount.h
+++ b/common/JackActivationCount.h
@@ -39,7 +39,7 @@ class JackActivationCount
 
     private:
 
-        SInt32 fValue;
+        alignas(SInt32) SInt32 fValue;
         SInt32 fCount;
 
     public:

--- a/common/JackActivationCount.h
+++ b/common/JackActivationCount.h
@@ -45,7 +45,10 @@ class JackActivationCount
     public:
 
         JackActivationCount(): fValue(0), fCount(0)
-        {}
+        {
+            static_assert(offsetof(JackActivationCount, fValue) % sizeof(fValue) == 0,
+                          "fValue must be aligned within JackActivationCount");
+        }
 
         bool Signal(JackSynchro* synchro, JackClientControl* control);
 

--- a/common/JackAtomicArrayState.h
+++ b/common/JackAtomicArrayState.h
@@ -23,6 +23,7 @@
 #include "JackAtomic.h"
 #include "JackCompilerDeps.h"
 #include <string.h> // for memcpy
+#include <cstddef>
 
 namespace Jack
 {
@@ -159,6 +160,8 @@ class JackAtomicArrayState
 
         JackAtomicArrayState()
         {
+            static_assert(offsetof(JackAtomicArrayState, fCounter) % sizeof(fCounter) == 0,
+                          "fCounter must be aligned within JackAtomicArrayState");
             Counter1(fCounter) = 0;
         }
 

--- a/common/JackAtomicArrayState.h
+++ b/common/JackAtomicArrayState.h
@@ -122,7 +122,7 @@ class JackAtomicArrayState
         // fState[2] ==> request
 
         T fState[3];
-        volatile AtomicArrayCounter fCounter;
+        alignas(UInt32) volatile AtomicArrayCounter fCounter;
 
         UInt32 WriteNextStateStartAux(int state, bool* result)
         {

--- a/common/JackAtomicState.h
+++ b/common/JackAtomicState.h
@@ -94,7 +94,7 @@ class JackAtomicState
     protected:
 
         T fState[2];
-        volatile AtomicCounter fCounter;
+        alignas(UInt32) volatile AtomicCounter fCounter;
         SInt32 fCallWriteCounter;
 
         UInt32 WriteNextStateStartAux()

--- a/common/JackAtomicState.h
+++ b/common/JackAtomicState.h
@@ -93,8 +93,8 @@ class JackAtomicState
 
     protected:
 
-        T fState[2];
         volatile AtomicCounter fCounter;
+        T fState[2];
         SInt32 fCallWriteCounter;
 
         UInt32 WriteNextStateStartAux()

--- a/common/JackAtomicState.h
+++ b/common/JackAtomicState.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #include "JackAtomic.h"
 #include "JackCompilerDeps.h"
 #include <string.h> // for memcpy
+#include <cstddef>
 
 namespace Jack
 {
@@ -131,6 +132,8 @@ class JackAtomicState
 
         JackAtomicState()
         {
+            static_assert(offsetof(JackAtomicState, fCounter) % sizeof(fCounter) == 0,
+                          "fCounter must be aligned within JackAtomicState");
             Counter(fCounter) = 0;
             fCallWriteCounter = 0;
         }

--- a/common/JackAtomicState.h
+++ b/common/JackAtomicState.h
@@ -93,8 +93,8 @@ class JackAtomicState
 
     protected:
 
-        volatile AtomicCounter fCounter;
         T fState[2];
+        volatile AtomicCounter fCounter;
         SInt32 fCallWriteCounter;
 
         UInt32 WriteNextStateStartAux()

--- a/common/JackConnectionManager.cpp
+++ b/common/JackConnectionManager.cpp
@@ -32,6 +32,9 @@ namespace Jack
 JackConnectionManager::JackConnectionManager()
 {
     int i;
+    static_assert(offsetof(JackConnectionManager, fInputCounter) % sizeof(UInt32) == 0,
+                  "fInputCounter must be aligned within JackConnectionManager");
+
     jack_log("JackConnectionManager::InitConnections size = %ld ", sizeof(JackConnectionManager));
 
     for (i = 0; i < PORT_NUM_MAX; i++) {

--- a/common/JackConnectionManager.h
+++ b/common/JackConnectionManager.h
@@ -417,7 +417,7 @@ class SERVER_EXPORT JackConnectionManager
         JackFixedArray1<PORT_NUM_FOR_CLIENT> fInputPort[CLIENT_NUM];	/*! Table of input port per refnum : to find a refnum for a given port */
         JackFixedArray<PORT_NUM_FOR_CLIENT> fOutputPort[CLIENT_NUM];	/*! Table of output port per refnum : to find a refnum for a given port */
         JackFixedMatrix<CLIENT_NUM> fConnectionRef;						/*! Table of port connections by (refnum , refnum) */
-        JackActivationCount fInputCounter[CLIENT_NUM];					/*! Activation counter per refnum */
+        alignas(UInt32) JackActivationCount fInputCounter[CLIENT_NUM];	/*! Activation counter per refnum */
         JackLoopFeedback<CONNECTION_NUM_FOR_PORT> fLoopFeedback;		/*! Loop feedback connections */
 
         bool IsLoopPathAux(int ref1, int ref2) const;

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -64,7 +64,7 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     int fClientPriority;
     int fMaxClientPriority;
     char fServerName[JACK_SERVER_NAME_SIZE+1];
-    JackTransportEngine fTransport;
+    alignas(UInt32) JackTransportEngine fTransport;
     jack_timer_type_t fClockSource;
     int fDriverNum;
     bool fVerbose;
@@ -86,7 +86,7 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     UInt64 fConstraint;
 
     // Timer
-    JackFrameTimer fFrameTimer;
+    alignas(UInt32) JackFrameTimer fFrameTimer;
 
 #ifdef JACK_MONITOR
     JackEngineProfiling fProfiler;

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -48,14 +48,7 @@ class JackGraphManager;
 PRE_PACKED_STRUCTURE
 struct SERVER_EXPORT JackEngineControl : public JackShmMem
 {
-    // Timer
-    JackFrameTimer fFrameTimer;
-
-    // Padding to align fTransport
-    char padding[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
-    
     // Shared state
-    JackTransportEngine fTransport;
     jack_nframes_t fBufferSize;
     jack_nframes_t fSampleRate;
     bool fSyncMode;
@@ -71,6 +64,7 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     int fClientPriority;
     int fMaxClientPriority;
     char fServerName[JACK_SERVER_NAME_SIZE+1];
+    JackTransportEngine fTransport;
     jack_timer_type_t fClockSource;
     int fDriverNum;
     bool fVerbose;
@@ -90,6 +84,9 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     UInt64 fPeriod;
     UInt64 fComputation;
     UInt64 fConstraint;
+
+    // Timer
+    JackFrameTimer fFrameTimer;
 
 #ifdef JACK_MONITOR
     JackEngineProfiling fProfiler;

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -48,7 +48,14 @@ class JackGraphManager;
 PRE_PACKED_STRUCTURE
 struct SERVER_EXPORT JackEngineControl : public JackShmMem
 {
+    // Timer
+    JackFrameTimer fFrameTimer;
+
+    // Padding to align fTransport
+    char padding[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
+    
     // Shared state
+    JackTransportEngine fTransport;
     jack_nframes_t fBufferSize;
     jack_nframes_t fSampleRate;
     bool fSyncMode;
@@ -64,7 +71,6 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     int fClientPriority;
     int fMaxClientPriority;
     char fServerName[JACK_SERVER_NAME_SIZE+1];
-    JackTransportEngine fTransport;
     jack_timer_type_t fClockSource;
     int fDriverNum;
     bool fVerbose;
@@ -84,9 +90,6 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     UInt64 fPeriod;
     UInt64 fComputation;
     UInt64 fConstraint;
-
-    // Timer
-    JackFrameTimer fFrameTimer;
 
 #ifdef JACK_MONITOR
     JackEngineProfiling fProfiler;

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -48,14 +48,11 @@ class JackGraphManager;
 PRE_PACKED_STRUCTURE
 struct SERVER_EXPORT JackEngineControl : public JackShmMem
 {
-    // Padding to align start of JackEngineControl after inherited JackShmMem data
-    char fPadding1[ sizeof(UInt32) - sizeof(JackShmMem) % sizeof(UInt32) ];
-
     // Timer
     JackFrameTimer fFrameTimer;
 
     // Padding to align fTransport
-    char fPadding2[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
+    char padding[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
     
     // Shared state
     JackTransportEngine fTransport;
@@ -104,7 +101,6 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
                       "fTransport must be aligned within JackEngineControl");
         static_assert(offsetof(JackEngineControl, fFrameTimer) % sizeof(UInt32) == 0,
                       "fFrameTimer must be aligned within JackEngineControl");
-
         fBufferSize = 512;
         fSampleRate = 48000;
         fPeriodUsecs = jack_time_t(1000000.f / fSampleRate * fBufferSize);

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -49,13 +49,13 @@ PRE_PACKED_STRUCTURE
 struct SERVER_EXPORT JackEngineControl : public JackShmMem
 {
     // Padding to align start of JackEngineControl after inherited JackShmMem data
-    char fPadding1[ sizeof(UInt32) - sizeof(JackShmMem) % sizeof(UInt32) ];
+    char fPadding1[ sizeof(UInt32) - (sizeof(JackShmMem) % sizeof(UInt32)) ];
 
     // Timer
     JackFrameTimer fFrameTimer;
 
     // Padding to align fTransport
-    char fPadding2[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
+    char fPadding2[ sizeof(UInt32) - (sizeof(fFrameTimer) % sizeof(UInt32)) ];
     
     // Shared state
     JackTransportEngine fTransport;

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -93,7 +93,11 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
 #endif
 
     JackEngineControl(bool sync, bool temporary, long timeout, bool rt, long priority, bool verbose, jack_timer_type_t clock, const char* server_name)
-    {
+      {
+        static_assert(offsetof(JackEngineControl, fTransport) % sizeof(UInt32) == 0,
+                      "fTransport must be aligned within JackEngineControl");
+        static_assert(offsetof(JackEngineControl, fFrameTimer) % sizeof(UInt32) == 0,
+                      "fFrameTimer must be aligned within JackEngineControl");
         fBufferSize = 512;
         fSampleRate = 48000;
         fPeriodUsecs = jack_time_t(1000000.f / fSampleRate * fBufferSize);

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -48,11 +48,14 @@ class JackGraphManager;
 PRE_PACKED_STRUCTURE
 struct SERVER_EXPORT JackEngineControl : public JackShmMem
 {
+    // Padding to align start of JackEngineControl after inherited JackShmMem data
+    char fPadding1[ sizeof(UInt32) - sizeof(JackShmMem) % sizeof(UInt32) ];
+
     // Timer
     JackFrameTimer fFrameTimer;
 
     // Padding to align fTransport
-    char padding[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
+    char fPadding2[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
     
     // Shared state
     JackTransportEngine fTransport;
@@ -101,6 +104,7 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
                       "fTransport must be aligned within JackEngineControl");
         static_assert(offsetof(JackEngineControl, fFrameTimer) % sizeof(UInt32) == 0,
                       "fFrameTimer must be aligned within JackEngineControl");
+
         fBufferSize = 512;
         fSampleRate = 48000;
         fPeriodUsecs = jack_time_t(1000000.f / fSampleRate * fBufferSize);

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -49,13 +49,13 @@ PRE_PACKED_STRUCTURE
 struct SERVER_EXPORT JackEngineControl : public JackShmMem
 {
     // Padding to align start of JackEngineControl after inherited JackShmMem data
-    char fPadding1[ sizeof(UInt32) - (sizeof(JackShmMem) % sizeof(UInt32)) ];
+    char fPadding1[ sizeof(UInt32) - sizeof(JackShmMem) % sizeof(UInt32) ];
 
     // Timer
     JackFrameTimer fFrameTimer;
 
     // Padding to align fTransport
-    char fPadding2[ sizeof(UInt32) - (sizeof(fFrameTimer) % sizeof(UInt32)) ];
+    char fPadding2[ sizeof(UInt32) - sizeof(fFrameTimer) % sizeof(UInt32) ];
     
     // Shared state
     JackTransportEngine fTransport;

--- a/common/JackMessageBuffer.cpp
+++ b/common/JackMessageBuffer.cpp
@@ -38,7 +38,10 @@ JackMessageBuffer::JackMessageBuffer()
     fOutBuffer(0),
     fOverruns(0),
     fRunning(false)
-{}
+{
+    static_assert(offsetof(JackMessageBuffer, fOverruns) % sizeof(fOverruns) == 0,
+                  "fOverruns must be aligned within JackMessageBuffer");
+}
 
 JackMessageBuffer::~JackMessageBuffer()
 {}

--- a/common/JackMessageBuffer.h
+++ b/common/JackMessageBuffer.h
@@ -64,7 +64,7 @@ class JackMessageBuffer : public JackRunnableInterface
         JackProcessSync fGuard;
         volatile unsigned int fInBuffer;
         volatile unsigned int fOutBuffer;
-        SInt32 fOverruns;
+        alignas(SInt32) SInt32 fOverruns;
         bool fRunning;
 
         void Flush();

--- a/common/JackTransportEngine.cpp
+++ b/common/JackTransportEngine.cpp
@@ -36,6 +36,8 @@ namespace Jack
 
 JackTransportEngine::JackTransportEngine(): JackAtomicArrayState<jack_position_t>()
 {
+    static_assert(offsetof(JackTransportEngine, fWriteCounter) % sizeof(fWriteCounter) == 0,
+                  "fWriteCounter must be first member of JackTransportEngine to ensure its alignment");
     fTransportState = JackTransportStopped;
     fTransportCmd = fPreviousCmd = TransportCommandStop;
     fSyncTimeout = 10000000;	/* 10 seconds default...

--- a/common/JackTransportEngine.h
+++ b/common/JackTransportEngine.h
@@ -104,7 +104,7 @@ class SERVER_EXPORT JackTransportEngine : public JackAtomicArrayState<jack_posit
         bool fPendingPos;
         bool fNetworkSync;
         bool fConditionnal;
-        SInt32 fWriteCounter;
+        alignas(SInt32) SInt32 fWriteCounter;
 
         bool CheckAllRolling(JackClientInterface** table);
         void MakeAllStartingLocating(JackClientInterface** table);

--- a/common/JackTransportEngine.h
+++ b/common/JackTransportEngine.h
@@ -101,10 +101,10 @@ class SERVER_EXPORT JackTransportEngine : public JackAtomicArrayState<jack_posit
         jack_time_t fSyncTimeout;
         int fSyncTimeLeft;
         int fTimeBaseMaster;
-        SInt32 fWriteCounter;
         bool fPendingPos;
         bool fNetworkSync;
         bool fConditionnal;
+        SInt32 fWriteCounter;
 
         bool CheckAllRolling(JackClientInterface** table);
         void MakeAllStartingLocating(JackClientInterface** table);

--- a/common/JackTransportEngine.h
+++ b/common/JackTransportEngine.h
@@ -101,10 +101,10 @@ class SERVER_EXPORT JackTransportEngine : public JackAtomicArrayState<jack_posit
         jack_time_t fSyncTimeout;
         int fSyncTimeLeft;
         int fTimeBaseMaster;
+        SInt32 fWriteCounter;
         bool fPendingPos;
         bool fNetworkSync;
         bool fConditionnal;
-        SInt32 fWriteCounter;
 
         bool CheckAllRolling(JackClientInterface** table);
         void MakeAllStartingLocating(JackClientInterface** table);

--- a/macosx/JackAtomic_os.h
+++ b/macosx/JackAtomic_os.h
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #define __JackAtomic_APPLE__
 
 #include "JackTypes.h"
+#include <cassert>
 
 #if defined(__ppc__) || defined(__ppc64__)
 
@@ -67,8 +68,11 @@ static inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void* ad
 
 #else
 
+#include <stdio.h>
 static inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void* addr)
 {
+    // Assert pointer is 32-bit aligned
+    assert(((long)addr & (sizeof(int)-1)) == 0);
     return __sync_bool_compare_and_swap ((UInt32*)addr, value, newvalue);
 }
 


### PR DESCRIPTION
Fix for issue #749.

Atomic accesses on AArch64 require atomically accessed fields to be naturally aligned. The packed structure layouts used on macOS to ensure than x86 and ARM processes can share memory breaks this constraint in some instances.

This change
  1. Introduces alignment checks that ensure atomically-accessed fields are aligned within their parent structure (and that these parent structures are aligned within any struct containing them). These checks are static and have no runtime overhead.
  2. Changes order of some fields, and adds some padding in one instance, to meet the alignment constraints.

