### PR TITLE
ALSA: convert properly S24_LE

### DIFF
--- a/common/memops.h
+++ b/common/memops.h
@@ -55,6 +55,8 @@ void sample_move_dS_floatLE (char *dst, jack_default_audio_sample_t *src, unsign
 /* integer functions */
 void sample_move_d32u24_sSs          (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d32u24_sS           (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
+void sample_move_d32l24_sSs          (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
+void sample_move_d32l24_sS           (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d24_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d24_sS              (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
 void sample_move_d16_sSs             (char *dst, jack_default_audio_sample_t *src, unsigned long nsamples, unsigned long dst_skip, dither_state_t *state);
@@ -81,6 +83,8 @@ void sample_move_dither_shaped_d16_sS     (char *dst, jack_default_audio_sample_
 
 void sample_move_dS_s32u24s          (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s32u24           (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
+void sample_move_dS_s32l24s          (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
+void sample_move_dS_s32l24           (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s24s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s24              (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);
 void sample_move_dS_s16s             (jack_default_audio_sample_t *dst, char *src, unsigned long nsamples, unsigned long src_skip);

--- a/example-clients/simdtests.cpp
+++ b/example-clients/simdtests.cpp
@@ -119,6 +119,26 @@ test_case_data_t test_cases[] = {
 		NULL,
 		"32u24" },
 	{
+		4,
+		3,
+		true,
+		accelerated::sample_move_d32l24_sSs,
+		origerated::sample_move_d32l24_sSs,
+		accelerated::sample_move_dS_s32l24s,
+		origerated::sample_move_dS_s32l24s,
+		NULL,
+		"32l24s" },
+	{
+		4,
+		3,
+		false,
+		accelerated::sample_move_d32l24_sS,
+		origerated::sample_move_d32l24_sS,
+		accelerated::sample_move_dS_s32l24,
+		origerated::sample_move_dS_s32l24,
+		NULL,
+		"32l24" },
+	{
 		3,
 		3,
 		true,
@@ -283,7 +303,8 @@ int main(int argc, char *argv[])
 #else
 					test_cases[testcase].reverse);
 #endif
-				if(intval_accel != intval_orig) {
+				// allow a deviation of 1
+				if(intval_accel>intval_orig+1 || intval_orig>intval_accel+1) {
 					if(int_error_count<maxerr_displayed) {
 						printf("Value error sample %u:", sample);
 						printf(" Orig 0x");

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -315,8 +315,8 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 
 			case 4: /* NO DITHER */
 				driver->write_via_copy = driver->quirk_bswap?
-					sample_move_d32u24_sSs:
-					sample_move_d32u24_sS;
+					sample_move_d32l24_sSs:
+					sample_move_d32l24_sS;
 				break;
 
 			default:
@@ -344,8 +344,8 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 				break;
 			case 4:
 				driver->read_via_copy = driver->quirk_bswap?
-					sample_move_dS_s32u24s:
-					sample_move_dS_s32u24;
+					sample_move_dS_s32l24s:
+					sample_move_dS_s32l24;
 				break;
 			}
 		}

--- a/tools/alsa_in.c
+++ b/tools/alsa_in.c
@@ -97,7 +97,7 @@ alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
 	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d32l24_sS, sample_move_dS_s32l24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }

--- a/tools/alsa_out.c
+++ b/tools/alsa_out.c
@@ -98,7 +98,7 @@ alsa_format_t formats[] = {
 	{ SND_PCM_FORMAT_FLOAT_LE, 4, sample_move_dS_floatLE, sample_move_floatLE_sSs, "float" },
 	{ SND_PCM_FORMAT_S32, 4, sample_move_d32u24_sS, sample_move_dS_s32u24, "32bit" },
 	{ SND_PCM_FORMAT_S24_3LE, 3, sample_move_d24_sS, sample_move_dS_s24, "24bit - real" },
-	{ SND_PCM_FORMAT_S24, 4, sample_move_d24_sS, sample_move_dS_s24, "24bit" },
+	{ SND_PCM_FORMAT_S24, 4, sample_move_d32l24_sS, sample_move_dS_s32l24, "24bit" },
 	{ SND_PCM_FORMAT_S16, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit" }
 #ifdef __ANDROID__
 	,{ SND_PCM_FORMAT_S16_LE, 2, sample_move_d16_sS, sample_move_dS_s16, "16bit little-endian" }


### PR DESCRIPTION
ALSA S24_LE is using the **lower** 3 bytes, not the upper.

> [Signed 24 bit Little Endian using low three bytes in 32-bit word](https://git.alsa-project.org/?p=alsa-lib.git;a=blob;f=include/pcm.h#l140)

This patch adds the memops for all 32l24 conversions like 32u24, and use them for ALSA driver only.
Maybe some other driver should use this too (OSS/Boomer) but I can not test them.
SIMD optimizations have been checked on ARM NEON and x86 SSE2.

Fixes jackaudio/jack2#459