### PR TITLE
Use dllimport/dllexport in public jack headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Generate macOS package
       shell: bash
       run: |
-        ./macosx/generate-pkg.sh $(pwd)/destdir ${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        ./macosx/generate-pkg.sh $(pwd)/destdir/usr/local ${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-macOS-intel-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
@@ -95,21 +95,13 @@ jobs:
         python ./waf configure --platform=darwin --prefix=/usr/local
         python ./waf build -j $(sysctl -n hw.logicalcpu)
         python ./waf install --destdir=$(pwd)/destdir
-    #- name: Patch binaries
-      #shell: bash
-      #run: |
-        #pushd $(pwd)/destdir
-        #for f in $(ls bin/* lib/*.dylib lib/jack/*); do
-          #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjack.0.dylib" "/usr/local/lib/libjack.0.dylib" "${f}"
-          #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjacknet.0.dylib" "/usr/local/lib/libjacknet.0.dylib" "${f}"
-          #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjackserver.0.dylib" "/usr/local/lib/libjackserver.0.dylib" "${f}"
     - name: Set sha8
       id: slug
       run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
     - name: Generate macOS package
       shell: bash
       run: |
-        ./macosx/generate-pkg.sh $(pwd)/destdir ${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        ./macosx/generate-pkg.sh $(pwd)/destdir/usr/local ${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-macOS-universal-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
       shell: bash
       run: |
         pushd PawPaw && source local.env macos && popd
-        ~/PawPawBuilds/targets/macos/bin/python3 ./waf configure --platform=darwin --prefix=/usr/local
-        ~/PawPawBuilds/targets/macos/bin/python3 ./waf build -j $(sysctl -n hw.logicalcpu)
-        ~/PawPawBuilds/targets/macos/bin/python3 ./waf install --destdir="$(pwd)/destdir"
+        python ./waf configure --platform=darwin --prefix=/usr/local
+        python ./waf build -j $(sysctl -n hw.logicalcpu)
+        python ./waf install --destdir="$(pwd)/destdir"
 
   # macOS native universal build
   macos_universal:
@@ -90,16 +90,10 @@ jobs:
       with:
         path: |
           ~/PawPawBuilds/builds
-          ~/PawPawBuilds/debs
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
           /var/cache/apt/archives
         key: cache-win32
-    #- name: Restore debian packages cache
-      #run: |
-        #if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
-          #sudo cp ~/PawPawBuilds/debs/*.deb /var/cache/apt/archives/; \
-        #fi
     - name: Set up dependencies
       run: |
         wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add - && \
@@ -107,10 +101,6 @@ jobs:
         sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
         sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
           binutils-mingw-w64-i686 g++-mingw-w64-i686
-    #- name: Cache debian packages
-      #run: |
-        #mkdir -p ~/PawPawBuilds/debs && \
-        #sudo mv /var/cache/apt/archives/*.deb ~/PawPawBuilds/debs/
     - name: Bootstrap win32 cross-compiled
       shell: bash
       run: |
@@ -139,16 +129,10 @@ jobs:
       with:
         path: |
           ~/PawPawBuilds/builds
-          ~/PawPawBuilds/debs
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
           /var/cache/apt/archives
         key: cache-win64
-    #- name: Restore debian packages cache
-      #run: |
-        #if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
-          #sudo cp ~/PawPawBuilds/debs/*.deb /var/cache/apt/archives/; \
-        #fi
     - name: Set up dependencies
       run: |
         wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add - && \
@@ -156,10 +140,6 @@ jobs:
         sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
         sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
           binutils-mingw-w64-x86-64 g++-mingw-w64-x86-64
-    #- name: Cache debian packages
-      #run: |
-        #mkdir -p ~/PawPawBuilds/debs && \
-        #sudo mv /var/cache/apt/archives/*.deb ~/PawPawBuilds/debs/
     - name: Bootstrap win64 cross-compiled
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           ~/PawPawBuilds/builds
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-        key: macos-${PAWPAW_VERSION}
+        key: macos
     - name: Set up dependencies
       run: |
         brew install cmake jq meson
@@ -46,6 +46,17 @@ jobs:
         python ./waf configure --platform=darwin --prefix=/usr/local
         python ./waf build -j $(sysctl -n hw.logicalcpu)
         python ./waf install --destdir="$(pwd)/destdir"
+    - name: Generate macOS package
+      shell: bash
+      run: |
+        ./macosx/generate-pkg.sh $(pwd)/destdir
+    - name: Set sha8
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jack2-macOS-intel-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        path: macosx/jack2-osx-*.pkg
 
   # macOS native universal build
   macos_universal:
@@ -61,7 +72,7 @@ jobs:
           ~/PawPawBuilds/builds
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-        key: macos-universal-${PAWPAW_VERSION}
+        key: macos-universal
     - name: Set up dependencies
       run: |
         brew install cmake jq meson
@@ -83,7 +94,26 @@ jobs:
         pushd PawPaw && source local.env macos-universal && popd
         python ./waf configure --platform=darwin --prefix=/usr/local
         python ./waf build -j $(sysctl -n hw.logicalcpu)
-        python ./waf install --destdir="$(pwd)/destdir"
+        python ./waf install --destdir=$(pwd)/destdir
+    #- name: Patch binaries
+      #shell: bash
+      #run: |
+        #pushd $(pwd)/destdir
+        #for f in $(ls bin/* lib/*.dylib lib/jack/*); do
+          #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjack.0.dylib" "/usr/local/lib/libjack.0.dylib" "${f}"
+          #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjacknet.0.dylib" "/usr/local/lib/libjacknet.0.dylib" "${f}"
+          #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjackserver.0.dylib" "/usr/local/lib/libjackserver.0.dylib" "${f}"
+    - name: Generate macOS package
+      shell: bash
+      run: |
+        ./macosx/generate-pkg.sh $(pwd)/destdir
+    - name: Set sha8
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jack2-macOS-universal-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        path: macosx/jack2-osx-*.pkg
 
   # linux with win32 cross-compilation
   win32:
@@ -100,7 +130,7 @@ jobs:
           ~/PawPawBuilds/debs
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-        key: win32-${PAWPAW_VERSION}
+        key: win32
     - name: Restore debian packages cache
       run: |
         if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
@@ -154,7 +184,7 @@ jobs:
           ~/PawPawBuilds/debs
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-        key: win64-${PAWPAW_VERSION}
+        key: win64
     - name: Restore debian packages cache
       run: |
         if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,156 @@
+name: build
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+env:
+  DEBIAN_FRONTEND: noninteractive
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  PAWPAW_VERSION: 8c69660ab10b75cd7a488f41386dbcb4c8802c5a
+
+jobs:
+  # macOS native intel build
+  macos:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/PawPawBuilds/builds
+          ~/PawPawBuilds/downloads
+          ~/PawPawBuilds/targets
+        key: cache-macos
+    - name: Set up dependencies
+      run: |
+        brew install cmake jq meson
+    - name: Bootstrap macOS intel
+      shell: bash
+      run: |
+        if [ ! -d PawPaw ]; then
+            git clone https://github.com/DISTRHO/PawPaw.git
+            git -C PawPaw checkout ${PAWPAW_VERSION}
+        fi
+        ./PawPaw/bootstrap-jack2.sh macos && ./PawPaw/.cleanup.sh macos
+
+  # macOS native universal build
+  macos_universal:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/PawPawBuilds/builds
+          ~/PawPawBuilds/downloads
+          ~/PawPawBuilds/targets
+        key: cache-macos-universal
+    - name: Set up dependencies
+      run: |
+        brew install cmake jq meson
+    - name: Fix up Xcode
+      run: |
+        sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+        sudo xcode-select -s "/Applications/Xcode_12.3.app"
+    - name: Bootstrap macOS universal
+      shell: bash
+      run: |
+        if [ ! -d PawPaw ]; then
+            git clone https://github.com/DISTRHO/PawPaw.git
+            git -C PawPaw checkout ${PAWPAW_VERSION}
+        fi
+        ./PawPaw/bootstrap-jack2.sh macos-universal && ./PawPaw/.cleanup.sh macos-universal
+
+  # linux with win32 cross-compilation
+  win32:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/PawPawBuilds/builds
+          ~/PawPawBuilds/debs
+          ~/PawPawBuilds/downloads
+          ~/PawPawBuilds/targets
+          /var/cache/apt/archives
+        key: cache-win32
+    #- name: Restore debian packages cache
+      #run: |
+        #if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
+          #sudo cp ~/PawPawBuilds/debs/*.deb /var/cache/apt/archives/; \
+        #fi
+    - name: Set up dependencies
+      run: |
+        wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add - && \
+        sudo dpkg --add-architecture i386 && \
+        sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
+        sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
+          binutils-mingw-w64-i686 g++-mingw-w64-i686
+    #- name: Cache debian packages
+      #run: |
+        #mkdir -p ~/PawPawBuilds/debs && \
+        #sudo mv /var/cache/apt/archives/*.deb ~/PawPawBuilds/debs/
+    - name: Bootstrap win32 cross-compiled
+      shell: bash
+      run: |
+        if [ ! -d PawPaw ]; then
+            git clone https://github.com/DISTRHO/PawPaw.git
+            git -C PawPaw checkout ${PAWPAW_VERSION}
+        fi
+        ./PawPaw/bootstrap-jack2.sh win32 && ./PawPaw/.cleanup.sh win32
+
+  # linux with win64 cross-compilation
+  win64:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/PawPawBuilds/builds
+          ~/PawPawBuilds/debs
+          ~/PawPawBuilds/downloads
+          ~/PawPawBuilds/targets
+          /var/cache/apt/archives
+        key: cache-win64
+    #- name: Restore debian packages cache
+      #run: |
+        #if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
+          #sudo cp ~/PawPawBuilds/debs/*.deb /var/cache/apt/archives/; \
+        #fi
+    - name: Set up dependencies
+      run: |
+        wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add - && \
+        sudo dpkg --add-architecture i386 && \
+        sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
+        sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
+          binutils-mingw-w64-x86-64 g++-mingw-w64-x86-64
+    #- name: Cache debian packages
+      #run: |
+        #mkdir -p ~/PawPawBuilds/debs && \
+        #sudo mv /var/cache/apt/archives/*.deb ~/PawPawBuilds/debs/
+    - name: Bootstrap win64 cross-compiled
+      shell: bash
+      run: |
+        if [ ! -d PawPaw ]; then
+            git clone https://github.com/DISTRHO/PawPaw.git
+            git -C PawPaw checkout ${PAWPAW_VERSION}
+        fi
+        ./PawPaw/bootstrap-jack2.sh win64 && ./PawPaw/.cleanup.sh win64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,3 +269,44 @@ jobs:
       with:
         name: jack2-win64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
         path: windows/inno/jack2-*.exe
+
+  # ubuntu-20.04
+  ubuntu-20.04:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/debs
+        key: ubuntu-20.04
+    - name: Restore debian packages cache
+      run: |
+        if [ -d ~/debs ] && [ "$(ls ~/debs | wc -l)" -ne 0 ]; then \
+          sudo cp ~/debs/*.deb /var/cache/apt/archives/; \
+        fi
+    - name: Set up dependencies
+      run: |
+        sudo add-apt-repository -y ppa:ubuntustudio-ppa/backports
+        sudo sed -i "s/# deb-src/deb-src/" /etc/apt/sources.list /etc/apt/sources.list.d/*.list
+        sudo apt-get update -qq
+        sudo apt-get build-dep jackd2
+        sudo apt-get install devscripts
+    - name: Cache debian packages
+      run: |
+        mkdir -p ~/debs && \
+        sudo mv /var/cache/apt/archives/*.deb ~/debs/
+    - name: Set sha8
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - name: Build jack2 packages
+      shell: bash
+      run: |
+        apt-get source jackd2
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jack2-ubuntu-20.04-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        path: *.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,12 +181,12 @@ jobs:
         wineboot -u
         # Download and install innosetup
         curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
-        wine is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
+        xvfb-run wine is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
         # create installer
         ln -sf $(pwd)/destdir windows/inno/win32
         pushd windows/inno
         echo "#define VERSION \"${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}\"" > version.iss
-        wine ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win32-mini.iss
+        xvfb-run wine ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win32-mini.iss
         popd
     - uses: actions/upload-artifact@v2
       with:
@@ -266,12 +266,12 @@ jobs:
         wineboot -u
         # Download and install innosetup
         curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
-        wine64 is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
+        xvfb-run wine64 is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
         # create installer
         ln -sf $(pwd)/destdir windows/inno/win64
         pushd windows/inno
         echo "#define VERSION \"${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}\"" > version.iss
-        wine64 ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win64-mini.iss
+        xvfb-run wine64 ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win64-mini.iss
         popd
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,7 +305,11 @@ jobs:
     - name: Build jack2 packages
       shell: bash
       run: |
-        apt-get source jackd2
+        apt-get source -d jackd2
+        tar xf *.debian.tar.xz
+        rm -rf debian/source
+        dch -M -b -v "$(cat wscript | awk 'sub("VERSION=","")' | tr -d "'")~$(date +"%Y%m%d")git${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}" -D focal "automated build"
+        debuild -rfakeroot --no-lintian || true
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-ubuntu-20.04-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,9 +165,11 @@ jobs:
     - name: Generate MSVC lib files
       shell: bash
       run: |
-        llvm-dlltool -m i386 -D libjack.dll -d $(pwd)/destdir/lib/libjack.def -l $(pwd)/destdir/lib/libjack.lib
-        llvm-dlltool -m i386 -D libjacknet.dll -d $(pwd)/destdir/lib/libjacknet.def -l $(pwd)/destdir/lib/libjacknet.lib
-        llvm-dlltool -m i386 -D libjackserver.dll -d $(pwd)/destdir/lib/libjackserver.def -l $(pwd)/destdir/lib/libjackserver.lib
+        pushd $(pwd)/destdir/lib
+        llvm-dlltool -m i386 -D libjack.dll -d libjack.def -l libjack.lib
+        llvm-dlltool -m i386 -D libjacknet.dll -d libjacknet.def -l libjacknet.lib
+        llvm-dlltool -m i386 -D libjackserver.dll -d libjackserver.def -l libjackserver.lib
+        popd
 
   # linux with win64 cross-compilation
   win64:
@@ -212,14 +214,23 @@ jobs:
     - name: Build jack2
       shell: bash
       run: |
-        pushd PawPaw && source local.env win32 && popd
+        pushd PawPaw && source local.env win64 && popd
+        #export PATH+=":/usr/i686-w64-mingw32/bin"
+        #export LDFLAGS+="-L~/PawPawBuilds/targets/win64/lib32"
+        #--mixed
         ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
         ./waf build -j $(nproc)
         ./waf install
     - name: Generate MSVC lib files
       shell: bash
       run: |
-        llvm-dlltool -m i386 -D libjack.dll -d $(pwd)/destdir/lib32/libjack.def -l $(pwd)/destdir/lib32/libjack.lib
-        llvm-dlltool -m i386:x86-64 -D libjack64.dll -d $(pwd)/destdir/lib/libjack64.def -l $(pwd)/destdir/lib/libjack64.lib
-        llvm-dlltool -m i386:x86-64 -D libjacknet64.dll -d $(pwd)/destdir/lib/libjacknet64.def -l $(pwd)/destdir/lib/libjacknet64.lib
-        llvm-dlltool -m i386:x86-64 -D libjackserver64.dll -d $(pwd)/destdir/lib/libjackserver64.def -l $(pwd)/destdir/lib/libjackserver64.lib
+        # 32bit
+        #pushd $(pwd)/destdir/lib32
+        #llvm-dlltool -m i386 -D libjack.dll -d libjack.def -l libjack.lib
+        #popd
+        # 64bit
+        pushd $(pwd)/destdir/lib
+        llvm-dlltool -m i386:x86-64 -D libjack64.dll -d libjack64.def -l libjack64.lib
+        llvm-dlltool -m i386:x86-64 -D libjacknet64.dll -d libjacknet64.def -l libjacknet64.lib
+        llvm-dlltool -m i386:x86-64 -D libjackserver64.dll -d libjackserver64.def -l libjackserver64.lib
+        popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       run: |
         # Setup wine
         export WINEPREFIX=$(pwd)/innosetup
-        wineboot -u
+        xvfb-run wineboot -u
         # Download and install innosetup
         curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
         xvfb-run wine is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
@@ -263,7 +263,7 @@ jobs:
       run: |
         # Setup wine
         export WINEPREFIX=$(pwd)/innosetup
-        wineboot -u
+        xvfb-run wineboot -u
         # Download and install innosetup
         curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
         xvfb-run wine64 is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
         path: windows/inno/jack2-*.exe
 
   # ubuntu-20.04
-  ubuntu-20.04:
+  ubuntu_20_04:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,10 @@ jobs:
         echo "#define VERSION \"${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}\"" > version.iss
         wine ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win32-mini.iss
         popd
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jack2-win32-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        path: windows/inno/jack2-*.exe
 
   # linux with win64 cross-compilation
   win64:
@@ -269,3 +273,7 @@ jobs:
         echo "#define VERSION \"${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}\"" > version.iss
         wine64 ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win64-mini.iss
         popd
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jack2-win64-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
+        path: windows/inno/jack2-*.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         pushd PawPaw && source local.env macos && popd
         python ./waf configure --platform=darwin --prefix=/usr/local
         python ./waf build -j $(sysctl -n hw.logicalcpu)
-        python ./waf install --destdir="$(pwd)/destdir"
+        python ./waf install --destdir=$(pwd)/destdir
     - name: Generate macOS package
       shell: bash
       run: |
@@ -79,7 +79,7 @@ jobs:
     - name: Fix up Xcode
       run: |
         sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
-        sudo xcode-select -s "/Applications/Xcode_12.3.app"
+        sudo xcode-select -s /Applications/Xcode_12.3.app
     - name: Bootstrap macOS universal
       shell: bash
       run: |
@@ -159,7 +159,7 @@ jobs:
       shell: bash
       run: |
         pushd PawPaw && source local.env win32 && popd
-        ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
+        ./waf configure --platform=win32 --prefix=$(pwd)/destdir --static
         ./waf build -j $(nproc)
         ./waf install
     - name: Generate MSVC lib files
@@ -215,19 +215,18 @@ jobs:
       shell: bash
       run: |
         pushd PawPaw && source local.env win64 && popd
-        #export PATH+=":/usr/i686-w64-mingw32/bin"
-        #export LDFLAGS+="-L~/PawPawBuilds/targets/win64/lib32"
-        #--mixed
-        ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
+        export PATH+=":/usr/i686-w64-mingw32/bin"
+        export LDFLAGS+="-L~/PawPawBuilds/targets/win64/lib32"
+        ./waf configure --platform=win32 --prefix=$(pwd)/destdir --static --mixed
         ./waf build -j $(nproc)
         ./waf install
     - name: Generate MSVC lib files
       shell: bash
       run: |
         # 32bit
-        #pushd $(pwd)/destdir/lib32
-        #llvm-dlltool -m i386 -D libjack.dll -d libjack.def -l libjack.lib
-        #popd
+        pushd $(pwd)/destdir/lib32
+        llvm-dlltool -m i386 -D libjack.dll -d libjack.def -l libjack.lib
+        popd
         # 64bit
         pushd $(pwd)/destdir/lib
         llvm-dlltool -m i386:x86-64 -D libjack64.dll -d libjack64.def -l libjack64.lib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,13 @@ jobs:
         python ./waf configure --platform=darwin --prefix=/usr/local
         python ./waf build -j $(sysctl -n hw.logicalcpu)
         python ./waf install --destdir=$(pwd)/destdir
-    - name: Generate macOS package
-      shell: bash
-      run: |
-        ./macosx/generate-pkg.sh $(pwd)/destdir
     - name: Set sha8
       id: slug
       run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - name: Generate macOS package
+      shell: bash
+      run: |
+        ./macosx/generate-pkg.sh $(pwd)/destdir ${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-macOS-intel-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
@@ -103,13 +103,13 @@ jobs:
           #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjack.0.dylib" "/usr/local/lib/libjack.0.dylib" "${f}"
           #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjacknet.0.dylib" "/usr/local/lib/libjacknet.0.dylib" "${f}"
           #install_name_tool -change "${PAWPAW_PREFIX}/jack2/lib/libjackserver.0.dylib" "/usr/local/lib/libjackserver.0.dylib" "${f}"
-    - name: Generate macOS package
-      shell: bash
-      run: |
-        ./macosx/generate-pkg.sh $(pwd)/destdir
     - name: Set sha8
       id: slug
       run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - name: Generate macOS package
+      shell: bash
+      run: |
+        ./macosx/generate-pkg.sh $(pwd)/destdir ${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-macOS-universal-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,4 +313,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-ubuntu-20.04-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: ./*.deb
+        path: ../*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
       shell: bash
       run: |
         if [ ! -d PawPaw ]; then
-            git clone https://github.com/DISTRHO/PawPaw.git
-            git -C PawPaw checkout ${PAWPAW_VERSION}
+          git clone https://github.com/DISTRHO/PawPaw.git
+          git -C PawPaw checkout ${PAWPAW_VERSION}
         fi
         ./PawPaw/bootstrap-jack2.sh macos && ./PawPaw/.cleanup.sh macos
     - name: Build jack2
@@ -73,10 +73,17 @@ jobs:
       shell: bash
       run: |
         if [ ! -d PawPaw ]; then
-            git clone https://github.com/DISTRHO/PawPaw.git
-            git -C PawPaw checkout ${PAWPAW_VERSION}
+          git clone https://github.com/DISTRHO/PawPaw.git
+          git -C PawPaw checkout ${PAWPAW_VERSION}
         fi
         ./PawPaw/bootstrap-jack2.sh macos-universal && ./PawPaw/.cleanup.sh macos-universal
+    - name: Build jack2
+      shell: bash
+      run: |
+        pushd PawPaw && source local.env macos-universal && popd
+        python ./waf configure --platform=darwin --prefix=/usr/local
+        python ./waf build -j $(sysctl -n hw.logicalcpu)
+        python ./waf install --destdir="$(pwd)/destdir"
 
   # linux with win32 cross-compilation
   win32:
@@ -96,26 +103,26 @@ jobs:
         key: cache-win32
     - name: Set up dependencies
       run: |
-        wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add - && \
-        sudo dpkg --add-architecture i386 && \
-        sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
+        wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+        sudo dpkg --add-architecture i386
+        sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
         sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
           binutils-mingw-w64-i686 g++-mingw-w64-i686
     - name: Bootstrap win32 cross-compiled
       shell: bash
       run: |
         if [ ! -d PawPaw ]; then
-            git clone https://github.com/DISTRHO/PawPaw.git
-            git -C PawPaw checkout ${PAWPAW_VERSION}
+          git clone https://github.com/DISTRHO/PawPaw.git
+          git -C PawPaw checkout ${PAWPAW_VERSION}
         fi
         ./PawPaw/bootstrap-jack2.sh win32 && ./PawPaw/.cleanup.sh win32
     - name: Build jack2
       shell: bash
       run: |
         pushd PawPaw && source local.env win32 && popd
-        wine ~/PawPawBuilds/targets/win32/bin/python3.exe ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
-        wine ~/PawPawBuilds/targets/macos/bin/python3.exe ./waf build -j $(nproc)
-        wine ~/PawPawBuilds/targets/macos/bin/python3.exe ./waf install
+        ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
+        ./waf build -j $(nproc)
+        ./waf install
 
   # linux with win64 cross-compilation
   win64:
@@ -135,16 +142,23 @@ jobs:
         key: cache-win64
     - name: Set up dependencies
       run: |
-        wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add - && \
-        sudo dpkg --add-architecture i386 && \
-        sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
+        wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+        sudo dpkg --add-architecture i386
+        sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
         sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
           binutils-mingw-w64-x86-64 g++-mingw-w64-x86-64
     - name: Bootstrap win64 cross-compiled
       shell: bash
       run: |
         if [ ! -d PawPaw ]; then
-            git clone https://github.com/DISTRHO/PawPaw.git
-            git -C PawPaw checkout ${PAWPAW_VERSION}
+          git clone https://github.com/DISTRHO/PawPaw.git
+          git -C PawPaw checkout ${PAWPAW_VERSION}
         fi
         ./PawPaw/bootstrap-jack2.sh win64 && ./PawPaw/.cleanup.sh win64
+    - name: Build jack2
+      shell: bash
+      run: |
+        pushd PawPaw && source local.env win32 && popd
+        ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
+        ./waf build -j $(nproc)
+        ./waf install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       run: |
         # Setup wine
         export WINEPREFIX=$(pwd)/innosetup
-        xvfb-run wineboot -u
+        wineboot -u
         # Download and install innosetup
         curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
         xvfb-run wine is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
@@ -263,7 +263,7 @@ jobs:
       run: |
         # Setup wine
         export WINEPREFIX=$(pwd)/innosetup
-        xvfb-run wineboot -u
+        wineboot -u
         # Download and install innosetup
         curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
         xvfb-run wine64 is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,4 +309,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-ubuntu-20.04-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: *.deb
+        path: ./*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,24 @@ jobs:
         llvm-dlltool -m i386 -D libjacknet.dll -d libjacknet.def -l libjacknet.lib
         llvm-dlltool -m i386 -D libjackserver.dll -d libjackserver.def -l libjackserver.lib
         popd
+    - name: Set sha8
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - name: Generate Windows installer
+      shell: bash
+      run: |
+        # Setup wine
+        export WINEPREFIX=$(pwd)/innosetup
+        wineboot -u
+        # Download and install innosetup
+        curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
+        wine is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
+        # create installer
+        ln -sf $(pwd)/destdir windows/inno/win32
+        pushd windows/inno
+        echo "#define VERSION \"${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}\"" > version.iss
+        wine ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win32-mini.iss
+        popd
 
   # linux with win64 cross-compilation
   win64:
@@ -232,4 +250,22 @@ jobs:
         llvm-dlltool -m i386:x86-64 -D libjack64.dll -d libjack64.def -l libjack64.lib
         llvm-dlltool -m i386:x86-64 -D libjacknet64.dll -d libjacknet64.def -l libjacknet64.lib
         llvm-dlltool -m i386:x86-64 -D libjackserver64.dll -d libjackserver64.def -l libjackserver64.lib
+        popd
+    - name: Set sha8
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-8)"
+    - name: Generate Windows installer
+      shell: bash
+      run: |
+        # Setup wine
+        export WINEPREFIX=$(pwd)/innosetup
+        wineboot -u
+        # Download and install innosetup
+        curl -L https://jrsoftware.org/download.php/is.exe?site=2 -o is.exe
+        wine64 is.exe /allusers /dir=C:\\InnoSeup /nocancel /norestart /verysilent
+        # create installer
+        ln -sf $(pwd)/destdir windows/inno/win64
+        pushd windows/inno
+        echo "#define VERSION \"${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}\"" > version.iss
+        wine64 ${WINEPREFIX}/drive_c/InnoSeup/ISCC.exe win64-mini.iss
         popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,17 @@ jobs:
             git -C PawPaw checkout ${PAWPAW_VERSION}
         fi
         ./PawPaw/bootstrap-jack2.sh macos && ./PawPaw/.cleanup.sh macos
+    - name: Build jack2
+      shell: bash
+      run: |
+        pushd PawPaw && source local.env macos && popd
+        ~/PawPawBuilds/targets/macos/bin/python3 ./waf configure --platform=darwin --prefix=/usr/local
+        ~/PawPawBuilds/targets/macos/bin/python3 ./waf build -j $(sysctl -n hw.logicalcpu)
+        ~/PawPawBuilds/targets/macos/bin/python3 ./waf install --destdir="$(pwd)/destdir"
 
   # macOS native universal build
   macos_universal:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
       with:
@@ -112,6 +119,13 @@ jobs:
             git -C PawPaw checkout ${PAWPAW_VERSION}
         fi
         ./PawPaw/bootstrap-jack2.sh win32 && ./PawPaw/.cleanup.sh win32
+    - name: Build jack2
+      shell: bash
+      run: |
+        pushd PawPaw && source local.env win32 && popd
+        wine ~/PawPawBuilds/targets/win32/bin/python3.exe ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
+        wine ~/PawPawBuilds/targets/macos/bin/python3.exe ./waf build -j $(nproc)
+        wine ~/PawPawBuilds/targets/macos/bin/python3.exe ./waf install
 
   # linux with win64 cross-compilation
   win64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,4 +313,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: jack2-ubuntu-20.04-${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}
-        path: ../*.deb
+        path: ~/work/jack2/*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           ~/PawPawBuilds/builds
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-        key: cache-macos
+        key: macos-${PAWPAW_VERSION}
     - name: Set up dependencies
       run: |
         brew install cmake jq meson
@@ -61,7 +61,7 @@ jobs:
           ~/PawPawBuilds/builds
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-        key: cache-macos-universal
+        key: macos-universal-${PAWPAW_VERSION}
     - name: Set up dependencies
       run: |
         brew install cmake jq meson
@@ -97,10 +97,15 @@ jobs:
       with:
         path: |
           ~/PawPawBuilds/builds
+          ~/PawPawBuilds/debs
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-          /var/cache/apt/archives
-        key: cache-win32
+        key: win32-${PAWPAW_VERSION}
+    - name: Restore debian packages cache
+      run: |
+        if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
+          sudo cp ~/PawPawBuilds/debs/*.deb /var/cache/apt/archives/; \
+        fi
     - name: Set up dependencies
       run: |
         wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
@@ -108,6 +113,10 @@ jobs:
         sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
         sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
           binutils-mingw-w64-i686 g++-mingw-w64-i686
+    - name: Cache debian packages
+      run: |
+        mkdir -p ~/PawPawBuilds/debs && \
+        sudo mv /var/cache/apt/archives/*.deb ~/PawPawBuilds/debs/
     - name: Bootstrap win32 cross-compiled
       shell: bash
       run: |
@@ -123,6 +132,12 @@ jobs:
         ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
         ./waf build -j $(nproc)
         ./waf install
+    - name: Generate MSVC lib files
+      shell: bash
+      run: |
+        llvm-dlltool -m i386 -D libjack.dll -d $(pwd)/destdir/lib/libjack.def -l $(pwd)/destdir/lib/libjack.lib
+        llvm-dlltool -m i386 -D libjacknet.dll -d $(pwd)/destdir/lib/libjacknet.def -l $(pwd)/destdir/lib/libjacknet.lib
+        llvm-dlltool -m i386 -D libjackserver.dll -d $(pwd)/destdir/lib/libjackserver.def -l $(pwd)/destdir/lib/libjackserver.lib
 
   # linux with win64 cross-compilation
   win64:
@@ -136,10 +151,15 @@ jobs:
       with:
         path: |
           ~/PawPawBuilds/builds
+          ~/PawPawBuilds/debs
           ~/PawPawBuilds/downloads
           ~/PawPawBuilds/targets
-          /var/cache/apt/archives
-        key: cache-win64
+        key: win64-${PAWPAW_VERSION}
+    - name: Restore debian packages cache
+      run: |
+        if [ -d ~/PawPawBuilds/debs ] && [ "$(ls ~/PawPawBuilds/debs | wc -l)" -ne 0 ]; then \
+          sudo cp ~/PawPawBuilds/debs/*.deb /var/cache/apt/archives/; \
+        fi
     - name: Set up dependencies
       run: |
         wget -qO- https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
@@ -147,6 +167,10 @@ jobs:
         sudo apt-add-repository -y 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
         sudo apt-get install -y autopoint build-essential curl cmake jq llvm mingw-w64 qttools5-dev-tools winehq-stable xvfb \
           binutils-mingw-w64-x86-64 g++-mingw-w64-x86-64
+    - name: Cache debian packages
+      run: |
+        mkdir -p ~/PawPawBuilds/debs && \
+        sudo mv /var/cache/apt/archives/*.deb ~/PawPawBuilds/debs/
     - name: Bootstrap win64 cross-compiled
       shell: bash
       run: |
@@ -162,3 +186,10 @@ jobs:
         ./waf configure --platform=win32 --prefix="$(pwd)/destdir" --static
         ./waf build -j $(nproc)
         ./waf install
+    - name: Generate MSVC lib files
+      shell: bash
+      run: |
+        llvm-dlltool -m i386 -D libjack.dll -d $(pwd)/destdir/lib32/libjack.def -l $(pwd)/destdir/lib32/libjack.lib
+        llvm-dlltool -m i386:x86-64 -D libjack64.dll -d $(pwd)/destdir/lib/libjack64.def -l $(pwd)/destdir/lib/libjack64.lib
+        llvm-dlltool -m i386:x86-64 -D libjacknet64.dll -d $(pwd)/destdir/lib/libjacknet64.def -l $(pwd)/destdir/lib/libjacknet64.lib
+        llvm-dlltool -m i386:x86-64 -D libjackserver64.dll -d $(pwd)/destdir/lib/libjackserver64.def -l $(pwd)/destdir/lib/libjackserver64.lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-build/
-man/*.1
 .lock*
 .stamp_*
 .DS_Store
@@ -7,15 +5,22 @@ __pycache__
 *.dll
 *.pyc
 *.pkg
-android/.server/
-android/.client/
 codeBlocks
+/android/.server/
+/android/.client/
+/build/
+/man/*.1
+
+# common release files
+/destdir/
 
 # macos release files
-macos/package.xml
-macos/package-welcome.txt
+/macos/package.xml
+/macos/package-welcome.txt
 
 # windows release files
-windows/inno/version.iss
-windows/inno/win32
-windows/inno/win64
+/innosetup/
+/is.exe
+/windows/inno/version.iss
+/windows/inno/win32
+/windows/inno/win64

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Nedko Arnaudov
 Olaf Hering
 Olivier Humbert
 Paul Davis
+Peter Bridgman
 Peter L Jones
 Pieter Palmers
 Ricardo Crudo

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,7 +3,6 @@ ChangeLog
 
 * 1.9.19 (2021-07-15)
 
-  * WIP (note to write asking CI help)
   * Add jack_position_t::tick_double, and flags around it
   * Add zalsa "-w" argument to wait for soundcard to be available
   * Bump internal protocol version to 9 (due to struct alignment)

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,11 @@
 ChangeLog
 #########
 
+* 1.9.20 (2021-10-15)
+
+  * WIP
+  * Fix incomplete ASIO support on Windows
+
 * 1.9.19 (2021-07-15)
 
   * Add jack_position_t::tick_double, and flags around it

--- a/common/JackConstants.h
+++ b/common/JackConstants.h
@@ -24,7 +24,7 @@
 #include "config.h"
 #endif
 
-#define VERSION "1.9.19"
+#define VERSION "1.9.20"
 
 #define BUFFER_SIZE_MAX 8192
 

--- a/common/jack/intclient.h
+++ b/common/jack/intclient.h
@@ -26,6 +26,7 @@ extern "C"
 #endif
 
 #include <jack/types.h>
+#include <jack/systemdeps.h>
 
 /**
  * Get an internal client's name.  This is useful when @ref
@@ -42,6 +43,7 @@ extern "C"
  * client name obtained from the heap via malloc().  The caller should
  * jack_free() this storage when no longer needed.
  */
+JACK_CLIENT_API_EXPORT
 char *jack_get_internal_client_name (jack_client_t *client,
                                      jack_intclient_t intclient);
 
@@ -63,6 +65,7 @@ char *jack_get_internal_client_name (jack_client_t *client,
  * internal client was not found, and @a *status includes the @ref
  * JackNoSuchClient and @ref JackFailure bits.
  */
+JACK_CLIENT_API_EXPORT
 jack_intclient_t jack_internal_client_handle (jack_client_t *client,
         const char *client_name,
         jack_status_t *status);
@@ -104,6 +107,7 @@ jack_intclient_t jack_internal_client_handle (jack_client_t *client,
  * the load operation failed, the internal client was not loaded, and
  * @a *status includes the @ref JackFailure bit.
  */
+JACK_CLIENT_API_EXPORT
 jack_intclient_t jack_internal_client_load (jack_client_t *client,
         const char *client_name,
         jack_options_t options,
@@ -120,6 +124,7 @@ jack_intclient_t jack_internal_client_load (jack_client_t *client,
  *
  * @return 0 if successful, otherwise @ref JackStatus bits.
  */
+JACK_CLIENT_API_EXPORT
 jack_status_t jack_internal_client_unload (jack_client_t *client,
         jack_intclient_t intclient);
 

--- a/common/jack/jack.h
+++ b/common/jack/jack.h
@@ -60,6 +60,7 @@ extern "C"
  * @param major_ptr pointer to variable receiving protocol version of JACK.
  *
  */
+JACK_CLIENT_API_EXPORT
 void
 jack_get_version(
     int *major_ptr,
@@ -73,6 +74,7 @@ jack_get_version(
  * @return Human readable string describing JACK version being used.
  *
  */
+JACK_CLIENT_API_EXPORT
 const char *
 jack_get_version_string(void) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -114,6 +116,7 @@ jack_get_version_string(void) JACK_OPTIONAL_WEAK_EXPORT;
  * open operation failed, @a *status includes @ref JackFailure and the
  * caller is not a JACK client.
  */
+JACK_CLIENT_API_EXPORT
 jack_client_t * jack_client_open (const char *client_name,
                                   jack_options_t options,
                                   jack_status_t *status, ...) JACK_OPTIONAL_WEAK_EXPORT;
@@ -124,6 +127,7 @@ jack_client_t * jack_client_open (const char *client_name,
 *
 * @deprecated Please use jack_client_open().
 */
+JACK_CLIENT_API_EXPORT
 jack_client_t * jack_client_new (const char *client_name) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -131,12 +135,14 @@ jack_client_t * jack_client_new (const char *client_name) JACK_OPTIONAL_WEAK_DEP
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_client_close (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the maximum number of characters in a JACK client name
  * including the final NULL character.  This value is a constant.
  */
+JACK_CLIENT_API_EXPORT
 int jack_client_name_size (void) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -145,6 +151,7 @@ int jack_client_name_size (void) JACK_OPTIONAL_WEAK_EXPORT;
  * JackNameNotUnique status was returned.  In that case, the actual
  * name will differ from the @a client_name requested.
  */
+JACK_CLIENT_API_EXPORT
 char * jack_get_client_name (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -155,6 +162,7 @@ char * jack_get_client_name (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  * The caller is responsible for calling jack_free(3) on any non-NULL
  * returned value.
  */
+JACK_CLIENT_API_EXPORT
 char *jack_get_uuid_for_client_name (jack_client_t *client,
                                      const char    *client_name) JACK_WEAK_EXPORT;
 
@@ -167,6 +175,7 @@ char *jack_get_uuid_for_client_name (jack_client_t *client,
  * The caller is responsible for calling jack_free(3) on any non-NULL
  * returned value.
  */
+JACK_CLIENT_API_EXPORT
 char *jack_get_client_name_by_uuid (jack_client_t *client,
                                     const char    *client_uuid ) JACK_WEAK_EXPORT;
 
@@ -191,6 +200,7 @@ char *jack_get_client_name_by_uuid (jack_client_t *client,
  *
  * @return 0 if successful.
  */
+JACK_CLIENT_API_EXPORT
 int jack_internal_client_new (const char *client_name,
                               const char *load_name,
                               const char *load_init) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
@@ -200,6 +210,7 @@ int jack_internal_client_new (const char *client_name,
  *
  * @deprecated Please use jack_internal_client_unload().
  */
+JACK_CLIENT_API_EXPORT
 void jack_internal_client_close (const char *client_name) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -208,6 +219,7 @@ void jack_internal_client_close (const char *client_name) JACK_OPTIONAL_WEAK_DEP
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_activate (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -217,17 +229,20 @@ int jack_activate (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_deactivate (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return pid of client. If not available, 0 will be returned.
  */
+JACK_CLIENT_API_EXPORT
 int jack_get_client_pid (const char *name) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the pthread ID of the thread running the JACK client side
  * real-time code.
  */
+JACK_CLIENT_API_EXPORT
 jack_native_thread_t jack_client_thread_id (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*@}*/
@@ -239,6 +254,7 @@ jack_native_thread_t jack_client_thread_id (jack_client_t *client) JACK_OPTIONAL
  *
  * @return 1 if JACK is running realtime, 0 otherwise
  */
+JACK_CLIENT_API_EXPORT
 int jack_is_realtime (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -252,6 +268,7 @@ int jack_is_realtime (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @deprecated Please use jack_cycle_wait() and jack_cycle_signal() functions.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_thread_wait (jack_client_t *client, int status) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -261,6 +278,7 @@ jack_nframes_t jack_thread_wait (jack_client_t *client, int status) JACK_OPTIONA
  *
  * @return the number of frames of data to process
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_cycle_wait (jack_client_t* client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -269,6 +287,7 @@ jack_nframes_t jack_cycle_wait (jack_client_t* client) JACK_OPTIONAL_WEAK_EXPORT
  * @param client - pointer to a JACK client structure
  * @param status - if non-zero, calling thread should exit
  */
+JACK_CLIENT_API_EXPORT
 void jack_cycle_signal (jack_client_t* client, int status) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -287,6 +306,7 @@ void jack_cycle_signal (jack_client_t* client, int status) JACK_OPTIONAL_WEAK_EX
  *
  * @return 0 on success, otherwise a non-zero error code.
 */
+JACK_CLIENT_API_EXPORT
 int jack_set_process_thread(jack_client_t* client, JackThreadCallback thread_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*@}*/
@@ -310,6 +330,7 @@ int jack_set_process_thread(jack_client_t* client, JackThreadCallback thread_cal
  * @return 0 on success, otherwise a non-zero error code, causing JACK
  * to remove that client from the process() graph.
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_thread_init_callback (jack_client_t *client,
                                    JackThreadInitCallback thread_init_callback,
                                    void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -342,6 +363,7 @@ int jack_set_thread_init_callback (jack_client_t *client,
  * (since "jack_client_close" cannot be called directly in the context 
  * of the thread that calls the shutdown callback).
  */
+JACK_CLIENT_API_EXPORT
 void jack_on_shutdown (jack_client_t *client,
                        JackShutdownCallback shutdown_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -372,6 +394,7 @@ void jack_on_shutdown (jack_client_t *client,
  * (since "jack_client_close" cannot be called directly in the context 
  * of the thread that calls the shutdown callback).
  */
+JACK_CLIENT_API_EXPORT
 void jack_on_info_shutdown (jack_client_t *client,
                             JackInfoShutdownCallback shutdown_callback, void *arg) JACK_WEAK_EXPORT;
 
@@ -392,6 +415,7 @@ void jack_on_info_shutdown (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_process_callback (jack_client_t *client,
                                JackProcessCallback process_callback,
                                void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -412,6 +436,7 @@ int jack_set_process_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_freewheel_callback (jack_client_t *client,
                                  JackFreewheelCallback freewheel_callback,
                                  void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -435,6 +460,7 @@ int jack_set_freewheel_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_buffer_size_callback (jack_client_t *client,
                                    JackBufferSizeCallback bufsize_callback,
                                    void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -452,6 +478,7 @@ int jack_set_buffer_size_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_sample_rate_callback (jack_client_t *client,
                                    JackSampleRateCallback srate_callback,
                                    void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -469,6 +496,7 @@ int jack_set_sample_rate_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_client_registration_callback (jack_client_t *client,
                                             JackClientRegistrationCallback
                                             registration_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -486,7 +514,8 @@ int jack_set_client_registration_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
- int jack_set_port_registration_callback (jack_client_t *client,
+JACK_CLIENT_API_EXPORT
+int jack_set_port_registration_callback (jack_client_t *client,
                                           JackPortRegistrationCallback
                                           registration_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -503,6 +532,7 @@ int jack_set_client_registration_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_port_connect_callback (jack_client_t *client,
                                     JackPortConnectCallback
                                     connect_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -520,6 +550,7 @@ int jack_set_port_connect_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_port_rename_callback (jack_client_t *client,
                                    JackPortRenameCallback
                                    rename_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
@@ -537,6 +568,7 @@ int jack_set_port_rename_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_graph_order_callback (jack_client_t *client,
                                    JackGraphOrderCallback graph_callback,
                                    void *) JACK_OPTIONAL_WEAK_EXPORT;
@@ -554,6 +586,7 @@ int jack_set_graph_order_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_xrun_callback (jack_client_t *client,
                             JackXRunCallback xrun_callback, void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -616,6 +649,7 @@ int jack_set_xrun_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_latency_callback (jack_client_t *client,
 			       JackLatencyCallback latency_callback,
 			       void *) JACK_WEAK_EXPORT;
@@ -650,6 +684,7 @@ int jack_set_latency_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_freewheel(jack_client_t* client, int onoff) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -667,12 +702,14 @@ int jack_set_freewheel(jack_client_t* client, int onoff) JACK_OPTIONAL_WEAK_EXPO
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_buffer_size (jack_client_t *client, jack_nframes_t nframes) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the sample rate of the jack system, as set by the user when
  * jackd was started.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_get_sample_rate (jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -684,6 +721,7 @@ jack_nframes_t jack_get_sample_rate (jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @see jack_set_buffer_size_callback()
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_get_buffer_size (jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -696,6 +734,7 @@ jack_nframes_t jack_get_buffer_size (jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @return ENOSYS, function not implemented.
  */
+JACK_CLIENT_API_EXPORT
 int jack_engine_takeover_timebase (jack_client_t *) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -704,6 +743,7 @@ int jack_engine_takeover_timebase (jack_client_t *) JACK_OPTIONAL_WEAK_DEPRECATE
  * all clients as a percentage of the real time available per cycle
  * determined by the buffer size and sample rate.
  */
+JACK_CLIENT_API_EXPORT
 float jack_cpu_load (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*@}*/
@@ -742,6 +782,7 @@ float jack_cpu_load (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @return jack_port_t pointer on success, otherwise NULL.
  */
+JACK_CLIENT_API_EXPORT
 jack_port_t * jack_port_register (jack_client_t *client,
                                   const char *port_name,
                                   const char *port_type,
@@ -754,6 +795,7 @@ jack_port_t * jack_port_register (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_unregister (jack_client_t *client, jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -775,6 +817,7 @@ int jack_port_unregister (jack_client_t *client, jack_port_t *port) JACK_OPTIONA
  * Caching output ports is DEPRECATED in Jack 2.0, due to some new optimization (like "pipelining").
  * Port buffers have to be retrieved in each callback for proper functioning.
  */
+JACK_CLIENT_API_EXPORT
 void * jack_port_get_buffer (jack_port_t *port, jack_nframes_t) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -782,6 +825,7 @@ void * jack_port_get_buffer (jack_port_t *port, jack_nframes_t) JACK_OPTIONAL_WE
  *
  * @see jack_uuid_to_string() to convert into a string representation
  */
+JACK_CLIENT_API_EXPORT
 jack_uuid_t jack_port_uuid (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -790,6 +834,7 @@ jack_uuid_t jack_port_uuid (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @see jack_port_name_size().
  */
+JACK_CLIENT_API_EXPORT
 const char * jack_port_name (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -798,27 +843,32 @@ const char * jack_port_name (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @see jack_port_name_size().
  */
+JACK_CLIENT_API_EXPORT
 const char * jack_port_short_name (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the @ref JackPortFlags of the jack_port_t.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_flags (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the @a port type, at most jack_port_type_size() characters
  * including a final NULL.
  */
+JACK_CLIENT_API_EXPORT
 const char * jack_port_type (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
  /**
  * @return the @a port type id.
  */
+JACK_CLIENT_API_EXPORT
 jack_port_type_id_t jack_port_type_id (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return TRUE if the jack_port_t belongs to the jack_client_t.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_is_mine (const jack_client_t *client, const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -826,6 +876,7 @@ int jack_port_is_mine (const jack_client_t *client, const jack_port_t *port) JAC
  *
  * @pre The calling client must own @a port.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_connected (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -834,6 +885,7 @@ int jack_port_connected (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @see jack_port_name_size()
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_connected_to (const jack_port_t *port,
                             const char *port_name) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -848,6 +900,7 @@ int jack_port_connected_to (const jack_port_t *port,
  *
  * @see jack_port_name_size(), jack_port_get_all_connections()
  */
+JACK_CLIENT_API_EXPORT
 const char ** jack_port_get_connections (const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -869,6 +922,7 @@ const char ** jack_port_get_connections (const jack_port_t *port) JACK_OPTIONAL_
  *
  * @see jack_port_name_size()
  */
+JACK_CLIENT_API_EXPORT
 const char ** jack_port_get_all_connections (const jack_client_t *client,
                                              const jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -879,6 +933,7 @@ const char ** jack_port_get_all_connections (const jack_client_t *client,
  * turned out to serve essentially no purpose in real-life
  * JACK clients.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_tie (jack_port_t *src, jack_port_t *dst) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -888,6 +943,7 @@ int jack_port_tie (jack_port_t *src, jack_port_t *dst) JACK_OPTIONAL_WEAK_DEPREC
  * turned out to serve essentially no purpose in real-life
  * JACK clients.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_untie (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -900,6 +956,7 @@ int jack_port_untie (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_set_name (jack_port_t *port, const char *port_name) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -912,6 +969,7 @@ int jack_port_set_name (jack_port_t *port, const char *port_name) JACK_OPTIONAL_
  * This differs from jack_port_set_name() by triggering PortRename notifications to
  * clients that have registered a port rename handler.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_rename (jack_client_t* client, jack_port_t *port, const char *port_name) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -927,6 +985,7 @@ int jack_port_rename (jack_client_t* client, jack_port_t *port, const char *port
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_set_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -937,6 +996,7 @@ int jack_port_set_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_WEA
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_unset_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -944,12 +1004,14 @@ int jack_port_unset_alias (jack_port_t *port, const char *alias) JACK_OPTIONAL_W
  *
  * @return the number of aliases discovered for the port
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_get_aliases (const jack_port_t *port, char* const aliases[2]) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * If @ref JackPortCanMonitor is set for this @a port, turn input
  * monitoring on or off.  Otherwise, do nothing.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_request_monitor (jack_port_t *port, int onoff) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -960,6 +1022,7 @@ int jack_port_request_monitor (jack_port_t *port, int onoff) JACK_OPTIONAL_WEAK_
  *
  * @see jack_port_name_size()
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_request_monitor_by_name (jack_client_t *client,
                                        const char *port_name, int onoff) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -970,11 +1033,13 @@ int jack_port_request_monitor_by_name (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_ensure_monitor (jack_port_t *port, int onoff) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return TRUE if input monitoring has been requested for @a port.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_monitoring_input (jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -994,6 +1059,7 @@ int jack_port_monitoring_input (jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
  * @return 0 on success, EEXIST if the connection is already made,
  * otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_connect (jack_client_t *client,
                   const char *source_port,
                   const char *destination_port) JACK_OPTIONAL_WEAK_EXPORT;
@@ -1011,6 +1077,7 @@ int jack_connect (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_disconnect (jack_client_t *client,
                      const char *source_port,
                      const char *destination_port) JACK_OPTIONAL_WEAK_EXPORT;
@@ -1024,6 +1091,7 @@ int jack_disconnect (jack_client_t *client,
  * while generic connection clients (e.g. patchbays) would use
  * jack_disconnect().
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_disconnect (jack_client_t *client, jack_port_t *port) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1034,12 +1102,14 @@ int jack_port_disconnect (jack_client_t *client, jack_port_t *port) JACK_OPTIONA
  * with a colon (:) followed by its short name and a NULL
  * character.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_name_size(void) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the maximum number of characters in a JACK port type name
  * including the final NULL character.  This value is a constant.
  */
+JACK_CLIENT_API_EXPORT
 int jack_port_type_size(void) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1047,6 +1117,7 @@ int jack_port_type_size(void) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * this function may only be called in a buffer_size callback.
  */
+JACK_CLIENT_API_EXPORT
 size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_type) JACK_WEAK_EXPORT;
 
 /*@}*/
@@ -1115,6 +1186,7 @@ size_t jack_port_type_get_buffer_size (jack_client_t *client, const char *port_t
  * be replaced by a latency callback that calls @ref
  * jack_port_set_latency_range().
  */
+JACK_CLIENT_API_EXPORT
 void jack_port_set_latency (jack_port_t *port, jack_nframes_t) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -1129,6 +1201,7 @@ void jack_port_set_latency (jack_port_t *port, jack_nframes_t) JACK_OPTIONAL_WEA
  * the port is connected, and that gets signalled by the latency callback.
  * See @ref jack_set_latency_callback() for details.
  */
+JACK_CLIENT_API_EXPORT
 void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_t mode, jack_latency_range_t *range) JACK_WEAK_EXPORT;
 
 /**
@@ -1198,6 +1271,7 @@ void jack_port_get_latency_range (jack_port_t *port, jack_latency_callback_mode_
  * See the description of @ref jack_set_latency_callback for more
  * information.
  */
+JACK_CLIENT_API_EXPORT
 void jack_port_set_latency_range (jack_port_t *port, jack_latency_callback_mode_t mode, jack_latency_range_t *range) JACK_WEAK_EXPORT;
 
 /**
@@ -1213,6 +1287,7 @@ void jack_port_set_latency_range (jack_port_t *port, jack_latency_callback_mode_
  * @return zero for successful execution of the request. non-zero
  *         otherwise.
  */
+JACK_CLIENT_API_EXPORT
 int jack_recompute_total_latencies (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1230,6 +1305,7 @@ int jack_recompute_total_latencies (jack_client_t *client) JACK_OPTIONAL_WEAK_EX
  * be replaced by jack_port_get_latency_range() in any existing
  * use cases.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_port_get_latency (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -1242,6 +1318,7 @@ jack_nframes_t jack_port_get_latency (jack_port_t *port) JACK_OPTIONAL_WEAK_DEPR
  * be replaced by jack_port_get_latency_range() in any existing
  * use cases.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_port_get_total_latency (jack_client_t *client,
 					    jack_port_t *port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
@@ -1261,6 +1338,7 @@ jack_nframes_t jack_port_get_total_latency (jack_client_t *client,
  * be replaced by jack_recompute_total_latencies() in any existing
  * use cases.
  */
+JACK_CLIENT_API_EXPORT
 int jack_recompute_total_latency (jack_client_t*, jack_port_t* port) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /*@}*/
@@ -1286,6 +1364,7 @@ int jack_recompute_total_latency (jack_client_t*, jack_port_t* port) JACK_OPTION
  *
  * @see jack_port_name_size(), jack_port_type_size()
  */
+JACK_CLIENT_API_EXPORT
 const char ** jack_get_ports (jack_client_t *client,
                               const char *port_name_pattern,
                               const char *type_name_pattern,
@@ -1296,11 +1375,13 @@ const char ** jack_get_ports (jack_client_t *client,
  *
  * @see jack_port_name_size()
  */
+JACK_CLIENT_API_EXPORT
 jack_port_t * jack_port_by_name (jack_client_t *client, const char *port_name) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return address of the jack_port_t of a @a port_id.
  */
+JACK_CLIENT_API_EXPORT
 jack_port_t * jack_port_by_id (jack_client_t *client,
                                jack_port_id_t port_id) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -1319,6 +1400,7 @@ jack_port_t * jack_port_by_id (jack_client_t *client,
  * @return the estimated time in frames that has passed since the JACK
  * server began the current process cycle.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_frames_since_cycle_start (const jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1327,6 +1409,7 @@ jack_nframes_t jack_frames_since_cycle_start (const jack_client_t *) JACK_OPTION
  * callback).  The return value can be compared with the value of
  * jack_last_frame_time to relate time in other threads to JACK time.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_frame_time (const jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1343,6 +1426,7 @@ jack_nframes_t jack_frame_time (const jack_client_t *) JACK_OPTIONAL_WEAK_EXPORT
  * If an xrun occurs, clients must check this value again, as time
  * may have advanced in a non-linear way (e.g. cycles may have been skipped).
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_last_frame_time (const jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1388,6 +1472,7 @@ jack_nframes_t jack_last_frame_time (const jack_client_t *client) JACK_OPTIONAL_
  *
  * @return zero if OK, non-zero otherwise.
  */
+JACK_CLIENT_API_EXPORT
 int jack_get_cycle_times(const jack_client_t *client,
                         jack_nframes_t *current_frames,
                         jack_time_t    *current_usecs,
@@ -1397,11 +1482,13 @@ int jack_get_cycle_times(const jack_client_t *client,
 /**
  * @return the estimated time in microseconds of the specified frame time
  */
+JACK_CLIENT_API_EXPORT
 jack_time_t jack_frames_to_time(const jack_client_t *client, jack_nframes_t) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * @return the estimated time in frames for the specified system time.
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_time_to_frames(const jack_client_t *client, jack_time_t) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1410,6 +1497,7 @@ jack_nframes_t jack_time_to_frames(const jack_client_t *client, jack_time_t) JAC
  *
  * The value returned is guaranteed to be monotonic, but not linear.
  */
+JACK_CLIENT_API_EXPORT
 jack_time_t jack_get_time(void) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*@}*/
@@ -1427,6 +1515,7 @@ jack_time_t jack_get_time(void) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @param msg error message text (no newline at end).
  */
+JACK_CLIENT_API_EXPORT
 extern void (*jack_error_callback)(const char *msg) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1436,6 +1525,7 @@ extern void (*jack_error_callback)(const char *msg) JACK_OPTIONAL_WEAK_EXPORT;
  * The JACK library provides two built-in callbacks for this purpose:
  * default_jack_error_callback() and silent_jack_error_callback().
  */
+JACK_CLIENT_API_EXPORT
 void jack_set_error_function (void (*func)(const char *)) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1446,6 +1536,7 @@ void jack_set_error_function (void (*func)(const char *)) JACK_OPTIONAL_WEAK_EXP
  *
  * @param msg info message text (no newline at end).
  */
+JACK_CLIENT_API_EXPORT
 extern void (*jack_info_callback)(const char *msg) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -1455,6 +1546,7 @@ extern void (*jack_info_callback)(const char *msg) JACK_OPTIONAL_WEAK_EXPORT;
  * The JACK library provides two built-in callbacks for this purpose:
  * default_jack_info_callback() and silent_jack_info_callback().
  */
+JACK_CLIENT_API_EXPORT
 void jack_set_info_function (void (*func)(const char *)) JACK_OPTIONAL_WEAK_EXPORT;
 
 /*@}*/
@@ -1467,6 +1559,7 @@ void jack_set_info_function (void (*func)(const char *)) JACK_OPTIONAL_WEAK_EXPO
  *
  * @param ptr the memory pointer to be deallocated.
  */
+JACK_CLIENT_API_EXPORT
 void jack_free(void* ptr) JACK_OPTIONAL_WEAK_EXPORT;
 
 

--- a/common/jack/metadata.h
+++ b/common/jack/metadata.h
@@ -28,6 +28,7 @@
 #define __jack_metadata_h__
 
 #include <jack/types.h>
+#include <jack/systemdeps.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,6 +89,7 @@ typedef struct {
  *             types in the definition of jack_property_t above.
  * @return 0 on success.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_set_property(jack_client_t*,
                   jack_uuid_t subject,
@@ -108,6 +110,7 @@ jack_set_property(jack_client_t*,
  *
  * @return 0 on success, -1 if the @p subject has no @p key property.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_get_property(jack_uuid_t subject,
                   const char* key,
@@ -130,6 +133,7 @@ typedef struct {
  * @param desc a jack_description_t whose associated memory will all be released
  * @param free_description_itself if non-zero, then @param desc will also be passed to free()
  */
+JACK_CLIENT_API_EXPORT
 void
 jack_free_description (jack_description_t* desc, int free_description_itself);
 
@@ -140,6 +144,7 @@ jack_free_description (jack_description_t* desc, int free_description_itself);
  *             The caller must free this value with jack_free_description().
  * @return the number of properties, -1 if no @p subject with any properties exists.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_get_properties (jack_uuid_t         subject,
                      jack_description_t* desc);
@@ -151,6 +156,7 @@ jack_get_properties (jack_uuid_t         subject,
  *              and the array itself with jack_free().
  * @return the number of descriptions, or -1 on error.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_get_all_properties (jack_description_t** descs);
 
@@ -163,6 +169,7 @@ jack_get_all_properties (jack_description_t** descs);
  *
  * @return 0 on success, -1 otherwise
  */
+JACK_CLIENT_API_EXPORT
 int jack_remove_property (jack_client_t* client, jack_uuid_t subject, const char* key);
 
 /**
@@ -173,6 +180,7 @@ int jack_remove_property (jack_client_t* client, jack_uuid_t subject, const char
  *
  * @return a count of the number of properties removed, or -1 on error.
  */
+JACK_CLIENT_API_EXPORT
 int jack_remove_properties (jack_client_t* client, jack_uuid_t subject);
 
 /**
@@ -186,6 +194,7 @@ int jack_remove_properties (jack_client_t* client, jack_uuid_t subject);
  *
  * @return 0 on success, -1 otherwise
  */
+JACK_CLIENT_API_EXPORT
 int jack_remove_all_properties (jack_client_t* client);
 
 typedef enum {
@@ -221,6 +230,7 @@ typedef void (*JackPropertyChangeCallback)(jack_uuid_t            subject,
  *
  * @return 0 success, -1 otherwise.
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_property_change_callback (jack_client_t*             client,
                                        JackPropertyChangeCallback callback,
                                        void*                      arg);
@@ -229,6 +239,7 @@ int jack_set_property_change_callback (jack_client_t*             client,
  * A value that identifies what the hardware port is connected to (an external
  * device of some kind). Possible values might be "E-Piano" or "Master 2 Track".
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_CONNECTED;
 
 /**
@@ -242,6 +253,7 @@ extern const char* JACK_METADATA_CONNECTED;
  * status byte will gracefully ignore OSC messages if the user makes an
  * inappropriate connection.
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_EVENT_TYPES;
 
 /**
@@ -249,6 +261,7 @@ extern const char* JACK_METADATA_EVENT_TYPES;
  * specific hardware outputs of a client. Typical values might be
  * "ADAT1", "S/PDIF L" or "MADI 43".
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_HARDWARE;
 
 /**
@@ -256,6 +269,7 @@ extern const char* JACK_METADATA_HARDWARE;
  * NxN (with 32 < N <= 128) image to be used when displaying a visual
  * representation of that client or port.
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_ICON_LARGE;
 
 /**
@@ -267,6 +281,7 @@ extern const char* JACK_METADATA_ICON_LARGE;
  * Theme Specification:
  * https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_ICON_NAME;
 
 /**
@@ -274,6 +289,7 @@ extern const char* JACK_METADATA_ICON_NAME;
  * NxN (with N <=32) image to be used when displaying a visual representation
  * of that client or port.
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_ICON_SMALL;
 
 /**
@@ -287,6 +303,7 @@ extern const char* JACK_METADATA_ICON_SMALL;
  *
  * It is encouraged to use http://www.w3.org/2001/XMLSchema#int as the type.
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_ORDER;
 
 /**
@@ -294,10 +311,12 @@ extern const char* JACK_METADATA_ORDER;
  * unless the user has explicitly overridden that a request to show the port
  * name, or some other key value.
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_PRETTY_NAME;
 
 /**
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_PORT_GROUP;
 
 /**
@@ -309,6 +328,7 @@ extern const char* JACK_METADATA_PORT_GROUP;
  * their output directly to speakers.  In particular, CV ports are not
  * necessarily periodic at all and may have very high DC.
  */
+JACK_CLIENT_API_EXPORT
 extern const char* JACK_METADATA_SIGNAL_TYPE;
 
 /**

--- a/common/jack/midiport.h
+++ b/common/jack/midiport.h
@@ -26,6 +26,7 @@ extern "C" {
 #endif
 
 #include <jack/weakmacros.h>
+#include <jack/systemdeps.h>
 #include <jack/types.h>
 #include <stdlib.h>
 
@@ -53,6 +54,7 @@ typedef struct _jack_midi_event
  * @param port_buffer Port buffer from which to retrieve event.
  * @return number of events inside @a port_buffer
  */
+JACK_CLIENT_API_EXPORT
 uint32_t
 jack_midi_get_event_count(void* port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -79,6 +81,7 @@ jack_midi_get_event_count(void* port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
  * @param event_index Index of event to retrieve.
  * @return 0 on success, ENODATA if buffer is empty.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_midi_event_get(jack_midi_event_t *event,
                     void        *port_buffer,
@@ -93,6 +96,7 @@ jack_midi_event_get(jack_midi_event_t *event,
  *
  * @param port_buffer Port buffer to clear (must be an output port buffer).
  */
+JACK_CLIENT_API_EXPORT
 void
 jack_midi_clear_buffer(void *port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -106,6 +110,7 @@ jack_midi_clear_buffer(void *port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @param port_buffer Port buffer to reset.
  */
+JACK_CLIENT_API_EXPORT
 void
 jack_midi_reset_buffer(void *port_buffer) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
@@ -117,6 +122,7 @@ jack_midi_reset_buffer(void *port_buffer) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
  *
  * @param port_buffer Port buffer to check size of.
  */
+JACK_CLIENT_API_EXPORT
 size_t
 jack_midi_max_event_size(void* port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -140,6 +146,7 @@ jack_midi_max_event_size(void* port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
  * @return Pointer to the beginning of the reserved event's data buffer, or
  * NULL on error (ie not enough space).
  */
+JACK_CLIENT_API_EXPORT
 jack_midi_data_t*
 jack_midi_event_reserve(void *port_buffer,
                         jack_nframes_t  time,
@@ -167,6 +174,7 @@ jack_midi_event_reserve(void *port_buffer,
  * @param data_size Length of @a data in bytes.
  * @return 0 on success, ENOBUFS if there's not enough space in buffer for event.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_midi_event_write(void *port_buffer,
                       jack_nframes_t time,
@@ -182,6 +190,7 @@ jack_midi_event_write(void *port_buffer,
  * @param port_buffer Port to receive count for.
  * @returns Number of events that could not be written to @a port_buffer.
  */
+JACK_CLIENT_API_EXPORT
 uint32_t
 jack_midi_get_lost_event_count(void *port_buffer) JACK_OPTIONAL_WEAK_EXPORT;
 

--- a/common/jack/ringbuffer.h
+++ b/common/jack/ringbuffer.h
@@ -27,6 +27,7 @@ extern "C"
 #endif
 
 #include <sys/types.h>
+#include <jack/systemdeps.h>
 
 /** @file ringbuffer.h
  *
@@ -68,6 +69,7 @@ jack_ringbuffer_t ;
  * @return a pointer to a new jack_ringbuffer_t, if successful; NULL
  * otherwise.
  */
+JACK_CLIENT_API_EXPORT
 jack_ringbuffer_t *jack_ringbuffer_create(size_t sz);
 
 /**
@@ -76,6 +78,7 @@ jack_ringbuffer_t *jack_ringbuffer_create(size_t sz);
  *
  * @param rb a pointer to the ringbuffer structure.
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_free(jack_ringbuffer_t *rb);
 
 /**
@@ -98,6 +101,7 @@ void jack_ringbuffer_free(jack_ringbuffer_t *rb);
  * @param vec a pointer to a 2 element array of jack_ringbuffer_data_t.
  *
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_get_read_vector(const jack_ringbuffer_t *rb,
                                      jack_ringbuffer_data_t *vec);
 
@@ -120,6 +124,7 @@ void jack_ringbuffer_get_read_vector(const jack_ringbuffer_t *rb,
  * @param rb a pointer to the ringbuffer structure.
  * @param vec a pointer to a 2 element array of jack_ringbuffer_data_t.
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_get_write_vector(const jack_ringbuffer_t *rb,
                                       jack_ringbuffer_data_t *vec);
 
@@ -133,6 +138,7 @@ void jack_ringbuffer_get_write_vector(const jack_ringbuffer_t *rb,
  *
  * @return the number of bytes read, which may range from 0 to cnt.
  */
+JACK_CLIENT_API_EXPORT
 size_t jack_ringbuffer_read(jack_ringbuffer_t *rb, char *dest, size_t cnt);
 
 /**
@@ -150,6 +156,7 @@ size_t jack_ringbuffer_read(jack_ringbuffer_t *rb, char *dest, size_t cnt);
  *
  * @return the number of bytes read, which may range from 0 to cnt.
  */
+JACK_CLIENT_API_EXPORT
 size_t jack_ringbuffer_peek(jack_ringbuffer_t *rb, char *dest, size_t cnt);
 
 /**
@@ -163,6 +170,7 @@ size_t jack_ringbuffer_peek(jack_ringbuffer_t *rb, char *dest, size_t cnt);
  * @param rb a pointer to the ringbuffer structure.
  * @param cnt the number of bytes read.
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_read_advance(jack_ringbuffer_t *rb, size_t cnt);
 
 /**
@@ -172,6 +180,7 @@ void jack_ringbuffer_read_advance(jack_ringbuffer_t *rb, size_t cnt);
  *
  * @return the number of bytes available to read.
  */
+JACK_CLIENT_API_EXPORT
 size_t jack_ringbuffer_read_space(const jack_ringbuffer_t *rb);
 
 /**
@@ -181,6 +190,7 @@ size_t jack_ringbuffer_read_space(const jack_ringbuffer_t *rb);
  *
  * @param rb a pointer to the ringbuffer structure.
  */
+JACK_CLIENT_API_EXPORT
 int jack_ringbuffer_mlock(jack_ringbuffer_t *rb);
 
 /**
@@ -190,6 +200,7 @@ int jack_ringbuffer_mlock(jack_ringbuffer_t *rb);
  *
  * @param rb a pointer to the ringbuffer structure.
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_reset(jack_ringbuffer_t *rb);
 
 /**
@@ -200,6 +211,7 @@ void jack_ringbuffer_reset(jack_ringbuffer_t *rb);
  * @param rb a pointer to the ringbuffer structure.
  * @param sz the new size, that must be less than allocated size.
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_reset_size (jack_ringbuffer_t * rb, size_t sz);
 
 /**
@@ -211,8 +223,9 @@ void jack_ringbuffer_reset_size (jack_ringbuffer_t * rb, size_t sz);
  *
  * @return the number of bytes write, which may range from 0 to cnt
  */
+JACK_CLIENT_API_EXPORT
 size_t jack_ringbuffer_write(jack_ringbuffer_t *rb, const char *src,
-                             size_t cnt);
+                                                    size_t cnt);
 
 /**
  * Advance the write pointer.
@@ -225,6 +238,7 @@ size_t jack_ringbuffer_write(jack_ringbuffer_t *rb, const char *src,
  * @param rb a pointer to the ringbuffer structure.
  * @param cnt the number of bytes written.
  */
+JACK_CLIENT_API_EXPORT
 void jack_ringbuffer_write_advance(jack_ringbuffer_t *rb, size_t cnt);
 
 /**
@@ -234,6 +248,7 @@ void jack_ringbuffer_write_advance(jack_ringbuffer_t *rb, size_t cnt);
  *
  * @return the amount of free space (in bytes) available for writing.
  */
+JACK_CLIENT_API_EXPORT
 size_t jack_ringbuffer_write_space(const jack_ringbuffer_t *rb);
 
 #ifdef __cplusplus

--- a/common/jack/session.h
+++ b/common/jack/session.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include <jack/types.h>
 #include <jack/weakmacros.h>
+#include <jack/systemdeps.h>
 
 /**
  * @defgroup SessionClientFunctions Session API for clients.
@@ -184,9 +185,10 @@ typedef void (*JackSessionCallback)(jack_session_event_t *event,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_set_session_callback (jack_client_t       *client,
-                               JackSessionCallback  session_callback,
-                               void                *arg) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
+                                                      JackSessionCallback  session_callback,
+                                                      void                *arg) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
  * Reply to a session event.
@@ -201,8 +203,9 @@ int jack_set_session_callback (jack_client_t       *client,
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int jack_session_reply (jack_client_t        *client,
-                        jack_session_event_t *event) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
+                                               jack_session_event_t *event) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 
 /**
@@ -214,6 +217,7 @@ int jack_session_reply (jack_client_t        *client,
  * JACK developers recommend the use of NSM instead.
  * See https://github.com/linuxaudio/new-session-manager
  */
+JACK_CLIENT_API_EXPORT
 void jack_session_event_free (jack_session_event_t *event) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 
@@ -224,6 +228,7 @@ void jack_session_event_free (jack_session_event_t *event) JACK_OPTIONAL_WEAK_DE
  * The caller is responsible for calling jack_free(3) on any non-NULL
  * returned value.
  */
+JACK_CLIENT_API_EXPORT
 char *jack_client_get_uuid (jack_client_t *client) JACK_WEAK_EXPORT;
 
 /**
@@ -250,6 +255,7 @@ typedef struct  {
  * of jack_session_command_t. its terminated by ret[i].uuid == NULL target ==
  * NULL means send to all interested clients. otherwise a clientname
  */
+JACK_CLIENT_API_EXPORT
 jack_session_command_t *jack_session_notify (
 	jack_client_t*             client,
 	const char                *target,
@@ -263,6 +269,7 @@ jack_session_command_t *jack_session_notify (
  * JACK developers recommend the use of NSM instead.
  * See https://github.com/linuxaudio/new-session-manager
  */
+JACK_CLIENT_API_EXPORT
 void jack_session_commands_free (jack_session_command_t *cmds) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 
 /**
@@ -274,6 +281,7 @@ void jack_session_commands_free (jack_session_command_t *cmds) JACK_OPTIONAL_WEA
  *
  * @return 0 on success, otherwise a non-zero error code
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_reserve_client_name (jack_client_t *client,
                           const char    *name,
@@ -289,6 +297,7 @@ jack_reserve_client_name (jack_client_t *client,
  * @return 0 when the client has no session callback, 1 when it has one.
  *        -1 on error.
  */
+JACK_CLIENT_API_EXPORT
 int
 jack_client_has_session_callback (jack_client_t *client, const char *client_name) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
 

--- a/common/jack/statistics.h
+++ b/common/jack/statistics.h
@@ -27,12 +27,14 @@ extern "C"
 #endif
 
 #include <jack/types.h>
+#include <jack/systemdeps.h>
 
 /**
  * @return the maximum delay reported by the backend since
  * startup or reset.  When compared to the period size in usecs, this
  * can be used to estimate the ideal period size for a given setup.
  */
+JACK_CLIENT_API_EXPORT
 float jack_get_max_delayed_usecs (jack_client_t *client);
 
 /**
@@ -40,6 +42,7 @@ float jack_get_max_delayed_usecs (jack_client_t *client);
  * occurrence.  This probably only makes sense when called from a @ref
  * JackXRunCallback defined using jack_set_xrun_callback().
  */
+JACK_CLIENT_API_EXPORT
 float jack_get_xrun_delayed_usecs (jack_client_t *client);
 
 /**
@@ -48,6 +51,7 @@ float jack_get_xrun_delayed_usecs (jack_client_t *client);
  * system (e.g. toggling kernel preemption) has on the delay
  * experienced by JACK, without having to restart the JACK engine.
  */
+JACK_CLIENT_API_EXPORT
 void jack_reset_max_delayed_usecs (jack_client_t *client);
 
 #ifdef __cplusplus

--- a/common/jack/systemdeps.h
+++ b/common/jack/systemdeps.h
@@ -138,4 +138,17 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
     #define JACK_LIB_EXPORT
 #endif
 
+
+#ifdef _WIN32
+	#if defined(BUILDING_JACK)
+		#define JACK_CLIENT_API_EXPORT __declspec(dllexport)
+	#else
+		#define JACK_CLIENT_API_EXPORT __declspec(dllimport)
+	#endif
+#elif __GNUC__ >= 4
+	#define JACK_CLIENT_API_EXPORT __attribute__((visibility("default")))
+#else
+	#define JACK_CLIENT_API_EXPORT /* nothing */
+#endif
+
 #endif /* __jack_systemdeps_h__ */

--- a/common/jack/thread.h
+++ b/common/jack/thread.h
@@ -50,6 +50,7 @@ extern "C"
  * Otherwise returns -1.
  */
 
+JACK_CLIENT_API_EXPORT
 int jack_client_real_time_priority (jack_client_t*) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -58,6 +59,7 @@ int jack_client_real_time_priority (jack_client_t*) JACK_OPTIONAL_WEAK_EXPORT;
  * is subject to realtime scheduling. Otherwise returns -1.
  */
 
+JACK_CLIENT_API_EXPORT
 int jack_client_max_real_time_priority (jack_client_t*) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -70,6 +72,7 @@ int jack_client_max_real_time_priority (jack_client_t*) JACK_OPTIONAL_WEAK_EXPOR
  * @returns 0, if successful; EPERM, if the calling process lacks
  * required realtime privileges; otherwise some other error number.
  */
+JACK_CLIENT_API_EXPORT
 int jack_acquire_real_time_scheduling (jack_native_thread_t thread, int priority) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -88,12 +91,13 @@ int jack_acquire_real_time_scheduling (jack_native_thread_t thread, int priority
  *
  * @returns 0, if successful; otherwise some error number.
  */
+JACK_CLIENT_API_EXPORT
 int jack_client_create_thread (jack_client_t* client,
-                               jack_native_thread_t *thread,
-                               int priority,
-                               int realtime, 	/* boolean */
-                               void *(*start_routine)(void*),
-                               void *arg) JACK_OPTIONAL_WEAK_EXPORT;
+                                                      jack_native_thread_t *thread,
+                                                      int priority,
+                                                      int realtime, 	/* boolean */
+                                                      void *(*start_routine)(void*),
+                                                      void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
  * Drop realtime scheduling for a thread.
@@ -102,6 +106,7 @@ int jack_client_create_thread (jack_client_t* client,
  *
  * @returns 0, if successful; otherwise an error number.
  */
+JACK_CLIENT_API_EXPORT
 int jack_drop_real_time_scheduling (jack_native_thread_t thread) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -111,6 +116,7 @@ int jack_drop_real_time_scheduling (jack_native_thread_t thread) JACK_OPTIONAL_W
  *
  * @returns 0, if successful; otherwise an error number.
  */
+JACK_CLIENT_API_EXPORT
 int jack_client_stop_thread(jack_client_t* client, jack_native_thread_t thread) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -120,7 +126,8 @@ int jack_client_stop_thread(jack_client_t* client, jack_native_thread_t thread) 
  *
  * @returns 0, if successful; otherwise an error number.
  */
- int jack_client_kill_thread(jack_client_t* client, jack_native_thread_t thread) JACK_OPTIONAL_WEAK_EXPORT;
+JACK_CLIENT_API_EXPORT
+int jack_client_kill_thread(jack_client_t* client, jack_native_thread_t thread) JACK_OPTIONAL_WEAK_EXPORT;
 
 #ifndef _WIN32
 
@@ -147,6 +154,7 @@ int jack_client_stop_thread(jack_client_t* client, jack_native_thread_t thread) 
  * @param creator a function that creates a new thread
  *
  */
+JACK_CLIENT_API_EXPORT
 void jack_set_thread_creator (jack_thread_creator_t creator) JACK_OPTIONAL_WEAK_EXPORT;
 
 #endif

--- a/common/jack/transport.h
+++ b/common/jack/transport.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include <jack/types.h>
 #include <jack/weakmacros.h>
+#include <jack/systemdeps.h>
 
 /**
  * @defgroup TransportControl Transport and Timebase control
@@ -49,6 +50,7 @@ extern "C" {
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int  jack_release_timebase (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -71,7 +73,8 @@ int  jack_release_timebase (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
-int  jack_set_sync_callback (jack_client_t *client,
+JACK_CLIENT_API_EXPORT
+int jack_set_sync_callback (jack_client_t *client,
 			     JackSyncCallback sync_callback,
 			     void *arg) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -92,6 +95,7 @@ int  jack_set_sync_callback (jack_client_t *client,
  *
  * @return 0 on success, otherwise a non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int  jack_set_sync_timeout (jack_client_t *client,
 			    jack_time_t timeout) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -120,6 +124,7 @@ int  jack_set_sync_timeout (jack_client_t *client,
  *   timebase master;
  *   - other non-zero error code.
  */
+JACK_CLIENT_API_EXPORT
 int  jack_set_timebase_callback (jack_client_t *client,
 				 int conditional,
 				 JackTimebaseCallback timebase_callback,
@@ -141,6 +146,7 @@ int  jack_set_timebase_callback (jack_client_t *client,
  *
  * @return 0 if valid request, non-zero otherwise.
  */
+JACK_CLIENT_API_EXPORT
 int  jack_transport_locate (jack_client_t *client,
 			    jack_nframes_t frame) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -159,6 +165,7 @@ int  jack_transport_locate (jack_client_t *client,
  *
  * @return Current transport state.
  */
+JACK_CLIENT_API_EXPORT
 jack_transport_state_t jack_transport_query (const jack_client_t *client,
 					     jack_position_t *pos) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -169,6 +176,7 @@ jack_transport_state_t jack_transport_query (const jack_client_t *client,
  *
  * @param client the JACK client structure
  */
+JACK_CLIENT_API_EXPORT
 jack_nframes_t jack_get_current_transport_frame (const jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -187,6 +195,7 @@ jack_nframes_t jack_get_current_transport_frame (const jack_client_t *client) JA
  *
  * @return 0 if valid request, EINVAL if position structure rejected.
  */
+JACK_CLIENT_API_EXPORT
 int  jack_transport_reposition (jack_client_t *client,
 				const jack_position_t *pos) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -201,6 +210,7 @@ int  jack_transport_reposition (jack_client_t *client,
  *
  * @param client the JACK client structure.
  */
+JACK_CLIENT_API_EXPORT
 void jack_transport_start (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -211,6 +221,7 @@ void jack_transport_start (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @param client the JACK client structure.
  */
+JACK_CLIENT_API_EXPORT
 void jack_transport_stop (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
 
 /**
@@ -225,6 +236,7 @@ void jack_transport_stop (jack_client_t *client) JACK_OPTIONAL_WEAK_EXPORT;
  *
  * @pre Must be called from the process thread.
  */
+JACK_CLIENT_API_EXPORT
 void jack_get_transport_info (jack_client_t *client,
 			      jack_transport_info_t *tinfo) JACK_OPTIONAL_WEAK_EXPORT;
 
@@ -235,6 +247,7 @@ void jack_get_transport_info (jack_client_t *client,
  * earlier transport interface, but it does nothing.  Instead, define
  * a ::JackTimebaseCallback.
  */
+JACK_CLIENT_API_EXPORT
 void jack_set_transport_info (jack_client_t *client,
 			      jack_transport_info_t *tinfo) JACK_OPTIONAL_WEAK_EXPORT;
 

--- a/common/jack/uuid.h
+++ b/common/jack/uuid.h
@@ -21,6 +21,7 @@
 #define __jack_uuid_h__
 
 #include <jack/types.h>
+#include <jack/systemdeps.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,17 +31,26 @@ extern "C" {
 #define JACK_UUID_STRING_SIZE (JACK_UUID_SIZE+1) /* includes trailing null */
 #define JACK_UUID_EMPTY_INITIALIZER 0
 
-extern jack_uuid_t jack_client_uuid_generate ();
-extern jack_uuid_t jack_port_uuid_generate (uint32_t port_id);
+JACK_CLIENT_API_EXPORT
+jack_uuid_t jack_client_uuid_generate ();
+JACK_CLIENT_API_EXPORT
+jack_uuid_t jack_port_uuid_generate (uint32_t port_id);
 
-extern uint32_t jack_uuid_to_index (jack_uuid_t);
+JACK_CLIENT_API_EXPORT
+uint32_t jack_uuid_to_index (jack_uuid_t);
 
-extern int  jack_uuid_compare (jack_uuid_t, jack_uuid_t);
-extern void jack_uuid_copy (jack_uuid_t* dst, jack_uuid_t src);
-extern void jack_uuid_clear (jack_uuid_t*);
-extern int  jack_uuid_parse (const char *buf, jack_uuid_t*);
-extern void jack_uuid_unparse (jack_uuid_t, char buf[JACK_UUID_STRING_SIZE]);
-extern int  jack_uuid_empty (jack_uuid_t);
+JACK_CLIENT_API_EXPORT
+int  jack_uuid_compare (jack_uuid_t, jack_uuid_t);
+JACK_CLIENT_API_EXPORT
+void jack_uuid_copy (jack_uuid_t* dst, jack_uuid_t src);
+JACK_CLIENT_API_EXPORT
+void jack_uuid_clear (jack_uuid_t*);
+JACK_CLIENT_API_EXPORT
+int  jack_uuid_parse (const char *buf, jack_uuid_t*);
+JACK_CLIENT_API_EXPORT
+void jack_uuid_unparse (jack_uuid_t, char buf[JACK_UUID_STRING_SIZE]);
+JACK_CLIENT_API_EXPORT
+int  jack_uuid_empty (jack_uuid_t);
 
 #ifdef __cplusplus
 } /* namespace */

--- a/common/wscript
+++ b/common/wscript
@@ -117,6 +117,7 @@ def build(bld):
             '../posix/JackPosixMutex.cpp',
             '../macosx/JackMachThread.mm',
             '../macosx/JackMachSemaphore.mm',
+            '../macosx/JackMachSemaphoreServer.mm',
             '../posix/JackSocket.cpp',
             '../macosx/JackMachTime.c',
             ]

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -49,10 +49,15 @@ def build(bld):
         else:
             use = ['clientlib']
 
-        if bld.env['IS_MACOSX']:
-            prog = bld(features='c cprogram', framework = ['Foundation'])
+        if example_program == 'jack_simdtests':
+            ftrs = 'cxx cxxprogram'
         else:
-            prog = bld(features='c cprogram')
+            ftrs = 'c cprogram'
+
+        if bld.env['IS_MACOSX']:
+            prog = bld(features = ftrs, framework = ['Foundation'])
+        else:
+            prog = bld(features = ftrs)
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = example_program_source
         prog.use = use

--- a/macosx/JackMachSemaphore.mm
+++ b/macosx/JackMachSemaphore.mm
@@ -18,12 +18,18 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
 #include "JackMachSemaphore.h"
+#include "JackMachUtils.h"
 #include "JackConstants.h"
 #include "JackTools.h"
 #include "JackError.h"
-#include <fcntl.h>
-#include <stdio.h>
-#include <sys/mman.h>
+
+#include <mach/message.h>
+
+#define jack_mach_error(kern_result, message) \
+        jack_mach_error_uncurried("JackMachSemaphore", kern_result, message)
+
+#define jack_mach_bootstrap_err(kern_result, message, name) \
+        jack_mach_bootstrap_err_uncurried("JackMachSemaphore", kern_result, message, name)
 
 namespace Jack
 {
@@ -42,7 +48,7 @@ void JackMachSemaphore::BuildName(const char* client_name, const char* server_na
 
 bool JackMachSemaphore::Signal()
 {
-    if (!fSemaphore) {
+    if (fSemaphore == MACH_PORT_NULL) {
         jack_error("JackMachSemaphore::Signal name = %s already deallocated!!", fName);
         return false;
     }
@@ -60,7 +66,7 @@ bool JackMachSemaphore::Signal()
 
 bool JackMachSemaphore::SignalAll()
 {
-    if (!fSemaphore) {
+    if (fSemaphore == MACH_PORT_NULL) {
         jack_error("JackMachSemaphore::SignalAll name = %s already deallocated!!", fName);
         return false;
     }
@@ -79,7 +85,7 @@ bool JackMachSemaphore::SignalAll()
 
 bool JackMachSemaphore::Wait()
 {
-    if (!fSemaphore) {
+    if (fSemaphore == MACH_PORT_NULL) {
         jack_error("JackMachSemaphore::Wait name = %s already deallocated!!", fName);
         return false;
     }
@@ -93,7 +99,7 @@ bool JackMachSemaphore::Wait()
 
 bool JackMachSemaphore::TimedWait(long usec)
 {
-    if (!fSemaphore) {
+    if (fSemaphore == MACH_PORT_NULL) {
         jack_error("JackMachSemaphore::TimedWait name = %s already deallocated!!", fName);
         return false;
     }
@@ -109,132 +115,199 @@ bool JackMachSemaphore::TimedWait(long usec)
     return (res == KERN_SUCCESS);
 }
 
-bool JackMachSemaphore::recursiveBootstrapRegister(int counter)
+/*! \brief Server side: create semaphore and publish IPC primitives to make it accessible.
+ *
+ * This method;
+ * - Allocates a mach semaphore
+ * - Allocates a new mach IPC port and obtains a send right for it
+ * - Publishes IPC port send right to the bootstrap server
+ * - Starts a new JackMachSemaphoreServer thread, which listens for messages on the IPC port and
+ * replies with a send right to the mach semaphore.
+ *
+ * \returns false if any of the above steps fails, or true otherwise.
+ */
+bool JackMachSemaphore::Allocate(const char* client_name, const char* server_name, int value)
 {
-    if (counter == 99)
-        return false;
-
-    kern_return_t res;
-
-    if ((res = bootstrap_register(fBootPort, fSharedName, fSemaphore)) != KERN_SUCCESS) {
-        switch (res) {
-            case BOOTSTRAP_SUCCESS :
-                break;
-
-            case BOOTSTRAP_NOT_PRIVILEGED :
-            case BOOTSTRAP_NAME_IN_USE :
-            case BOOTSTRAP_UNKNOWN_SERVICE :
-            case BOOTSTRAP_SERVICE_ACTIVE :
-                // try again with next suffix 
-                snprintf(fSharedName, sizeof(fName), "%s-%d", fName, ++counter);
-                return recursiveBootstrapRegister(counter);
-                break;
-
-            default :
-                jack_log("bootstrap_register() err = %i:%s", res, bootstrap_strerror(res));
-                break;
-        }
-
-        jack_error("Allocate: can't check in mach semaphore name = %s err = %i:%s", fName, res, bootstrap_strerror(res));
+    if (fSemaphore != MACH_PORT_NULL) {
+        jack_error("JackMachSemaphore::Allocate: Semaphore already allocated; called twice? [%s]", fName);
         return false;
     }
 
-    return true;
-}
+    BuildName(client_name, server_name, fName, sizeof(fName));
 
-// Server side : publish the semaphore in the global namespace
-bool JackMachSemaphore::Allocate(const char* name, const char* server_name, int value)
-{
-    BuildName(name, server_name, fName, sizeof(fName));
     mach_port_t task = mach_task_self();
     kern_return_t res;
 
-    if (fBootPort == 0) {
+    if (fBootPort == MACH_PORT_NULL) {
         if ((res = task_get_bootstrap_port(task, &fBootPort)) != KERN_SUCCESS) {
-            jack_error("Allocate: Can't find bootstrap mach port err = %s", mach_error_string(res));
+            jack_mach_error(res, "can't find bootstrap mach port");
             return false;
         }
     }
-
-    if ((fSharedMem = shm_open(fName, O_CREAT | O_RDWR, 0777)) < 0) {
-        jack_error("Allocate: can't check in mach shared name = %s err = %s", fName, strerror(errno));
-        return false;
-    }
-
-    struct stat st;
-    if (fstat(fSharedMem, &st) != -1 && st.st_size == 0) {
-        if (ftruncate(fSharedMem, SYNC_MAX_NAME_SIZE+1) != 0) {
-            jack_error("Allocate: can't set shared memory size in mach shared name = %s err = %s", fName, strerror(errno));
-            return false;
-        }
-    }
-
-    char* const sharedName = (char*)mmap(NULL, SYNC_MAX_NAME_SIZE+1, PROT_READ|PROT_WRITE, MAP_SHARED, fSharedMem, 0);
-
-    if (sharedName == NULL || sharedName == MAP_FAILED) {
-        jack_error("Allocate: can't check in mach shared name = %s err = %s", fName, strerror(errno));
-        close(fSharedMem);
-        fSharedMem = -1;
-        shm_unlink(fName);
-        return false;
-    }
-
-    fSharedName = sharedName;
-    strcpy(fSharedName, fName);
 
     if ((res = semaphore_create(task, &fSemaphore, SYNC_POLICY_FIFO, value)) != KERN_SUCCESS) {
-        jack_error("Allocate: can create semaphore err = %i:%s", res, mach_error_string(res));
+        jack_mach_error(res, "failed to create semaphore");
         return false;
     }
 
-    jack_log("JackMachSemaphore::Allocate name = %s", fName);
-    return recursiveBootstrapRegister(1);
+    if ((res = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &fServicePort)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to allocate IPC port");
+
+        // Cleanup created semaphore
+        this->Destroy();
+
+        return false;
+    }
+
+    if ((res = mach_port_insert_right(mach_task_self(), fServicePort, fServicePort, MACH_MSG_TYPE_MAKE_SEND)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to obtain send right for IPC port");
+
+        // Cleanup created semaphore & mach port
+        this->Destroy();
+
+        return false;
+    }
+
+    if ((res = bootstrap_register(fBootPort, fName, fServicePort)) != KERN_SUCCESS) {
+        jack_mach_bootstrap_err(res, "can't register IPC port with bootstrap server", fName);
+
+        // Cleanup created semaphore & mach port
+        this->Destroy();
+
+        return false;
+    }
+
+    fSemServer = new JackMachSemaphoreServer(fSemaphore, fServicePort, fName);
+    fThreadSemServer = new JackMachThread(fSemServer);
+
+    if (fThreadSemServer->Start() < 0) {
+        jack_error("JackMachSemaphore::Allocate: failed to start semaphore IPC server thread [%s]", fName);
+
+        // Cleanup created semaphore, mach port (incl. service registration), and server
+        this->Destroy();
+
+        return false;
+    }
+
+    jack_log("JackMachSemaphore::Allocate: OK, name = %s", fName);
+    return true;
 }
 
-// Client side : get the published semaphore from server
-bool JackMachSemaphore::ConnectInput(const char* name, const char* server_name)
+/*! \brief Client side: Obtain semaphore from server via published IPC port.
+ *
+ * This method;
+ * - Looks up the service port for the jackd semaphore server for this client by name
+ * - Sends a message to that server asking for a semaphore port send right
+ * - Receives a semaphore send right in return and stores it locally
+ *
+ * \returns False if any of the above steps fails, or true otherwise.
+ */
+bool JackMachSemaphore::ConnectInput(const char* client_name, const char* server_name)
 {
-    BuildName(name, server_name, fName, sizeof(fName));
+    BuildName(client_name, server_name, fName, sizeof(fName));
+
+    mach_port_t task = mach_task_self();
     kern_return_t res;
 
-    // Temporary...
-    if (fSharedName) {
-        jack_log("Already connected name = %s", name);
+    if (fSemaphore != MACH_PORT_NULL) {
+        jack_log("JackMachSemaphore::Connect: Already connected name = %s", fName);
         return true;
     }
 
-    if (fBootPort == 0) {
-        if ((res = task_get_bootstrap_port(mach_task_self(), &fBootPort)) != KERN_SUCCESS) {
-            jack_error("Connect: can't find bootstrap port err = %s", mach_error_string(res));
+    if (fBootPort == MACH_PORT_NULL) {
+        if ((res = task_get_bootstrap_port(task, &fBootPort)) != KERN_SUCCESS) {
+            jack_mach_error(res, "can't find bootstrap port");
             return false;
         }
     }
 
-    if ((fSharedMem = shm_open(fName, O_RDWR, 0)) < 0) {
-        jack_error("Connect: can't connect mach shared name = %s err = %s", fName, strerror(errno));
+    if ((res = bootstrap_look_up(fBootPort, fName, &fServicePort)) != KERN_SUCCESS) {
+        jack_mach_bootstrap_err(res, "can't find IPC service port to request semaphore", fName);
         return false;
     }
 
-    char* const sharedName = (char*)mmap(NULL, SYNC_MAX_NAME_SIZE+1, PROT_READ|PROT_WRITE, MAP_SHARED, fSharedMem, 0);
+    mach_port_t semaphore_req_port;
 
-    if (sharedName == NULL || sharedName == MAP_FAILED) {
-        jack_error("Connect: can't connect mach shared name = %s err = %s", fName, strerror(errno));
-        close(fSharedMem);
-        fSharedMem = -1;
+    if ((res = mach_port_allocate(task, MACH_PORT_RIGHT_RECEIVE, &semaphore_req_port)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to allocate request port");
+
+        if ((res = mach_port_deallocate(task, fServicePort)) != KERN_SUCCESS) {
+            jack_mach_error(res, "failed to deallocate IPC service port during cleanup");
+        } else {
+            fServicePort = MACH_PORT_NULL;
+        }
+
         return false;
     }
 
-    if ((res = bootstrap_look_up(fBootPort, sharedName, &fSemaphore)) != KERN_SUCCESS) {
-        jack_error("Connect: can't find mach semaphore name = %s, sname = %s, err = %s", fName, sharedName, bootstrap_strerror(res));
-        close(fSharedMem);
-        fSharedMem = -1;
+    // Prepare a message buffer on the stack. We'll use it for both sending and receiving a message.
+    struct {
+        mach_msg_header_t hdr;
+        mach_msg_trailer_t trailer;
+    } msg;
+
+    /*
+     * Configure the message to consume the destination port we give it (_MOVE_SEND), and to
+     * transmute the local port receive right we give it into a send_once right at the destination.
+     * The server will use that send_once right to reply to us.
+     */
+    msg.hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_MOVE_SEND, MACH_MSG_TYPE_MAKE_SEND_ONCE);
+    msg.hdr.msgh_local_port = semaphore_req_port;
+    msg.hdr.msgh_remote_port = fServicePort;
+
+    mach_msg_return_t send_err = mach_msg(
+        &msg.hdr,
+        MACH_SEND_MSG,
+        sizeof(msg.hdr), // no trailer on send
+        0,
+        MACH_PORT_NULL,
+        MACH_MSG_TIMEOUT_NONE,
+        MACH_PORT_NULL);
+
+    if (send_err != MACH_MSG_SUCCESS) {
+        jack_mach_error(send_err, "failed to send semaphore port request IPC");
+
+        if ((res = mach_port_deallocate(task, fServicePort)) != KERN_SUCCESS) {
+            jack_mach_error(res, "failed to deallocate IPC service port during cleanup");
+        } else {
+            fServicePort = MACH_PORT_NULL;
+        }
+
+        if ((res = mach_port_destroy(task, semaphore_req_port)) != KERN_SUCCESS) {
+            jack_mach_error(res, "failed to destroy IPC request port during cleanup");
+        }
+
         return false;
+    } else {
+        fServicePort = MACH_PORT_NULL; // We moved it into the message and away to the destination
     }
 
-    fSharedName = sharedName;
+    mach_msg_return_t recv_err = mach_msg(
+        &msg.hdr,
+        MACH_RCV_MSG,
+        0,
+        sizeof(msg),
+        semaphore_req_port,
+        MACH_MSG_TIMEOUT_NONE,
+        MACH_PORT_NULL
+    );
 
-    jack_log("JackMachSemaphore::Connect name = %s ", fName);
-    return true;
+    /* Don't leak ports: irrespective of if we succeeded to read or not, destroy the port we created
+     * to send/receive the request as we have no further use for it either way. */
+    if ((res = mach_port_destroy(task, semaphore_req_port)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to destroy semaphore_req_port");
+        // This isn't good, but doesn't actually stop the semaphore from working... don't bail
+    }
+
+    if (recv_err != MACH_MSG_SUCCESS) {
+        jack_mach_error(recv_err, "failed to receive semaphore port");
+        return false;
+    } else {
+        fSemaphore = msg.hdr.msgh_remote_port;
+
+        jack_log("JackMachSemaphore::Connect: OK, name = %s ", fName);
+        return true;
+    }
 }
 
 bool JackMachSemaphore::Connect(const char* name, const char* server_name)
@@ -249,49 +322,75 @@ bool JackMachSemaphore::ConnectOutput(const char* name, const char* server_name)
 
 bool JackMachSemaphore::Disconnect()
 {
-    if (fSemaphore > 0) {
-        jack_log("JackMachSemaphore::Disconnect name = %s", fName);
-        fSemaphore = 0;
-    }
-
-    if (!fSharedName) {
+    if (fSemaphore == MACH_PORT_NULL) {
         return true;
     }
 
-    munmap(fSharedName, SYNC_MAX_NAME_SIZE+1);
-    fSharedName = NULL;
+    mach_port_t task = mach_task_self();
+    kern_return_t res;
 
-    close(fSharedMem);
-    fSharedMem = -1;
-    return true;
+    jack_log("JackMachSemaphore::Disconnect name = %s", fName);
+
+    if (fServicePort != MACH_PORT_NULL) {
+        // If we're still holding onto a service port send right for some reason, deallocate it
+        if ((res = mach_port_deallocate(task, fServicePort)) != KERN_SUCCESS) {
+            jack_mach_error(res, "failed to deallocate stray service port");
+            // Continue cleanup even if this fails; don't bail
+        } else {
+            fServicePort = MACH_PORT_NULL;
+        }
+    }
+
+    if ((res = mach_port_deallocate(task, fSemaphore)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to deallocate semaphore port");
+        return false;
+    } else {
+        fSemaphore = MACH_PORT_NULL;
+        return true;
+    }
 }
 
 // Server side : destroy the JackGlobals
 void JackMachSemaphore::Destroy()
 {
     kern_return_t res;
+    mach_port_t task = mach_task_self();
 
-    if (fSemaphore > 0) {
-        jack_log("JackMachSemaphore::Destroy name = %s", fName);
-        if ((res = semaphore_destroy(mach_task_self(), fSemaphore)) != KERN_SUCCESS) {
-            jack_error("JackMachSemaphore::Destroy can't destroy semaphore err = %s", mach_error_string(res));
-        }
-        fSemaphore = 0;
-    } else {
-        jack_error("JackMachSemaphore::Destroy semaphore < 0");
-    }
-
-    if (!fSharedName) {
+    if (fSemaphore == MACH_PORT_NULL) {
+        jack_error("JackMachSemaphore::Destroy semaphore is MACH_PORT_NULL; already destroyed?");
         return;
     }
 
-    munmap(fSharedName, SYNC_MAX_NAME_SIZE+1);
-    fSharedName = NULL;
+    if (fThreadSemServer) {
+        if (fThreadSemServer->Kill() < 0) {
+            jack_error("JackMachSemaphore::Destroy failed to kill semaphore server thread...");
+            // Oh dear. How sad. Never mind.
+        }
 
-    close(fSharedMem);
-    fSharedMem = -1;
+        JackMachThread* thread = fThreadSemServer;
+        fThreadSemServer = NULL;
+        delete thread;
+    }
 
-    shm_unlink(fName);
+    if (fSemServer) {
+        JackMachSemaphoreServer* server = fSemServer;
+        fSemServer = NULL;
+        delete server;
+    }
+
+    if ((res = mach_port_destroy(task, fServicePort)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to destroy IPC port");
+    } else {
+        fServicePort = MACH_PORT_NULL;
+    }
+
+    if ((res = semaphore_destroy(mach_task_self(), fSemaphore)) != KERN_SUCCESS) {
+        jack_mach_error(res, "failed to destroy semaphore");
+    } else {
+        fSemaphore = MACH_PORT_NULL;
+    }
+
+    jack_log("JackMachSemaphore::Destroy: OK, name = %s", fName);
 }
 
 } // end of namespace

--- a/macosx/JackMachSemaphoreServer.h
+++ b/macosx/JackMachSemaphoreServer.h
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2021 Peter Bridgman
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackMachSemaphoreServer__
+#define __JackMachSemaphoreServer__
+
+#include "JackCompilerDeps.h"
+#include "JackMachThread.h"
+
+#include <mach/mach.h>
+#include <mach/semaphore.h>
+
+namespace Jack
+{
+
+/*! \brief A runnable thread which listens for IPC messages and replies with a semaphore send right. */
+class SERVER_EXPORT JackMachSemaphoreServer : public JackRunnableInterface
+{
+    private:
+        /*! \brief The semaphore send right that will be dispatched to clients. */
+        semaphore_t fSemaphore;
+
+        /*! \brief The port on which we will listen for IPC messages. */
+        mach_port_t fServerReceive;
+
+        /*! \brief A pointer to a null-terminated string buffer that will be read to obtain the
+         * server name for reporting purposes. Not managed at all by this type. */
+        char* fName;
+
+    public:
+        JackMachSemaphoreServer(semaphore_t semaphore, mach_port_t server_recv, char* name):
+            fSemaphore(semaphore), fServerReceive(server_recv), fName(name)
+        {}
+
+        bool Execute() override;
+};
+
+} // end of namespace
+
+#endif

--- a/macosx/JackMachSemaphoreServer.mm
+++ b/macosx/JackMachSemaphoreServer.mm
@@ -1,0 +1,87 @@
+/*
+Copyright (C) 2021 Peter Bridgman
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#include "JackMachSemaphoreServer.h"
+#include "JackMachUtils.h"
+#include "JackConstants.h"
+#include "JackTools.h"
+#include "JackError.h"
+
+#include <mach/message.h>
+
+#define jack_mach_error(kern_result, message) \
+        jack_mach_error_uncurried("JackMachSemaphoreServer", kern_result, message)
+
+namespace Jack
+{
+
+bool JackMachSemaphoreServer::Execute() {
+    jack_log("JackMachSemaphoreServer::Execute: %s", fName);
+
+    /* Setup a message struct in our local stack frame which we can receive messages into and send
+     * messages from. */
+    struct {
+        mach_msg_header_t hdr;
+        mach_msg_trailer_t trailer;
+    } msg;
+
+    // Block until we receive a message on the fServerReceive port.
+    mach_msg_return_t recv_err = mach_msg(
+        &msg.hdr,
+        MACH_RCV_MSG,
+        0,
+        sizeof(msg),
+        fServerReceive,
+        MACH_MSG_TIMEOUT_NONE,
+        MACH_PORT_NULL
+    );
+
+    if (recv_err != MACH_MSG_SUCCESS) {
+        jack_mach_error(recv_err, "receive error");
+        return true; // Continue processing more connections
+    }
+
+    /* We're going to reuse the message struct that we received the message into to send a reply.
+     * Setup the semaphore send port that we want to give to the client as the local port... */
+    msg.hdr.msgh_local_port = fSemaphore;
+
+    /*
+     * ... to be returned by copy (_COPY_SEND), to a destination that is _SEND_ONCE that we no
+     * longer require. That destination will have been set by the client as their local_port, so
+     * will now already be the remote_port in the message we received (nifty, eh?).
+     */
+    msg.hdr.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_MOVE_SEND_ONCE, MACH_MSG_TYPE_COPY_SEND);
+
+    mach_msg_return_t send_err = mach_msg(
+        &msg.hdr,
+        MACH_SEND_MSG,
+        sizeof(msg.hdr), // no trailer on send
+        0,
+        MACH_PORT_NULL,
+        MACH_MSG_TIMEOUT_NONE,
+        MACH_PORT_NULL);
+
+    if (send_err != MACH_MSG_SUCCESS) {
+        jack_mach_error(send_err, "send error");
+    }
+
+    return true;
+}
+
+} // end of namespace

--- a/macosx/JackMachUtils.h
+++ b/macosx/JackMachUtils.h
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2021 Peter Bridgman
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+*/
+
+#ifndef __JackMachUtils__
+#define __JackMachUtils__
+
+#define jack_mach_error_uncurried(type_name, kern_return, message) \
+        jack_error(type_name "::%s: " message " - %i:%s", \
+                    __FUNCTION__, \
+                    kern_return, \
+                    mach_error_string(kern_return))
+
+#define jack_mach_bootstrap_err_uncurried(type_name, kern_return, message, service_name) \
+        jack_error(type_name "::%s: " message " [%s] - %i:%s", \
+                    __FUNCTION__, \
+                    service_name, \
+                    kern_return, \
+                    bootstrap_strerror(kern_return))
+
+#endif

--- a/macosx/generate-pkg.sh
+++ b/macosx/generate-pkg.sh
@@ -15,7 +15,11 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 
-VERSION=$(cat ../wscript | awk 'sub("VERSION=","")' | tr -d "'")
+if [ -n "${2}" ]; then
+    VERSION="${2}"
+else
+    VERSION=$(cat ../wscript | awk 'sub("VERSION=","")' | tr -d "'")
+fi
 
 rm -f jack2-osx-root.pkg
 rm -f jack2-osx-${VERSION}.pkg

--- a/tools/wscript
+++ b/tools/wscript
@@ -21,6 +21,7 @@ example_tools = {
 def configure(conf):
     conf.env['BUILD_TOOL_ALSA_IO'] = conf.env['SAMPLERATE'] and conf.env['BUILD_DRIVER_ALSA']
     conf.env['BUILD_TOOL_CLIENT_TRANSPORT'] = conf.env['READLINE']
+    conf.env['BUILD_TOOL_CLIENT_NETSOURCE'] = conf.env['CELT'] or conf.env['OPUS']
     conf.env['BUILD_TOOL_ZALSA'] = conf.env['ZALSA']
 
 def build(bld):
@@ -66,7 +67,7 @@ def build(bld):
                 prog.env['LIB_PTHREAD'] = [':libwinpthread.a']
         prog.target = 'jack_transport'
 
-    if bld.env['IS_LINUX'] or bld.env['IS_MACOSX']:
+    if bld.env['BUILD_TOOL_CLIENT_NETSOURCE']:
         prog = bld(features = 'c cprogram')
         prog.includes = os_incdir + ['.', '..', '../common/jack', '../common']
         prog.source = ['netsource.c', '../common/netjack_packet.c']

--- a/windows/JackTypes_os.h
+++ b/windows/JackTypes_os.h
@@ -31,9 +31,5 @@ typedef UInt64 uint64_t;
 typedef unsigned short uint16_t;
 typedef DWORD jack_tls_key;
 
-#if defined(__MINGW32__)
-#define PRIu64 "llu"
-#endif
-
 #endif
 

--- a/windows/inno/win32-mini.iss
+++ b/windows/inno/win32-mini.iss
@@ -1,0 +1,49 @@
+#include "version.iss"
+
+[Setup]
+AppName=JACK2
+AppPublisher=jackaudio.org
+AppPublisherURL=https://github.com/jackaudio/jack2/
+AppSupportURL=https://github.com/jackaudio/jack2/issues/
+AppUpdatesURL=https://github.com/jackaudio/jack2-releases/releases/
+AppVersion={#VERSION}
+DefaultDirName={commonpf32}\JACK2
+DisableDirPage=yes
+DisableWelcomePage=no
+LicenseFile=..\..\COPYING
+OutputBaseFilename=jack2-win32-{#VERSION}
+OutputDir=.
+UsePreviousAppDir=no
+
+[Types]
+Name: "full"; Description: "Full installation";
+Name: "custom"; Description: "Custom installation"; Flags: iscustom;
+
+[Components]
+Name: jackserver; Description: "JACK Server and tools"; Types: full custom; Flags: fixed;
+Name: dev; Description: "Developer resources"; Types: full;
+
+[Files]
+; icon
+Source: "jack.ico"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+; jackd and server libs
+Source: "win32\bin\jackd.exe"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+Source: "win32\lib\libjacknet.dll"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+Source: "win32\lib\libjackserver.dll"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+; drivers
+Source: "win32\lib\jack\*.dll"; DestDir: "{app}\jack"; Components: jackserver; Flags: ignoreversion;
+; tools
+Source: "win32\bin\jack_*.exe"; DestDir: "{app}\tools"; Components: jackserver; Flags: ignoreversion;
+; jack client lib (NOTE goes into windir)
+Source: "win32\lib\libjack.dll"; DestDir: "{win}"; Components: jackserver; Flags: ignoreversion;
+; dev
+Source: "win32\include\jack\*.h"; DestDir: "{app}\include\jack"; Components: dev; Flags: ignoreversion;
+Source: "win32\lib\*.a"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;
+Source: "win32\lib\*.def"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;
+Source: "win32\lib\*.lib"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;
+Source: "win32\lib\jack\*.a"; DestDir: "{app}\lib\jack"; Components: dev; Flags: ignoreversion;
+
+[Registry]
+Root: HKLM; Subkey: "Software\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "ServerExecutable"; ValueData: "{app}\jackd.exe"
+Root: HKLM; Subkey: "Software\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "InstallPath"; ValueData: "{app}"
+Root: HKLM; Subkey: "Software\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "Version"; ValueData: "{#VERSION}"

--- a/windows/inno/win64-mini.iss
+++ b/windows/inno/win64-mini.iss
@@ -1,0 +1,58 @@
+#include "version.iss"
+
+[Setup]
+ArchitecturesInstallIn64BitMode=x64
+AppName=JACK2
+AppPublisher=jackaudio.org
+AppPublisherURL=https://github.com/jackaudio/jack2/
+AppSupportURL=https://github.com/jackaudio/jack2/issues/
+AppUpdatesURL=https://github.com/jackaudio/jack2-releases/releases/
+AppVersion={#VERSION}
+DefaultDirName={commonpf64}\JACK2
+DisableDirPage=yes
+DisableWelcomePage=no
+LicenseFile=..\..\COPYING
+OutputBaseFilename=jack2-win64-{#VERSION}
+OutputDir=.
+UsePreviousAppDir=no
+
+[Types]
+Name: "full"; Description: "Full installation";
+Name: "custom"; Description: "Custom installation"; Flags: iscustom;
+
+[Components]
+Name: jackserver; Description: "JACK Server and tools"; Types: full custom; Flags: fixed;
+Name: dev; Description: "Developer resources"; Types: full;
+
+[Files]
+; icon
+Source: "jack.ico"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+; jackd and server libs
+Source: "win64\bin\jackd.exe"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+Source: "win64\lib\libjacknet64.dll"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+Source: "win64\lib\libjackserver64.dll"; DestDir: "{app}"; Components: jackserver; Flags: ignoreversion;
+; drivers
+Source: "win64\lib\jack\*.dll"; DestDir: "{app}\jack"; Components: jackserver; Flags: ignoreversion;
+; tools
+Source: "win64\bin\jack_*.exe"; DestDir: "{app}\tools"; Components: jackserver; Flags: ignoreversion;
+; jack client lib (NOTE goes into windir)
+Source: "win64\lib\libjack64.dll"; DestDir: "{win}"; Components: jackserver; Flags: ignoreversion;
+Source: "win64\lib32\libjack.dll"; DestDir: "{win}"; Components: jackserver; Flags: ignoreversion;
+; dev
+Source: "win64\include\jack\*.h"; DestDir: "{app}\include\jack"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib\*.a"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib\*.def"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib\*.lib"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib32\*.a"; DestDir: "{app}\lib32"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib32\*.def"; DestDir: "{app}\lib32"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib32\*.lib"; DestDir: "{app}\lib32"; Components: dev; Flags: ignoreversion;
+Source: "win64\lib\jack\*.a"; DestDir: "{app}\lib\jack"; Components: dev; Flags: ignoreversion;
+
+[Registry]
+Root: HKLM; Subkey: "Software\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "ServerExecutable"; ValueData: "{app}\jackd.exe"
+Root: HKLM; Subkey: "Software\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "InstallPath"; ValueData: "{app}"
+Root: HKLM; Subkey: "Software\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "Version"; ValueData: "{#VERSION}"
+; 32bit compat keys
+Root: HKLM; Subkey: "Software\WOW6432Node\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "ServerExecutable"; ValueData: "{app}\jackd.exe"
+Root: HKLM; Subkey: "Software\WOW6432Node\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "InstallPath"; ValueData: "{app}"
+Root: HKLM; Subkey: "Software\WOW6432Node\JACK"; Flags: deletevalue uninsdeletekeyifempty uninsdeletevalue; ValueType: string; ValueName: "Version"; ValueData: "{#VERSION}"

--- a/windows/portaudio/JackPortAudioDevices.h
+++ b/windows/portaudio/JackPortAudioDevices.h
@@ -24,7 +24,10 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <string>
 
 #include <portaudio.h>
+
+#if defined(HAVE_ASIO)
 #include <pa_asio.h>
+#endif
 
 /*!
 \brief A PortAudio Devices manager.

--- a/wscript
+++ b/wscript
@@ -221,9 +221,8 @@ def configure(conf):
         if Options.options.platform in ('msys', 'win32'):
             conf.env.append_value('INCLUDES', ['/mingw64/include'])
             conf.check(
-                header_name='asio.h',
-                includes='/opt/asiosdk/common',
-                msg='Checking for ASIO SDK',
+                header_name='pa_asio.h',
+                msg='Checking for PortAudio ASIO support',
                 define_name='HAVE_ASIO',
                 mandatory=False)
 

--- a/wscript
+++ b/wscript
@@ -218,7 +218,7 @@ def configure(conf):
     if conf.env['IS_WINDOWS']:
         conf.env.append_unique('CCDEFINES', '_POSIX')
         conf.env.append_unique('CXXDEFINES', '_POSIX')
-        if Options.options.platform == 'msys':
+        if Options.options.platform in ('msys', 'win32'):
             conf.env.append_value('INCLUDES', ['/mingw64/include'])
             conf.check(
                 header_name='asio.h',
@@ -388,7 +388,7 @@ def configure(conf):
         # existing install paths that use ADDON_DIR rather than have to
         # have special cases for windows each time.
         conf.env['ADDON_DIR'] = conf.env['LIBDIR'] + '/jack'
-        if Options.options.platform == 'msys':
+        if Options.options.platform in ('msys', 'win32'):
             conf.define('ADDON_DIR', 'jack')
             conf.define('__STDC_FORMAT_MACROS', 1) # for PRIu64
         else:

--- a/wscript
+++ b/wscript
@@ -11,7 +11,7 @@ import sys
 from waflib import Logs, Options, Task, Utils
 from waflib.Build import BuildContext, CleanContext, InstallContext, UninstallContext
 
-VERSION='1.9.19'
+VERSION='1.9.20'
 APPNAME='jack'
 JACK_API_VERSION = '0.1.0'
 

--- a/wscript
+++ b/wscript
@@ -229,7 +229,10 @@ def configure(conf):
     conf.env.append_unique('CFLAGS', '-Wall')
     conf.env.append_unique('CXXFLAGS', ['-Wall', '-Wno-invalid-offsetof'])
     conf.env.append_unique('CXXFLAGS', '-std=gnu++11')
-
+    
+    conf.env.append_unique('CFLAGS', '-DBUILDING_JACK')
+    conf.env.append_unique('CXXFLAGS', '-DBUILDING_JACK')
+    
     if not conf.env['IS_MACOSX']:
         conf.env.append_unique('LDFLAGS', '-Wl,--no-undefined')
     else:


### PR DESCRIPTION
I've finally come-up with a maybe more "radical" solution.

CFLAGS and CXXFLAGS are modified to add a global `BUILDING_JACK` define that choose between dllexport and dllimport.

When building jack, symbols are declared using dllexport.
When headers are used by an application, symbols will be declared using dllimport.

Fixes: #792