### PR TITLE
Add custom variable to jack pkgconfig to distinguish implementations

### DIFF
--- a/jack.pc.in
+++ b/jack.pc.in
@@ -3,6 +3,7 @@ exec_prefix=@PREFIX@
 libdir=@LIBDIR@
 includedir=@INCLUDEDIR@
 server_libs=-L@LIBDIR@ -l@SERVERLIB@
+jack_implementation=jack2
 
 Name: jack
 Description: the Jack Audio Connection Kit: a low-latency synchronous callback-based media server


### PR DESCRIPTION
jack.pc.in:
Add the custom `jack_implementation=jack2` pkgconfig variable to the
generated jack.pc file to be able to distinguish jack implementations.
As jack implementations exist with jack1, jack2 and pipewire-jack, it is
not (easily) possible to distinguish them by looking at the version
alone (particularly the case with jack2 vs. pipewire-jack, as they share
the same headers).