### PR TITLE
macOS: Pass JackMachSemaphore send right via mach_msg IPC

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Nedko Arnaudov
 Olaf Hering
 Olivier Humbert
 Paul Davis
+Peter Bridgman
 Peter L Jones
 Pieter Palmers
 Ricardo Crudo

--- a/common/wscript
+++ b/common/wscript
@@ -117,6 +117,7 @@ def build(bld):
             '../posix/JackPosixMutex.cpp',
             '../macosx/JackMachThread.mm',
             '../macosx/JackMachSemaphore.mm',
+            '../macosx/JackMachSemaphoreServer.mm',
             '../posix/JackSocket.cpp',
             '../macosx/JackMachTime.c',
             ]

--- a/macosx/JackMachSemaphoreServer.h
+++ b/macosx/JackMachSemaphoreServer.h
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2021 Peter Bridgman
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackMachSemaphoreServer__
+#define __JackMachSemaphoreServer__
+
+#include "JackCompilerDeps.h"
+#include "JackMachThread.h"
+
+#include <mach/mach.h>
+#include <mach/semaphore.h>
+
+namespace Jack
+{
+
+/*! \brief A runnable thread which listens for IPC messages and replies with a semaphore send right. */
+class SERVER_EXPORT JackMachSemaphoreServer : public JackRunnableInterface
+{
+    private:
+        /*! \brief The semaphore send right that will be dispatched to clients. */
+        semaphore_t fSemaphore;
+
+        /*! \brief The port on which we will listen for IPC messages. */
+        mach_port_t fServerReceive;
+
+        /*! \brief A pointer to a null-terminated string buffer that will be read to obtain the
+         * server name for reporting purposes. Not managed at all by this type. */
+        char* fName;
+
+    public:
+        JackMachSemaphoreServer(semaphore_t semaphore, mach_port_t server_recv, char* name):
+            fSemaphore(semaphore), fServerReceive(server_recv), fName(name)
+        {}
+
+        bool Execute() override;
+};
+
+} // end of namespace
+
+#endif

--- a/macosx/JackMachSemaphoreServer.mm
+++ b/macosx/JackMachSemaphoreServer.mm
@@ -1,0 +1,87 @@
+/*
+Copyright (C) 2021 Peter Bridgman
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackMachSemaphoreServer.h"
+#include "JackMachUtils.h"
+#include "JackConstants.h"
+#include "JackTools.h"
+#include "JackError.h"
+
+#include <mach/message.h>
+
+#define jack_mach_error(kern_result, message) \
+        jack_mach_error_uncurried("JackMachSemaphoreServer", kern_result, message)
+
+namespace Jack
+{
+
+bool JackMachSemaphoreServer::Execute() {
+    jack_log("JackMachSemaphoreServer::Execute: %s", fName);
+
+    /* Setup a message struct in our local stack frame which we can receive messages into and send
+     * messages from. */
+    struct {
+        mach_msg_header_t hdr;
+        mach_msg_trailer_t trailer;
+    } msg;
+
+    // Block until we receive a message on the fServerReceive port.
+    mach_msg_return_t recv_err = mach_msg(
+        &msg.hdr,
+        MACH_RCV_MSG,
+        0,
+        sizeof(msg),
+        fServerReceive,
+        MACH_MSG_TIMEOUT_NONE,
+        MACH_PORT_NULL
+    );
+
+    if (recv_err != MACH_MSG_SUCCESS) {
+        jack_mach_error(recv_err, "receive error");
+        return true; // Continue processing more connections
+    }
+
+    /* We're going to reuse the message struct that we received the message into to send a reply.
+     * Setup the semaphore send port that we want to give to the client as the local port... */
+    msg.hdr.msgh_local_port = fSemaphore;
+
+    /*
+     * ... to be returned by copy (_COPY_SEND), to a destination that is _SEND_ONCE that we no
+     * longer require. That destination will have been set by the client as their local_port, so
+     * will now already be the remote_port in the message we received (nifty, eh?).
+     */
+    msg.hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_MOVE_SEND_ONCE, MACH_MSG_TYPE_COPY_SEND);
+
+    mach_msg_return_t send_err = mach_msg(
+        &msg.hdr,
+        MACH_SEND_MSG,
+        sizeof(msg.hdr), // no trailer on send
+        0,
+        MACH_PORT_NULL,
+        MACH_MSG_TIMEOUT_NONE,
+        MACH_PORT_NULL);
+
+    if (send_err != MACH_MSG_SUCCESS) {
+        jack_mach_error(send_err, "send error");
+    }
+
+    return true;
+}
+
+} // end of namespace

--- a/macosx/JackMachUtils.h
+++ b/macosx/JackMachUtils.h
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2021 Peter Bridgman
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackMachUtils__
+#define __JackMachUtils__
+
+#define jack_mach_error_uncurried(type_name, kern_return, message) \
+        jack_error(type_name "::%s: " message " - %i:%s", \
+                    __FUNCTION__, \
+                    kern_return, \
+                    mach_error_string(kern_return))
+
+#define jack_mach_bootstrap_err_uncurried(type_name, kern_return, message, service_name) \
+        jack_error(type_name "::%s: " message " [%s] - %i:%s", \
+                    __FUNCTION__, \
+                    service_name, \
+                    kern_return, \
+                    bootstrap_strerror(kern_return))
+
+#endif


### PR DESCRIPTION
Previously, JackMachSemaphore would communicate the send right for the
semaphore object from the server to a client via a named service
registered via `bootstrap_register`. However, to do this, it would
register the semaphore's port as the service port directly.

In theory this ought to be fine, however in practice, macOS `launchd`,
which provides the `bootstrap_register` interface, does not correctly
detect when such a port becomes dead, and incorrectly believes that the
service that it provides is forever alive, even past the end of the
`jackd` process' (and therefore the semaphore's) existence. This seems
to be *specific* to semaphore ports, as `launchd` is expecting a
standard IPC port, owned by the task, not the kernel. This prevents
`jackd` from later registering another service with the same name, as
launchd rejects the registration as conflicting with an active service.

To get around this, `jackd` previously added a counter to the end of the
named service registrations, allowing old services to remain in the
system until the end of the session. To prevent things getting out of
hand, this was capped at 98 service registrations for a given semaphore
name. This led to #784, in which running a client for the 99th time
resulted in the semaphore creation failing and the client failing to
connect.

As launchd outlives multiple runs of `jackd`, this situation persisted
across restarts of jackd, requiring a restart of the user's session
(i.e. a reboot) to fix.

An initial attempt at fixing this (see #785) tried passing the port
rights directly via shared memory, however mach is too clever for us and
foils that plan by having port names be looked up in a per-task table
(sensible when you think about it).

In this commit, we use mach IPC messages to transfer the send right for
the semaphore from the server to the client. By registering a standard IPC
port with the bootstrap server, the service registrations are correctly torn
down when the ports are destroyed.

It works something like this:

* Server creates IPC port and registers it globally via `bootstrap_register`
* Server listens on IPC port for messages
* Client looks up IPC port via `bootstrap_look_up`
* Client sends it a message
* Server replies with a message containing a send right to the
semaphore's port
* Client is then free to use the semaphore port as before.

This resolves #784.