### PR TITLE
Add jack_position_t::tick_double, and flags around it

### DIFF
--- a/common/jack/types.h
+++ b/common/jack/types.h
@@ -538,17 +538,21 @@ typedef uint64_t jack_unique_t;         /**< Unique ID (opaque) */
  */
 typedef enum {
 
-    JackPositionBBT = 0x10,     /**< Bar, Beat, Tick */
-    JackPositionTimecode = 0x20,        /**< External timecode */
-    JackBBTFrameOffset =      0x40,     /**< Frame offset of BBT information */
-    JackAudioVideoRatio =     0x80, /**< audio frames per video frame */
-    JackVideoFrameOffset =   0x100  /**< frame offset of first video frame */
+    JackPositionBBT      = 0x10,  /**< Bar, Beat, Tick */
+    JackPositionTimecode = 0x20,  /**< External timecode */
+    JackBBTFrameOffset   = 0x40,  /**< Frame offset of BBT information */
+    JackAudioVideoRatio  = 0x80,  /**< audio frames per video frame */
+    JackVideoFrameOffset = 0x100, /**< frame offset of first video frame */
+    JackTickDouble       = 0x200, /**< double-precision tick */
 
 } jack_position_bits_t;
 
 /** all valid position bits */
 #define JACK_POSITION_MASK (JackPositionBBT|JackPositionTimecode)
 #define EXTENDED_TIME_INFO
+
+/** transport tick_double member is available for use */
+#define JACK_TICK_DOUBLE
 
 PRE_PACKED_STRUCTURE
 struct _jack_position {
@@ -609,10 +613,18 @@ struct _jack_position {
                          set, but the value is zero, there is
                          no video frame within this cycle. */
 
+    /* JACK extra transport fields */
+
+    double              tick_double; /**< current tick-within-beat in double precision.
+                         Should be assumed zero if JackTickDouble is not set.
+                         Since older versions of JACK do not expose this variable,
+                         the macro JACK_TICK_DOUBLE is provided,
+                         which can be used as build-time detection. */
+
     /* For binary compatibility, new fields should be allocated from
      * this padding area with new valid bits controlling access, so
      * the existing structure size and offsets are preserved. */
-    int32_t             padding[7];
+    int32_t             padding[5];
 
     /* When (unique_1 == unique_2) the contents are consistent. */
     jack_unique_t       unique_2;       /**< unique ID */

--- a/common/jack/types.h
+++ b/common/jack/types.h
@@ -543,7 +543,7 @@ typedef enum {
     JackBBTFrameOffset   = 0x40,  /**< Frame offset of BBT information */
     JackAudioVideoRatio  = 0x80,  /**< audio frames per video frame */
     JackVideoFrameOffset = 0x100, /**< frame offset of first video frame */
-    JackTickDouble       = 0x200, /**< double-precision tick */
+    JackTickDouble       = 0x200, /**< double-resolution tick */
 
 } jack_position_bits_t;
 
@@ -615,7 +615,7 @@ struct _jack_position {
 
     /* JACK extra transport fields */
 
-    double              tick_double; /**< current tick-within-beat in double precision.
+    double              tick_double; /**< current tick-within-beat in double resolution.
                          Should be assumed zero if JackTickDouble is not set.
                          Since older versions of JACK do not expose this variable,
                          the macro JACK_TICK_DOUBLE is provided,


### PR DESCRIPTION
This PR adds `tick_double` to `jack_position_t` and `JackTickDouble` as a validation flag for it.
Since older versions of JACK do not expose this variable, the macro JACK_TICK_DOUBLE is provided, which can be used as build-time detection.

Example code for transport-listening clients:
```
double tick;
#ifdef JACK_TICK_DOUBLE
if (pos.valid & JackTickDouble)
    tick = pos.tick_double;
else
#endif
    tick = pos.tick;
```

Rationale:
When using JACK transport to sync between clients with precise timing requirements (such as MIDI sequencers) rounding errors would accumulate and eventually make the separate clients out of sync.
This was observed in Carla and mod-host, which use audio plugins as JACK clients. Some MIDI plugins could miss notes due to rounding errors. This change has been deployed in MOD Devices for a couple of releases already and it is known to work (that is, it corrects the situation).
Since the transport API has padding members available for use and it has been unchanged for several years (so there won't be a need to add more fields in the short or middle term), let's just go for it.
