### PR TITLE
macOS: pass JackMachSemaphore send right directly via shm

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Nedko Arnaudov
 Olaf Hering
 Olivier Humbert
 Paul Davis
+Peter Bridgman
 Peter L Jones
 Pieter Palmers
 Ricardo Crudo

--- a/macosx/JackMachSemaphore.h
+++ b/macosx/JackMachSemaphore.h
@@ -39,12 +39,16 @@ class SERVER_EXPORT JackMachSemaphore : public detail::JackSynchro
     private:
 
         semaphore_t fSemaphore;
-        mach_port_t fBootPort;
 
         int fSharedMem;
-        char* fSharedName;
 
-        bool recursiveBootstrapRegister(int counter);
+        /*! \brief Pointer to shared memory containing semaphore send right port.
+         *
+         * If the semaphore has been Allocate()d (in the case of the server) or Connect()ed (in the
+         * case of the client), and not yet Disconnect()ed or Destroy()ed, a pointer to a shared
+         * memory segment at which a send right for a semaphore can be found. Otherwise, NULL.
+         */
+        mach_port_t* fSharedSemaphoreSend;
 
     protected:
 
@@ -52,7 +56,7 @@ class SERVER_EXPORT JackMachSemaphore : public detail::JackSynchro
 
     public:
 
-        JackMachSemaphore():JackSynchro(), fSemaphore(0), fBootPort(0), fSharedMem(0), fSharedName(NULL)
+        JackMachSemaphore():JackSynchro(), fSemaphore(0), fSharedMem(0), fSharedSemaphoreSend(NULL)
         {}
 
         bool Signal();


### PR DESCRIPTION
Previously, JackMachSemaphore would communicate the send right for the
semaphore object from the server to the client via a named service
regstered via `bootstrap_register`. However,

 * This is deprecated (see bootstrap.h) - the recommendation is to pass
 the send right for the port directly, rather than indirecting via the
 service name and the bootstrap server

 * This led to #784, wherein old service names were not cleaned up, and
 the server would abandon attempting to create the 99th service, leading
 to clients failing to connect after they had connected 98 times on a
 given boot of the OS.

 This commit implements the advice from the deprecation notice in
 bootstrap.h, communicating the send right for the semaphore port
 directly via the shared memory segment that we used to use to
 communicate the service name, bypassing the need to register a named
 service entirely. This resolves #784.

**NB**: I am unsure what guarantees JACK makes about the stability of the client/server
interface, or exactly how clients load the dylib containing this functionality - but I assume this
would not be backwards-compatible between different client/server versions (?) - I'm unsure of
what the implications of this are or if some protocol version bump / similar would be required?