### PR TITLE
OpenSL ES driver. Changing the queue processing strategy.

### DIFF
--- a/android/JackOpenSLESDriver.cpp
+++ b/android/JackOpenSLESDriver.cpp
@@ -30,7 +30,6 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <fcntl.h>
 #include <math.h>
 
-#include <android/log.h>
 #include "opensl_io.h"
 
 #define JACK_OPENSLES_DEFAULT_SAMPLERATE   48000

--- a/android/opensl_io.h
+++ b/android/opensl_io.h
@@ -72,10 +72,12 @@ typedef struct opensl_stream {
   // current buffer half (0, 1)
   int currentOutputBuffer;
   int currentInputBuffer;
-  
+
   // buffers
   short *outputBuffer[2];
   short *inputBuffer[2];
+  int outputBufferSize[2];
+  int inputBufferSize[2];
 
   // size of buffers
   int outBufSamples;


### PR DESCRIPTION
Queue handling has been moved to Callback functions. The write / read functions only fill the audio data buffers. This allows for continuous flow of data to / from queues.
That provides continuous sound without clicks and distortion. The driver was tested on Android phone Xiaomi Redmi 8 Note with DAW Ardor and showed good sound quality.
