### PR TITLE
Optional example clients and tools

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,11 @@ ChangeLog
 
   * WIP
   * Fix incomplete ASIO support on Windows
+  * Add waf autooption ``--example-tools`` to allow optional build of
+    executables, libraries and man pages provided by `jack-example-tools
+    <https://github.com/jackaudio/jack-example-tools>`_ (the files are built by
+    default). Building and installing the additional files can be disabled by
+    using ``--example-tools=no`` or ``--no-example-tools``.
 
 * 1.9.19 (2021-07-15)
 

--- a/man/fill_template
+++ b/man/fill_template
@@ -2,6 +2,10 @@
 d=""
 [ -z "$SOURCE_DATE_EPOCH" ] || d=--date=@$SOURCE_DATE_EPOCH
 
-for i in *.0 ; do
-   sed -e "s/!VERSION!/${1}/g" -e "s/!DATE!/`date $d '+%B %Y'`/g" < ${i} > ${i%%0}1
-done
+if [ "$2" == "True" ]; then
+  for i in *.0 ; do
+    sed -e "s/!VERSION!/${1}/g" -e "s/!DATE!/`date $d '+%B %Y'`/g" < ${i} > ${i%%0}1
+  done
+else
+  sed -e "s/!VERSION!/${1}/g" -e "s/!DATE!/`date $d '+%B %Y'`/g" < jackd.0 > jackd.1
+fi

--- a/man/wscript
+++ b/man/wscript
@@ -1,11 +1,10 @@
 #! /usr/bin/python3
 # encoding: utf-8
 
-import re
-import os
-
 
 def build(bld):
-    bld.exec_command('cd man ; sh fill_template %s' % bld.env['JACK_VERSION'])
+    bld.exec_command('cd man ; sh fill_template {} {}'.format(
+        bld.env['JACK_VERSION'],
+        bld.env['HAVE_JACK_EXAMPLE_TOOLS'])
+    )
     bld.install_files(bld.env['MANDIR'], bld.path.ant_glob('*.1'))
-

--- a/wscript
+++ b/wscript
@@ -134,6 +134,12 @@ def options(opt):
             'celt',
             help='Build with CELT')
     celt.add_function(check_for_celt)
+    opt.add_auto_option(
+            'example-tools',
+            help='Build with jack-example-tools',
+            conf_dest='BUILD_JACK_EXAMPLE_TOOLS',
+            default=True,
+    )
 
     # Suffix _PKG to not collide with HAVE_OPUS defined by the option.
     opus = opt.add_auto_option(
@@ -296,9 +302,9 @@ def configure(conf):
         else:
             conf.env['SYSTEMD_USER_UNIT_DIR'] = None
 
-
-    conf.recurse('example-clients')
-    conf.recurse('tools')
+    if conf.env['HAVE_JACK_EXAMPLE_TOOLS']:
+        conf.recurse('example-clients')
+        conf.recurse('tools')
 
     # test for the availability of ucontext, and how it should be used
     for t in ['gp_regs', 'uc_regs', 'mc_gregs', 'gregs']:
@@ -839,13 +845,14 @@ def build(bld):
 
     build_drivers(bld)
 
-    bld.recurse('example-clients')
-    bld.recurse('tools')
+    if bld.env['HAVE_JACK_EXAMPLE_TOOLS']:
+        bld.recurse('example-clients')
+        bld.recurse('tools')
 
     if bld.env['IS_LINUX'] or bld.env['IS_FREEBSD']:
         bld.recurse('man')
         bld.recurse('systemd')
-    if not bld.env['IS_WINDOWS']:
+    if not bld.env['IS_WINDOWS'] and bld.env['HAVE_JACK_EXAMPLE_TOOLS']:
         bld.recurse('tests')
     if bld.env['BUILD_JACKDBUS']:
         bld.recurse('dbus')


### PR DESCRIPTION
This allows for omitting the build and installation of libraries, executables and man pages provided by [jack-example-tools](https://github.com/jackaudio/jack-example-tools), by setting the new configure flag `--example-tools` (which currently defaults to `"yes"`) to `"no"`.

Additionally, this PR fixes many syntax problems in the top-level wscript file.

Fixes #805