### PR TITLE
Override permission issues by separating users metadata

### DIFF
--- a/common/JackMetadata.cpp
+++ b/common/JackMetadata.cpp
@@ -21,6 +21,7 @@
 #include "JackMetadata.h"
 
 #include "JackClient.h"
+#include "JackTools.h"
 
 #include <string.h>
 #include <sys/stat.h>
@@ -68,20 +69,20 @@ JackMetadata::~JackMetadata()
     if (fIsEngine)
     {
         // cleanup after libdb, nasty!
-        snprintf (dbpath, sizeof(dbpath), "%s/jack_db/metadata.db", fDBFilesDir);
+        snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/metadata.db", fDBFilesDir, JackTools::GetUID());
         remove (dbpath);
 
-        snprintf (dbpath, sizeof(dbpath), "%s/jack_db/__db.001", fDBFilesDir);
+        snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/__db.001", fDBFilesDir, JackTools::GetUID());
         remove (dbpath);
 
-        snprintf (dbpath, sizeof(dbpath), "%s/jack_db/__db.002", fDBFilesDir);
+        snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/__db.002", fDBFilesDir, JackTools::GetUID());
         remove (dbpath);
 
-        snprintf (dbpath, sizeof(dbpath), "%s/jack_db/__db.003", fDBFilesDir);
+        snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/__db.003", fDBFilesDir, JackTools::GetUID());
         remove (dbpath);
 
         // remove our custom dir
-        snprintf (dbpath, sizeof(dbpath), "%s/jack_db", fDBFilesDir);
+        snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d", fDBFilesDir, JackTools::GetUID());
         rmdir (dbpath);
     }
 #endif
@@ -115,7 +116,7 @@ int JackMetadata::PropertyInit()
         return -1;
     }
 
-    snprintf (dbpath, sizeof(dbpath), "%s/jack_db", fDBFilesDir);
+    snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d", fDBFilesDir, JackTools::GetUID());
 #ifdef WIN32
     mkdir (dbpath);
 #else
@@ -129,16 +130,16 @@ int JackMetadata::PropertyInit()
             jack_error ("Failed to open previous DB environment, trying again clean...");
 
             // cleanup old stuff
-            snprintf (dbpath, sizeof(dbpath), "%s/jack_db/metadata.db", fDBFilesDir);
+            snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/metadata.db", fDBFilesDir, JackTools::GetUID());
             remove (dbpath);
 
-            snprintf (dbpath, sizeof(dbpath), "%s/jack_db/__db.001", fDBFilesDir);
+            snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/__db.001", fDBFilesDir, JackTools::GetUID());
             remove (dbpath);
 
-            snprintf (dbpath, sizeof(dbpath), "%s/jack_db/__db.002", fDBFilesDir);
+            snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/__db.002", fDBFilesDir, JackTools::GetUID());
             remove (dbpath);
 
-            snprintf (dbpath, sizeof(dbpath), "%s/jack_db/__db.003", fDBFilesDir);
+            snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/__db.003", fDBFilesDir, JackTools::GetUID());
             remove (dbpath);
 
             // try again fresh
@@ -160,7 +161,7 @@ int JackMetadata::PropertyInit()
         return -1;
     }
 
-    snprintf (dbpath, sizeof(dbpath), "%s/jack_db/metadata.db", fDBFilesDir);
+    snprintf (dbpath, sizeof(dbpath), "%s/jack_db-%d/metadata.db", fDBFilesDir, JackTools::GetUID());
     if ((ret = fDB->open (fDB, NULL, dbpath, NULL, DB_HASH, DB_CREATE | DB_THREAD, 0666)) != 0) {
         jack_error ("Cannot open metadata DB at %s: %s", dbpath, db_strerror (ret));
         fDB->close (fDB, 0);


### PR DESCRIPTION
I have issues on computer wits several user accounts and jack2 and jack2-dbus installed. It looks like dbus uses UID and GID of current user and mask 027 for starting jack2
```
[root@arch shm]# ls -la
total 72
drwxr-x---  2 me me   120 Dec  5 11:57 jack_db

[root@arch shm]# ls -la jack_db/
total 324
drwxr-x--- 2 me me    120 Dec  5 11:57 .
drwxrwxrwt 4 root     root        100 Dec  5 12:58 ..
-rw-r----- 1 me me  393216 Dec  5 11:57 __db.001
-rw-r----- 1 me me  49152 Dec  5 11:57 __db.002
-rw-r----- 1 me me  49152 Dec  5 11:57 __db.003
-rw-r--r-- 1 me me  12288 Dec  5 11:57 metadata.db

```
Effectively, other user can't connect to metadata. There is a lot of reports out of github in regarding this issue as well.
Proposed PR is about to handle metadata of all users separately, as it was in jack1 (and is implemented in other software). Hopefully it should fix #569 and #757.