### PR TITLE
Fix wscripts syntax

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+output-file = flake8.txt
+exclude = .git,waflib,autooptions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
         apt-get source -d jackd2
         tar xf *.debian.tar.xz
         rm -rf debian/source
-        dch -M -b -v "$(cat wscript | awk 'sub("VERSION=","")' | tr -d "'")~$(date +"%Y%m%d")git${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}" -D focal "automated build"
+        dch -M -b -v "$(cat wscript | awk 'sub("^VERSION = ","")' | tr -d "'")~$(date +"%Y%m%d")git${{ github.event.pull_request.number || steps.slug.outputs.sha8 }}" -D focal "automated build"
         debuild -rfakeroot --no-lintian || true
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+---
+
+name: Test files
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install flake8
+      - name: Lint with flake8
+        run: flake8

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 *.dll
 *.pyc
 *.pkg
+flake8.txt
 codeBlocks
 /android/.server/
 /android/.client/

--- a/common/wscript
+++ b/common/wscript
@@ -1,8 +1,8 @@
 #! /usr/bin/python3
 # encoding: utf-8
 
-import re
 import os
+
 
 def configure(conf):
     conf.env['BUILD_NETLIB'] = conf.env['SAMPLERATE']
@@ -11,17 +11,20 @@ def configure(conf):
     if conf.env['IS_WINDOWS']:
         try:
             conf.check(header_name='regex.h', lib='regex', uselib_store='REGEX', define_name='HAVE_REGEX_H')
-        except:
+        except Exception:
             conf.check(header_name='tre/regex.h', lib='tre', uselib_store='REGEX', define_name='HAVE_TRE_REGEX_H')
         conf.check(header_name='winsock2.h', lib='ws2_32', uselib_store='WS2_32', define_name='HAVE_WINSOCK2_H')
-        conf.check(header_name=['windows.h', 'mmsystem.h'], lib='winmm', uselib_store='WINMM', define_name='HAVE_MMSYSTEM_H')
+        conf.check(
+            header_name=['windows.h', 'mmsystem.h'], lib='winmm', uselib_store='WINMM', define_name='HAVE_MMSYSTEM_H'
+        )
         conf.check(header_name=['windows.h', 'psapi.h'], lib='psapi', uselib_store='PSAPI', define_name='HAVE_PSAPI_H')
 
-def create_jack_process_obj(bld, target, sources, uselib = None, framework = None):
-    process = bld(features = ['cxx', 'cxxshlib'])
+
+def create_jack_process_obj(bld, target, sources, uselib=None, framework=None):
+    process = bld(features=['cxx', 'cxxshlib'])
     if not bld.env['IS_WINDOWS']:
         process.env['cxxshlib_PATTERN'] = '%s.so'
-    process.defines  = ['HAVE_CONFIG_H','SERVER_SIDE']
+    process.defines = ['HAVE_CONFIG_H', 'SERVER_SIDE']
     if bld.env['IS_MACOSX']:
         if framework:
             process.framework = framework
@@ -35,14 +38,15 @@ def create_jack_process_obj(bld, target, sources, uselib = None, framework = Non
     if bld.env['IS_WINDOWS']:
         env_includes = ['../windows', '../windows/portaudio']
     process.includes = ['.'] + env_includes + ['jack', '..']
-    process.name     = target
-    process.target   = target
-    process.source   = sources
+    process.name = target
+    process.target = target
+    process.source = sources
     if bld.env['IS_LINUX'] or bld.env['IS_MACOSX'] or bld.env['IS_FREEBSD']:
         process.env.append_value('CPPFLAGS', '-fvisibility=hidden')
     process.install_path = '${ADDON_DIR}/'
     process.use = [uselib.name]
     return process
+
 
 def build(bld):
     common_libsources = [
@@ -113,13 +117,13 @@ def build(bld):
             'JackDebugClient.cpp',
             'timestamps.c',
             'promiscuous.c',
-           '../posix/JackPosixThread.cpp',
-           '../posix/JackFifo.cpp',
-           '../posix/JackPosixProcessSync.cpp',
-           '../posix/JackPosixMutex.cpp',
-           '../posix/JackSocket.cpp',
-           '../solaris/JackSolarisTime.c',
-           ]
+            '../posix/JackPosixThread.cpp',
+            '../posix/JackFifo.cpp',
+            '../posix/JackPosixProcessSync.cpp',
+            '../posix/JackPosixMutex.cpp',
+            '../posix/JackSocket.cpp',
+            '../solaris/JackSolarisTime.c',
+        ]
         includes = ['../solaris', '../posix'] + includes
         uselib.append('RT')
 
@@ -147,7 +151,7 @@ def build(bld):
             '../windows/JackWinThread.cpp',
             '../windows/JackWinTime.c',
             ]
-        includes = ['../windows' ] + includes
+        includes = ['../windows'] + includes
         libsuffix = "64" if (bld.env['DEST_CPU'] == "x86_64" and not bld.variant) else ""
         buildbindir = os.path.join('..', bld.path.get_bld().srcpath().rstrip(bld.path.srcpath()))
         staticbuild = bool('BUILD_STATIC' in bld.env and bld.env['BUILD_STATIC'])
@@ -159,7 +163,7 @@ def build(bld):
     else:
         libsuffix = ""
 
-    clientlib = bld(features = ['c', 'cxx', 'cxxshlib', 'cshlib'])
+    clientlib = bld(features=['c', 'cxx', 'cxxshlib', 'cshlib'])
     if bld.env['IS_MACOSX']:
         clientlib.framework = ['CoreAudio', 'Accelerate']
     clientlib.defines = 'HAVE_CONFIG_H'
@@ -243,10 +247,10 @@ def build(bld):
         # we don't want to build other stuff in this variant
         return
 
-    serverlib = bld(features = ['c', 'cxx', 'cxxshlib', 'cshlib'])
+    serverlib = bld(features=['c', 'cxx', 'cxxshlib', 'cshlib'])
     if bld.env['IS_MACOSX']:
         serverlib.framework = ['CoreAudio', 'CoreFoundation', 'Accelerate']
-    serverlib.defines = ['HAVE_CONFIG_H','SERVER_SIDE']
+    serverlib.defines = ['HAVE_CONFIG_H', 'SERVER_SIDE']
     serverlib.includes = includes
     serverlib.name = 'serverlib'
     serverlib.target = 'jackserver'+libsuffix
@@ -358,10 +362,10 @@ def build(bld):
         serverlib.env.append_value('LINKFLAGS', '-lnsl -lsocket')
 
     if bld.env['BUILD_NETLIB']:
-        netlib = bld(features = ['c', 'cxx', 'cxxshlib', 'cshlib'])
+        netlib = bld(features=['c', 'cxx', 'cxxshlib', 'cshlib'])
         if bld.env['IS_MACOSX']:
-            netlib.framework =  ['CoreAudio']
-        netlib.defines = ['HAVE_CONFIG_H','SERVER_SIDE']
+            netlib.framework = ['CoreAudio']
+        netlib.defines = ['HAVE_CONFIG_H', 'SERVER_SIDE']
         netlib.includes = includes
         netlib.name = 'netlib'
         netlib.target = 'jacknet'+libsuffix
@@ -391,24 +395,49 @@ def build(bld):
             'ringbuffer.c']
 
         if bld.env['IS_LINUX']:
-            netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../linux/JackLinuxTime.c']
+            netlib.source += [
+                '../posix/JackNetUnixSocket.cpp',
+                '../posix/JackPosixThread.cpp',
+                '../posix/JackPosixMutex.cpp',
+                '../linux/JackLinuxTime.c',
+            ]
             netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
         if bld.env['IS_FREEBSD']:
-            netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../linux/JackLinuxTime.c']
+            netlib.source += [
+                '../posix/JackNetUnixSocket.cpp',
+                '../posix/JackPosixThread.cpp',
+                '../posix/JackPosixMutex.cpp',
+                '../linux/JackLinuxTime.c',
+            ]
             netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
         if bld.env['IS_SUN']:
-            netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../solaris/JackSolarisTime.c']
+            netlib.source += [
+                '../posix/JackNetUnixSocket.cpp',
+                '../posix/JackPosixThread.cpp',
+                '../posix/JackPosixMutex.cpp',
+                '../solaris/JackSolarisTime.c',
+            ]
             netlib.env.append_value('CPPFLAGS', '-fvisibility=hidden')
 
-
         if bld.env['IS_MACOSX']:
-            netlib.source += ['../posix/JackNetUnixSocket.cpp','../posix/JackPosixThread.cpp', '../posix/JackPosixMutex.cpp', '../macosx/JackMachThread.mm', '../macosx/JackMachTime.c']
+            netlib.source += [
+                '../posix/JackNetUnixSocket.cpp',
+                '../posix/JackPosixThread.cpp',
+                '../posix/JackPosixMutex.cpp',
+                '../macosx/JackMachThread.mm',
+                '../macosx/JackMachTime.c',
+            ]
             netlib.env.append_value('LINKFLAGS', '-single_module')
 
         if bld.env['IS_WINDOWS']:
-            netlib.source += ['../windows/JackNetWinSocket.cpp','../windows/JackWinThread.cpp', '../windows/JackMMCSS.cpp', '../windows/JackWinTime.c']
+            netlib.source += [
+                '../windows/JackNetWinSocket.cpp',
+                '../windows/JackWinThread.cpp',
+                '../windows/JackMMCSS.cpp',
+                '../windows/JackWinTime.c',
+            ]
 
         if bld.env['IS_MACOSX']:
             netlib.cnum = bld.env['JACK_API_VERSION']
@@ -441,45 +470,48 @@ def build(bld):
          ]
 
     if bld.env['BUILD_ADAPTER'] and bld.env['IS_MACOSX']:
-         audio_adapter_sources += ['../macosx/coreaudio/JackCoreAudioAdapter.mm']
-         process = create_jack_process_obj(bld,
-              'audioadapter',
-              audio_adapter_sources,
-              serverlib,
-              framework = [
-                      'CoreAudio',
-                      'AudioUnit',
-                      'AudioToolbox',
-                      'CoreServices'
-              ]
-         )
-         process.use += ['SAMPLERATE']
+        audio_adapter_sources += ['../macosx/coreaudio/JackCoreAudioAdapter.mm']
+        process = create_jack_process_obj(
+            bld,
+            'audioadapter',
+            audio_adapter_sources,
+            serverlib,
+            framework=[
+                'CoreAudio',
+                'AudioUnit',
+                'AudioToolbox',
+                'CoreServices',
+            ]
+        )
+        process.use += ['SAMPLERATE']
 
     if bld.env['BUILD_ADAPTER'] and bld.env['IS_LINUX'] and bld.env['BUILD_DRIVER_ALSA']:
-         audio_adapter_sources += ['../linux/alsa/JackAlsaAdapter.cpp']
-         process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
-         process.use += ['ALSA', 'SAMPLERATE']
+        audio_adapter_sources += ['../linux/alsa/JackAlsaAdapter.cpp']
+        process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
+        process.use += ['ALSA', 'SAMPLERATE']
 
     if bld.env['BUILD_ADAPTER'] and (bld.env['IS_SUN'] or bld.env['IS_FREEBSD']):
-         audio_adapter_sources += ['../solaris/oss/JackOSSAdapter.cpp', 'memops.c']
-         process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
-         process.use += 'SAMPLERATE'
+        audio_adapter_sources += ['../solaris/oss/JackOSSAdapter.cpp', 'memops.c']
+        process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
+        process.use += 'SAMPLERATE'
 
     if bld.env['BUILD_ADAPTER'] and bld.env['IS_WINDOWS']:
-         audio_adapter_sources += ['../windows/portaudio/JackPortAudioAdapter.cpp', '../windows/portaudio/JackPortAudioDevices.cpp']
-         process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
-         process.use += ['SAMPLERATE', 'PORTAUDIO']
-
+        audio_adapter_sources += [
+            '../windows/portaudio/JackPortAudioAdapter.cpp',
+            '../windows/portaudio/JackPortAudioDevices.cpp',
+        ]
+        process = create_jack_process_obj(bld, 'audioadapter', audio_adapter_sources, serverlib)
+        process.use += ['SAMPLERATE', 'PORTAUDIO']
 
     bld.install_files('${PREFIX}/include/jack', bld.path.ant_glob('jack/*.h'))
 
     # process jack.pc.in -> jack.pc
-    obj = bld(
-        features = 'subst_pc',
-        source = '../jack.pc.in',
-        target = 'jack.pc',
-        install_path = '${PKGCONFDIR}',
-        INCLUDEDIR = os.path.normpath(bld.env['PREFIX'] + '/include'),
-        CLIENTLIB = clientlib.target,
-        SERVERLIB = serverlib.target,
-        )
+    bld(
+        features='subst_pc',
+        source='../jack.pc.in',
+        target='jack.pc',
+        install_path='${PKGCONFDIR}',
+        INCLUDEDIR=os.path.normpath(bld.env['PREFIX'] + '/include'),
+        CLIENTLIB=clientlib.target,
+        SERVERLIB=serverlib.target,
+    )

--- a/compat/alloca/wscript
+++ b/compat/alloca/wscript
@@ -19,14 +19,17 @@
 
 from waflib import Errors
 
+
 def options(opt):
     pass
+
 
 def configure(conf):
     try:
         conf.check(header_name='alloca.h')
     except Errors.ConfigurationError:
         conf.env.append_unique('INCLUDES', conf.path.abspath())
+
 
 def build(bld):
     pass

--- a/compat/wscript
+++ b/compat/wscript
@@ -19,6 +19,7 @@
 
 import os
 
+
 def get_subdirs(ctx):
     """
     Get the compatibility module subirectories.
@@ -37,6 +38,7 @@ def get_subdirs(ctx):
             subdirs.append(entry)
     return subdirs
 
+
 def recurse_into_subdirs(ctx):
     """
     Recurse into compatibility module subdirectories.
@@ -47,11 +49,14 @@ def recurse_into_subdirs(ctx):
     for x in get_subdirs(ctx):
         ctx.recurse(x)
 
+
 def options(opt):
     recurse_into_subdirs(opt)
 
+
 def configure(conf):
     recurse_into_subdirs(conf)
+
 
 def build(bld):
     recurse_into_subdirs(bld)

--- a/dbus/wscript
+++ b/dbus/wscript
@@ -2,24 +2,34 @@
 # encoding: utf-8
 
 import os.path
-import re # subst_func
 
 from waflib import Logs, Options
 
+
 def options(opt):
-    opt.add_option('--enable-pkg-config-dbus-service-dir', action='store_true', default=False, help='force D-Bus service install dir to be one returned by pkg-config')
+    opt.add_option(
+        '--enable-pkg-config-dbus-service-dir',
+        action='store_true',
+        default=False,
+        help='force D-Bus service install dir to be one returned by pkg-config',
+    )
+
 
 def configure(conf):
     conf.env['BUILD_JACKDBUS'] = False
     conf.define('JACK_VERSION', conf.env['JACK_VERSION'])
 
     if not conf.check_cfg(package='dbus-1 >= 1.0.0', args='--cflags --libs', mandatory=False):
-        print(Logs.colors.RED + 'ERROR !! jackdbus will not be built because libdbus-dev is missing' + Logs.colors.NORMAL)
+        print(
+            Logs.colors.RED + 'ERROR !! jackdbus will not be built because libdbus-dev is missing' + Logs.colors.NORMAL
+        )
         return
 
     dbus_dir = conf.check_cfg(package='dbus-1', args='--variable=session_bus_services_dir')
     if not dbus_dir:
-        print(Logs.colors.RED + 'ERROR !! jackdbus will not be built because service dir is unknown' + Logs.colors.NORMAL)
+        print(
+            Logs.colors.RED + 'ERROR !! jackdbus will not be built because service dir is unknown' + Logs.colors.NORMAL
+        )
         return
 
     dbus_dir = dbus_dir.strip()
@@ -36,8 +46,9 @@ def configure(conf):
 
     conf.env['BUILD_JACKDBUS'] = True
 
+
 def build(bld):
-    obj = bld(features = ['c', 'cprogram'], idx=17)
+    obj = bld(features=['c', 'cprogram'], idx=17)
     if bld.env['IS_LINUX']:
         sysdeps_dbus_include = ['../linux', '../posix']
     if bld.env['IS_FREEBSD']:
@@ -46,7 +57,7 @@ def build(bld):
         sysdeps_dbus_include = ['../macosx', '../posix']
 
     obj.includes = sysdeps_dbus_include + ['.', '../', '../common', '../common/jack']
-    obj.defines = ['HAVE_CONFIG_H','SERVER_SIDE']
+    obj.defines = ['HAVE_CONFIG_H', 'SERVER_SIDE']
     obj.source = [
         'jackdbus.c',
         'controller.c',
@@ -59,7 +70,6 @@ def build(bld):
         'controller_iface_transport.c',
         'xml.c',
         'xml_expat.c',
-        #'xml_nop.c',
         'xml_write_raw.c',
         'sigsegv.c',
         'reserve.c',
@@ -84,11 +94,11 @@ def build(bld):
 
     # process org.jackaudio.service.in -> org.jackaudio.service
     obj = bld(
-            features = 'subst',
-            source = 'org.jackaudio.service.in',
-            target = 'org.jackaudio.service',
-            install_path = '${DBUS_SERVICES_DIR}/',
-            BINDIR = bld.env['PREFIX'] + '/bin')
+            features='subst',
+            source='org.jackaudio.service.in',
+            target='org.jackaudio.service',
+            install_path='${DBUS_SERVICES_DIR}/',
+            BINDIR=bld.env['PREFIX'] + '/bin')
 
     if not bld.env['IS_WINDOWS']:
         bld.install_files('${PREFIX}/bin', 'jack_control', chmod=0o755)

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -2,29 +2,31 @@
 # encoding: utf-8
 
 example_programs = {
-    'jack_cpu_load' : 'cpu_load.c',
-    'jack_latent_client' : 'latent_client.c',
-    'jack_metro' : 'metro.c',
-    'jack_midi_latency_test' : 'midi_latency_test.c',
-    'jack_midiseq' : 'midiseq.c',
-    'jack_midisine' : 'midisine.c',
-    'jack_net_master' : 'netmaster.c',
-    'jack_net_slave' : 'netslave.c',
-    'jack_server_control' : 'server_control.cpp',
-    'jack_showtime' : 'showtime.c',
-    'jack_simdtests' : 'simdtests.cpp',
-    'jack_simple_client' : 'simple_client.c',
-    'jack_simple_session_client' : 'simple_session_client.c',
-    'jack_thru' : 'thru_client.c',
-    'jack_zombie' : 'zombie.c',
+    'jack_cpu_load': 'cpu_load.c',
+    'jack_latent_client': 'latent_client.c',
+    'jack_metro': 'metro.c',
+    'jack_midi_latency_test': 'midi_latency_test.c',
+    'jack_midiseq': 'midiseq.c',
+    'jack_midisine': 'midisine.c',
+    'jack_net_master': 'netmaster.c',
+    'jack_net_slave': 'netslave.c',
+    'jack_server_control': 'server_control.cpp',
+    'jack_showtime': 'showtime.c',
+    'jack_simdtests': 'simdtests.cpp',
+    'jack_simple_client': 'simple_client.c',
+    'jack_simple_session_client': 'simple_session_client.c',
+    'jack_thru': 'thru_client.c',
+    'jack_zombie': 'zombie.c',
     }
 
 example_libs = {
-    'inprocess' : 'inprocess.c',
-    }
+    'inprocess': 'inprocess.c',
+}
+
 
 def configure(conf):
     conf.env['BUILD_EXAMPLE_CLIENT_REC'] = conf.env['SNDFILE']
+
 
 def build(bld):
     if bld.env['IS_LINUX']:
@@ -57,9 +59,9 @@ def build(bld):
             ftrs = 'c cprogram'
 
         if bld.env['IS_MACOSX']:
-            prog = bld(features = ftrs, framework = ['Foundation'])
+            prog = bld(features=ftrs, framework=['Foundation'])
         else:
-            prog = bld(features = ftrs)
+            prog = bld(features=ftrs)
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = example_program_source
         prog.use = use
@@ -71,13 +73,11 @@ def build(bld):
             prog.use += ['M']
         if bld.env['IS_WINDOWS'] and bld.env['BUILD_STATIC']:
             prog.env['LIB_PTHREAD'] = [':libwinpthread.a']
-        #prog.cflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
-        #prog.cxxflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
 
         prog.target = example_program
 
     if bld.env['BUILD_EXAMPLE_CLIENT_REC']:
-        prog = bld(features = 'c cprogram')
+        prog = bld(features='c cprogram')
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = 'capture_client.c'
         prog.use = ['clientlib']
@@ -96,7 +96,7 @@ def build(bld):
         prog.target = 'jack_rec'
 
     for example_lib, example_lib_source in list(example_libs.items()):
-        lib = bld(features = 'c cshlib')
+        lib = bld(features='c cshlib')
         if not bld.env['IS_WINDOWS']:
             lib.env['cshlib_PATTERN'] = '%s.so'
         lib.includes = os_incdir + ['../common/jack', '../common']

--- a/tests/wscript
+++ b/tests/wscript
@@ -3,30 +3,30 @@
 
 test_programs = {
     # For testing purposes
-    #'synchroClient': ['testSynchroClient.cpp'],
-    #'synchroServer': ['testSynchroServer.cpp'],
-    #'synchroServerClient': ['testSynchroServerClient.cpp'],
-    #'testSem': ['testSem.cpp'],
+    # 'synchroClient': ['testSynchroClient.cpp'],
+    # 'synchroServer': ['testSynchroServer.cpp'],
+    # 'synchroServerClient': ['testSynchroServerClient.cpp'],
+    # 'testSem': ['testSem.cpp'],
     'jack_test': ['test.cpp'],
     'jack_cpu': ['cpu.c'],
     'jack_iodelay': ['iodelay.cpp'],
-    'jack_multiple_metro' : ['external_metro.cpp'],
+    'jack_multiple_metro': ['external_metro.cpp'],
     }
+
 
 def build(bld):
     for test_program, test_program_sources in list(test_programs.items()):
-        prog = bld(features = 'cxx cxxprogram')
+        prog = bld(features='cxx cxxprogram')
         if bld.env['IS_MACOSX']:
-            prog.includes = ['..','../macosx', '../posix', '../common/jack', '../common']
+            prog.includes = ['..', '../macosx', '../posix', '../common/jack', '../common']
         if bld.env['IS_LINUX']:
-            prog.includes = ['..','../linux', '../posix', '../common/jack', '../common']
+            prog.includes = ['..', '../linux', '../posix', '../common/jack', '../common']
         if bld.env['IS_FREEBSD']:
-            prog.includes = ['..','../freebsd', '../posix', '../common/jack', '../common']
+            prog.includes = ['..', '../freebsd', '../posix', '../common/jack', '../common']
         if bld.env['IS_SUN']:
-            prog.includes = ['..','../solaris', '../posix', '../common/jack', '../common']
+            prog.includes = ['..', '../solaris', '../posix', '../common/jack', '../common']
         prog.source = test_program_sources
         if bld.env['IS_LINUX']:
             prog.uselib = 'RT'
         prog.use = 'clientlib'
         prog.target = test_program
-        #prog.cxxflags = ['-Wno-deprecated-declarations']

--- a/tools/wscript
+++ b/tools/wscript
@@ -2,27 +2,29 @@
 # encoding: utf-8
 
 example_tools = {
-    'jack_alias' : 'alias.c',
-    'jack_bufsize' : 'bufsize.c',
-    'jack_connect' : 'connect.c',
-    'jack_evmon' : 'evmon.c',
-    'jack_freewheel' : 'freewheel.c',
-    'jack_load' : 'ipload.c',
-    'jack_lsp' : 'lsp.c',
-    'jack_midi_dump' : 'midi_dump.c',
-    'jack_monitor_client' : 'monitor_client.c',
-    'jack_property' : 'property.c',
-    'jack_samplerate' : 'samplerate.c',
-    'jack_session_notify' : 'session_notify.c',
-    'jack_unload' : 'ipunload.c',
-    'jack_wait' : 'wait.c',
+    'jack_alias': 'alias.c',
+    'jack_bufsize': 'bufsize.c',
+    'jack_connect': 'connect.c',
+    'jack_evmon': 'evmon.c',
+    'jack_freewheel': 'freewheel.c',
+    'jack_load': 'ipload.c',
+    'jack_lsp': 'lsp.c',
+    'jack_midi_dump': 'midi_dump.c',
+    'jack_monitor_client': 'monitor_client.c',
+    'jack_property': 'property.c',
+    'jack_samplerate': 'samplerate.c',
+    'jack_session_notify': 'session_notify.c',
+    'jack_unload': 'ipunload.c',
+    'jack_wait': 'wait.c',
     }
+
 
 def configure(conf):
     conf.env['BUILD_TOOL_ALSA_IO'] = conf.env['SAMPLERATE'] and conf.env['BUILD_DRIVER_ALSA']
     conf.env['BUILD_TOOL_CLIENT_TRANSPORT'] = conf.env['READLINE']
     conf.env['BUILD_TOOL_CLIENT_NETSOURCE'] = conf.env['CELT'] or conf.env['OPUS']
     conf.env['BUILD_TOOL_ZALSA'] = conf.env['ZALSA']
+
 
 def build(bld):
     if bld.env['IS_LINUX']:
@@ -37,7 +39,7 @@ def build(bld):
         os_incdir = ['../windows']
     for example_tool, example_tool_source in list(example_tools.items()):
         if bld.env['IS_MACOSX']:
-            prog = bld(features='c cprogram', framework = ['Foundation'])
+            prog = bld(features='c cprogram', framework=['Foundation'])
         else:
             prog = bld(features='c cprogram')
         prog.includes = os_incdir + ['../common/jack', '../common']
@@ -49,13 +51,13 @@ def build(bld):
             prog.use += ['M']
         if bld.env['IS_WINDOWS'] and bld.env['BUILD_STATIC']:
             prog.env['LIB_PTHREAD'] = [':libwinpthread.a']
-        #prog.cflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
-        #prog.cxxflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
+        # prog.cflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
+        # prog.cxxflags = ['-Wno-deprecated-declarations', '-Wno-misleading-indentation']
 
         prog.target = example_tool
 
     if bld.env['BUILD_TOOL_CLIENT_TRANSPORT']:
-        prog = bld(features = 'c cprogram')
+        prog = bld(features='c cprogram')
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = 'transport.c'
         prog.use = ['clientlib']
@@ -70,7 +72,7 @@ def build(bld):
         prog.target = 'jack_transport'
 
     if bld.env['BUILD_TOOL_CLIENT_NETSOURCE']:
-        prog = bld(features = 'c cprogram')
+        prog = bld(features='c cprogram')
         prog.includes = os_incdir + ['.', '..', '../common/jack', '../common']
         prog.source = ['netsource.c', '../common/netjack_packet.c']
         prog.env.append_value('CFLAGS', '-DNO_JACK_ERROR')
@@ -79,14 +81,14 @@ def build(bld):
         prog.defines = ['HAVE_CONFIG_H']
 
     if bld.env['IS_LINUX'] and bld.env['BUILD_TOOL_ALSA_IO']:
-        prog = bld(features = 'c cprogram')
+        prog = bld(features='c cprogram')
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = ['alsa_in.c', '../common/memops.c']
         prog.env.append_value('CFLAGS', '-DNO_JACK_ERROR')
         prog.use = ['clientlib', 'ALSA', 'SAMPLERATE', 'M']
         prog.target = 'alsa_in'
 
-        prog = bld(features = 'c cprogram')
+        prog = bld(features='c cprogram')
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = ['alsa_out.c', '../common/memops.c']
         prog.env.append_value('CFLAGS', '-DNO_JACK_ERROR')
@@ -94,20 +96,32 @@ def build(bld):
         prog.target = 'alsa_out'
 
     if bld.env['IS_LINUX'] and bld.env['BUILD_TOOL_ZALSA']:
-        prog = bld(features = ['cxx', 'cxxshlib'])
-        prog.defines = ['HAVE_CONFIG_H','SERVER_SIDE','APPNAME="zalsa_in"','VERSION="0.4.0"']
+        prog = bld(features=['cxx', 'cxxshlib'])
+        prog.defines = ['HAVE_CONFIG_H', 'SERVER_SIDE', 'APPNAME="zalsa_in"', 'VERSION="0.4.0"']
         prog.install_path = '${ADDON_DIR}/'
         prog.includes = os_incdir + ['../common/jack', '../common', 'zalsa']
-        prog.source = ['zalsa/zita-a2j.cc', 'zalsa/alsathread.cc', 'zalsa/jackclient.cc', 'zalsa/pxthread.cc', 'zalsa/lfqueue.cc']
+        prog.source = [
+            'zalsa/zita-a2j.cc',
+            'zalsa/alsathread.cc',
+            'zalsa/jackclient.cc',
+            'zalsa/pxthread.cc',
+            'zalsa/lfqueue.cc',
+        ]
         prog.target = 'zalsa_in'
         prog.use = ['ZITA-ALSA-PCMI', 'ZITA-RESAMPLER', 'ALSA', 'M', 'RT', 'serverlib']
         prog.env['cxxshlib_PATTERN'] = '%s.so'
 
-        prog = bld(features = ['cxx', 'cxxshlib'])
-        prog.defines = ['HAVE_CONFIG_H','SERVER_SIDE','APPNAME="zalsa_out"','VERSION="0.4.0"']
+        prog = bld(features=['cxx', 'cxxshlib'])
+        prog.defines = ['HAVE_CONFIG_H', 'SERVER_SIDE', 'APPNAME="zalsa_out"', 'VERSION="0.4.0"']
         prog.install_path = '${ADDON_DIR}/'
         prog.includes = os_incdir + ['../common/jack', '../common', 'zalsa']
-        prog.source = ['zalsa/zita-j2a.cc', 'zalsa/alsathread.cc', 'zalsa/jackclient.cc', 'zalsa/pxthread.cc', 'zalsa/lfqueue.cc']
+        prog.source = [
+            'zalsa/zita-j2a.cc',
+            'zalsa/alsathread.cc',
+            'zalsa/jackclient.cc',
+            'zalsa/pxthread.cc',
+            'zalsa/lfqueue.cc',
+        ]
         prog.target = 'zalsa_out'
         prog.use = ['ZITA-ALSA-PCMI', 'ZITA-RESAMPLER', 'ALSA', 'M', 'RT', 'serverlib']
         prog.env['cxxshlib_PATTERN'] = '%s.so'

--- a/wscript
+++ b/wscript
@@ -6,11 +6,11 @@ import os
 import shutil
 import sys
 
-from waflib import Logs, Options, Task, Utils
+from waflib import Logs, Options, TaskGen
 from waflib.Build import BuildContext, CleanContext, InstallContext, UninstallContext
 
-VERSION='1.9.20'
-APPNAME='jack'
+VERSION = '1.9.20'
+APPNAME = 'jack'
 JACK_API_VERSION = '0.1.0'
 
 # these variables are mandatory ('/' are converted automatically)
@@ -20,11 +20,13 @@ out = 'build'
 # lib32 variant name used when building in mixed mode
 lib32 = 'lib32'
 
+
 def display_feature(conf, msg, build):
     if build:
         conf.msg(msg, 'yes', color='GREEN')
     else:
         conf.msg(msg, 'no', color='YELLOW')
+
 
 def check_for_celt(conf):
     found = False
@@ -45,36 +47,69 @@ def check_for_celt(conf):
     if not found:
         raise conf.errors.ConfigurationError
 
+
 def options(opt):
     # options provided by the modules
     opt.load('compiler_cxx')
     opt.load('compiler_c')
-    opt.load('autooptions');
+    opt.load('autooptions')
 
     opt.load('xcode6')
 
     opt.recurse('compat')
 
     # install directories
-    opt.add_option('--htmldir', type='string', default=None, help='HTML documentation directory [Default: <prefix>/share/jack-audio-connection-kit/reference/html/')
+    opt.add_option(
+        '--htmldir',
+        type='string',
+        default=None,
+        help='HTML documentation directory [Default: <prefix>/share/jack-audio-connection-kit/reference/html/',
+    )
     opt.add_option('--libdir', type='string', help='Library directory [Default: <prefix>/lib]')
     opt.add_option('--libdir32', type='string', help='32bit Library directory [Default: <prefix>/lib32]')
     opt.add_option('--pkgconfigdir', type='string', help='pkg-config file directory [Default: <libdir>/pkgconfig]')
     opt.add_option('--mandir', type='string', help='Manpage directory [Default: <prefix>/share/man/man1]')
 
     # options affecting binaries
-    opt.add_option('--platform', type='string', default=sys.platform, help='Target platform for cross-compiling, e.g. cygwin or win32')
+    opt.add_option(
+        '--platform',
+        type='string',
+        default=sys.platform,
+        help='Target platform for cross-compiling, e.g. cygwin or win32',
+    )
     opt.add_option('--mixed', action='store_true', default=False, help='Build with 32/64 bits mixed mode')
     opt.add_option('--debug', action='store_true', default=False, dest='debug', help='Build debuggable binaries')
-    opt.add_option('--static', action='store_true', default=False, dest='static', help='Build static binaries (Windows only)')
+    opt.add_option(
+        '--static',
+        action='store_true',
+        default=False,
+        dest='static',
+        help='Build static binaries (Windows only)',
+    )
 
     # options affecting general jack functionality
-    opt.add_option('--classic', action='store_true', default=False, help='Force enable standard JACK (jackd) even if D-Bus JACK (jackdbus) is enabled too')
+    opt.add_option(
+        '--classic',
+        action='store_true',
+        default=False,
+        help='Force enable standard JACK (jackd) even if D-Bus JACK (jackdbus) is enabled too',
+    )
     opt.add_option('--dbus', action='store_true', default=False, help='Enable D-Bus JACK (jackdbus)')
-    opt.add_option('--autostart', type='string', default='default', help='Autostart method. Possible values: "default", "classic", "dbus", "none"')
+    opt.add_option(
+        '--autostart',
+        type='string',
+        default='default',
+        help='Autostart method. Possible values: "default", "classic", "dbus", "none"',
+    )
     opt.add_option('--profile', action='store_true', default=False, help='Build with engine profiling')
     opt.add_option('--clients', default=256, type='int', dest='clients', help='Maximum number of JACK clients')
-    opt.add_option('--ports-per-application', default=2048, type='int', dest='application_ports', help='Maximum number of ports per application')
+    opt.add_option(
+        '--ports-per-application',
+        default=2048,
+        type='int',
+        dest='application_ports',
+        help='Maximum number of ports per application',
+    )
     opt.add_option('--systemd-unit', action='store_true', default=False, help='Install systemd units.')
 
     opt.set_auto_options_define('HAVE_%s')
@@ -115,7 +150,7 @@ def options(opt):
             'portaudio',
             help='Enable Portaudio driver',
             conf_dest='BUILD_DRIVER_PORTAUDIO')
-    portaudio.check(header_name='windows.h') # only build portaudio on windows
+    portaudio.check(header_name='windows.h')  # only build portaudio on windows
     portaudio.check_cfg(
             package='portaudio-2.0 >= 19',
             uselib_store='PORTAUDIO',
@@ -190,6 +225,7 @@ def options(opt):
     # this must be called before the configure phase
     opt.apply_auto_options_hack()
 
+
 def detect_platform(conf):
     # GNU/kFreeBSD and GNU/Hurd are treated as Linux
     platforms = [
@@ -201,12 +237,12 @@ def detect_platform(conf):
         ('IS_WINDOWS', 'Windows', ['cygwin', 'msys', 'win32'])
     ]
 
-    for key,name,strings in platforms:
+    for key, name, strings in platforms:
         conf.env[key] = False
 
     conf.start_msg('Checking platform')
     platform = Options.options.platform
-    for key,name,strings in platforms:
+    for key, name, strings in platforms:
         for s in strings:
             if platform.startswith(s):
                 conf.env[key] = True
@@ -245,16 +281,16 @@ def configure(conf):
         conf.check(lib='aften', uselib='AFTEN', define_name='AFTEN')
         conf.check_cxx(
             fragment=''
-                + '#include <aften/aften.h>\n'
-                + 'int\n'
-                + 'main(void)\n'
-                + '{\n'
-                + 'AftenContext fAftenContext;\n'
-                + 'aften_set_defaults(&fAftenContext);\n'
-                + 'unsigned char *fb;\n'
-                + 'float *buf=new float[10];\n'
-                + 'int res = aften_encode_frame(&fAftenContext, fb, buf, 1);\n'
-                + '}\n',
+            + '#include <aften/aften.h>\n'
+            + 'int\n'
+            + 'main(void)\n'
+            + '{\n'
+            + 'AftenContext fAftenContext;\n'
+            + 'aften_set_defaults(&fAftenContext);\n'
+            + 'unsigned char *fb;\n'
+            + 'float *buf=new float[10];\n'
+            + 'int res = aften_encode_frame(&fAftenContext, fb, buf, 1);\n'
+            + '}\n',
             lib='aften',
             msg='Checking for aften_encode_frame()',
             define_name='HAVE_AFTEN_NEW_API',
@@ -270,15 +306,15 @@ def configure(conf):
     # Check for functions.
     conf.check(
             fragment=''
-                + '#define _GNU_SOURCE\n'
-                + '#include <poll.h>\n'
-                + '#include <signal.h>\n'
-                + '#include <stddef.h>\n'
-                + 'int\n'
-                + 'main(void)\n'
-                + '{\n'
-                + '   ppoll(NULL, 0, NULL, NULL);\n'
-                + '}\n',
+            + '#define _GNU_SOURCE\n'
+            + '#include <poll.h>\n'
+            + '#include <signal.h>\n'
+            + '#include <stddef.h>\n'
+            + 'int\n'
+            + 'main(void)\n'
+            + '{\n'
+            + '   ppoll(NULL, 0, NULL, NULL);\n'
+            + '}\n',
             msg='Checking for ppoll',
             define_name='HAVE_PPOLL',
             mandatory=False)
@@ -292,7 +328,7 @@ def configure(conf):
     conf.recurse('common')
     if Options.options.dbus:
         conf.recurse('dbus')
-        if conf.env['BUILD_JACKDBUS'] != True:
+        if not conf.env['BUILD_JACKDBUS']:
             conf.fatal('jackdbus was explicitly requested but cannot be built')
     if conf.env['IS_LINUX']:
         if Options.options.systemd_unit:
@@ -367,7 +403,7 @@ def configure(conf):
         conf.env.append_unique('CFLAGS', '-g')
         conf.env.append_unique('LINKFLAGS', '-g')
 
-    if not Options.options.autostart in ['default', 'classic', 'dbus', 'none']:
+    if Options.options.autostart not in ['default', 'classic', 'dbus', 'none']:
         conf.fatal('Invalid autostart value "' + Options.options.autostart + '"')
 
     if Options.options.autostart == 'default':
@@ -398,10 +434,10 @@ def configure(conf):
         conf.env['ADDON_DIR'] = conf.env['LIBDIR'] + '/jack'
         if Options.options.platform in ('msys', 'win32'):
             conf.define('ADDON_DIR', 'jack')
-            conf.define('__STDC_FORMAT_MACROS', 1) # for PRIu64
+            conf.define('__STDC_FORMAT_MACROS', 1)  # for PRIu64
         else:
-            # don't define ADDON_DIR in config.h, use the default 'jack' defined in
-            # windows/JackPlatformPlug_os.h
+            # don't define ADDON_DIR in config.h, use the default 'jack'
+            # defined in windows/JackPlatformPlug_os.h
             pass
     else:
         conf.env['ADDON_DIR'] = os.path.normpath(os.path.join(conf.env['LIBDIR'], 'jack'))
@@ -430,7 +466,8 @@ def configure(conf):
 
         if conf.env['IS_WINDOWS'] and conf.env['BUILD_STATIC']:
             def replaceFor32bit(env):
-                for e in env: yield e.replace('x86_64', 'i686', 1)
+                for e in env:
+                    yield e.replace('x86_64', 'i686', 1)
             for env in ('AR', 'CC', 'CXX', 'LINK_CC', 'LINK_CXX'):
                 conf.all_envs[lib32][env] = list(replaceFor32bit(conf.all_envs[lib32][env]))
             conf.all_envs[lib32]['LIB_REGEX'] = ['tre32']
@@ -462,7 +499,7 @@ def configure(conf):
         ('C++ compiler flags', ['CXXFLAGS', 'CPPFLAGS']),
         ('Linker flags',       ['LINKFLAGS', 'LDFLAGS'])
     ]
-    for name,vars in tool_flags:
+    for name, vars in tool_flags:
         flags = []
         for var in vars:
             flags += conf.all_envs[''][var]
@@ -496,18 +533,23 @@ def configure(conf):
             print(Logs.colors.RED + 'WARNING: but service file will be installed in')
             print(Logs.colors.RED + 'WARNING:', end=' ')
             print(Logs.colors.CYAN + conf.env['DBUS_SERVICES_DIR'])
-            print(Logs.colors.RED + 'WARNING: You may need to adjust your D-Bus configuration after installing jackdbus')
+            print(
+                Logs.colors.RED + 'WARNING: You may need to adjust your D-Bus configuration after installing jackdbus'
+            )
             print('WARNING: You can override dbus service install directory')
             print('WARNING: with --enable-pkg-config-dbus-service-dir option to this script')
             print(Logs.colors.NORMAL, end=' ')
     print()
 
+
 def init(ctx):
     for y in (BuildContext, CleanContext, InstallContext, UninstallContext):
-        name = y.__name__.replace('Context','').lower()
+        name = y.__name__.replace('Context', '').lower()
+
         class tmp(y):
             cmd = name + '_' + lib32
             variant = lib32
+
 
 def obj_add_includes(bld, obj):
     if bld.env['BUILD_JACKDBUS']:
@@ -528,15 +570,16 @@ def obj_add_includes(bld, obj):
     if bld.env['IS_WINDOWS']:
         obj.includes += ['windows']
 
+
 # FIXME: Is SERVER_SIDE needed?
 def build_jackd(bld):
     jackd = bld(
-        features = ['cxx', 'cxxprogram'],
-        defines = ['HAVE_CONFIG_H','SERVER_SIDE'],
-        includes = ['.', 'common', 'common/jack'],
-        target = 'jackd',
-        source = ['common/Jackdmp.cpp'],
-        use = ['serverlib', 'SYSTEMD']
+        features=['cxx', 'cxxprogram'],
+        defines=['HAVE_CONFIG_H', 'SERVER_SIDE'],
+        includes=['.', 'common', 'common/jack'],
+        target='jackd',
+        source=['common/Jackdmp.cpp'],
+        use=['serverlib', 'SYSTEMD']
     )
 
     if bld.env['BUILD_JACKDBUS']:
@@ -560,6 +603,7 @@ def build_jackd(bld):
 
     return jackd
 
+
 # FIXME: Is SERVER_SIDE needed?
 def create_driver_obj(bld, **kw):
     if 'use' in kw:
@@ -568,10 +612,10 @@ def create_driver_obj(bld, **kw):
         kw['use'] = ['serverlib']
 
     driver = bld(
-        features = ['c', 'cxx', 'cshlib', 'cxxshlib'],
-        defines = ['HAVE_CONFIG_H', 'SERVER_SIDE'],
-        includes = ['.', 'common', 'common/jack'],
-        install_path = '${ADDON_DIR}/',
+        features=['c', 'cxx', 'cshlib', 'cxxshlib'],
+        defines=['HAVE_CONFIG_H', 'SERVER_SIDE'],
+        includes=['.', 'common', 'common/jack'],
+        install_path='${ADDON_DIR}/',
         **kw)
 
     if bld.env['IS_WINDOWS']:
@@ -582,6 +626,7 @@ def create_driver_obj(bld, **kw):
     obj_add_includes(bld, driver)
 
     return driver
+
 
 def build_drivers(bld):
     # Non-hardware driver sources. Lexically sorted.
@@ -690,103 +735,104 @@ def build_drivers(bld):
     # Create non-hardware driver objects. Lexically sorted.
     create_driver_obj(
         bld,
-        target = 'dummy',
-        source = dummy_src)
+        target='dummy',
+        source=dummy_src)
 
     create_driver_obj(
         bld,
-        target = 'loopback',
-        source = loopback_src)
+        target='loopback',
+        source=loopback_src)
 
     create_driver_obj(
         bld,
-        target = 'net',
-        source = net_src,
-        use = ['CELT'])
+        target='net',
+        source=net_src,
+        use=['CELT'])
 
     create_driver_obj(
         bld,
-        target = 'netone',
-        source = netone_src,
-        use = ['SAMPLERATE', 'CELT'])
+        target='netone',
+        source=netone_src,
+        use=['SAMPLERATE', 'CELT'])
 
     create_driver_obj(
         bld,
-        target = 'proxy',
-        source = proxy_src)
+        target='proxy',
+        source=proxy_src)
 
     # Create hardware driver objects. Lexically sorted after the conditional,
     # e.g. BUILD_DRIVER_ALSA.
     if bld.env['BUILD_DRIVER_ALSA']:
         create_driver_obj(
             bld,
-            target = 'alsa',
-            source = alsa_src,
-            use = ['ALSA'])
+            target='alsa',
+            source=alsa_src,
+            use=['ALSA'])
         create_driver_obj(
             bld,
-            target = 'alsarawmidi',
-            source = alsarawmidi_src,
-            use = ['ALSA'])
+            target='alsarawmidi',
+            source=alsarawmidi_src,
+            use=['ALSA'])
 
     if bld.env['BUILD_DRIVER_FFADO']:
         create_driver_obj(
             bld,
-            target = 'firewire',
-            source = ffado_src,
-            use = ['LIBFFADO'])
+            target='firewire',
+            source=ffado_src,
+            use=['LIBFFADO'])
 
     if bld.env['BUILD_DRIVER_IIO']:
         create_driver_obj(
             bld,
-            target = 'iio',
-            source = iio_src,
-            use = ['GTKIOSTREAM', 'EIGEN3'])
+            target='iio',
+            source=iio_driver_src,
+            use=['GTKIOSTREAM', 'EIGEN3'])
 
     if bld.env['BUILD_DRIVER_PORTAUDIO']:
         create_driver_obj(
             bld,
-            target = 'portaudio',
-            source = portaudio_src,
-            use = ['PORTAUDIO'])
+            target='portaudio',
+            source=portaudio_src,
+            use=['PORTAUDIO'])
 
     if bld.env['BUILD_DRIVER_WINMME']:
         create_driver_obj(
             bld,
-            target = 'winmme',
-            source = winmme_src,
-            use = ['WINMME'])
+            target='winmme',
+            source=winmme_src,
+            use=['WINMME'])
 
     if bld.env['IS_MACOSX']:
         create_driver_obj(
             bld,
-            target = 'coreaudio',
-            source = coreaudio_src,
-            use = ['AFTEN'],
-            framework = ['AudioUnit', 'CoreAudio', 'CoreServices'])
+            target='coreaudio',
+            source=coreaudio_src,
+            use=['AFTEN'],
+            framework=['AudioUnit', 'CoreAudio', 'CoreServices'])
 
         create_driver_obj(
             bld,
-            target = 'coremidi',
-            source = coremidi_src,
-            use = ['serverlib'], # FIXME: Is this needed?
-            framework = ['AudioUnit', 'CoreMIDI', 'CoreServices', 'Foundation'])
+            target='coremidi',
+            source=coremidi_src,
+            use=['serverlib'],  # FIXME: Is this needed?
+            framework=['AudioUnit', 'CoreMIDI', 'CoreServices', 'Foundation'])
 
     if bld.env['IS_FREEBSD']:
         create_driver_obj(
             bld,
-            target = 'oss',
-            source = freebsd_oss_src)
+            target='oss',
+            source=freebsd_oss_src)
 
     if bld.env['IS_SUN']:
         create_driver_obj(
             bld,
-            target = 'boomer',
-            source = boomer_src)
+            target='boomer',
+            source=boomer_src)
         create_driver_obj(
             bld,
-            target = 'oss',
-            source = oss_src)
+            target='oss',
+            source=oss_src)
+
 
 def build(bld):
     if not bld.variant and bld.env['BUILD_WITH_32_64']:
@@ -822,12 +868,12 @@ def build(bld):
         html_build_dir = bld.path.find_or_declare('html').abspath()
 
         bld(
-            features = 'subst',
-            source = 'doxyfile.in',
-            target = 'doxyfile',
-            HTML_BUILD_DIR = html_build_dir,
-            SRCDIR = bld.srcnode.abspath(),
-            VERSION = VERSION
+            features='subst',
+            source='doxyfile.in',
+            target='doxyfile',
+            HTML_BUILD_DIR=html_build_dir,
+            SRCDIR=bld.srcnode.abspath(),
+            VERSION=VERSION
         )
 
         # There are two reasons for logging to doxygen.log and using it as
@@ -843,9 +889,9 @@ def build(bld):
             return task.exec_command(cmd)
 
         bld(
-            rule = doxygen,
-            source = 'doxyfile',
-            target = 'doxygen.log'
+            rule=doxygen,
+            source='doxyfile',
+            target='doxygen.log'
         )
 
         # Determine where to install HTML documentation. Since share_dir is the
@@ -867,19 +913,18 @@ def build(bld):
             Logs.pprint('CYAN', 'Installing doxygen documentation...')
             shutil.copytree(html_build_dir, html_install_dir)
             Logs.pprint('CYAN', 'Installing doxygen documentation done.')
-        elif bld.cmd =='uninstall':
+        elif bld.cmd == 'uninstall':
             Logs.pprint('CYAN', 'Uninstalling doxygen documentation...')
             if os.path.isdir(share_dir):
                 shutil.rmtree(share_dir)
             Logs.pprint('CYAN', 'Uninstalling doxygen documentation done.')
-        elif bld.cmd =='clean':
+        elif bld.cmd == 'clean':
             if os.access(html_build_dir, os.R_OK):
                 Logs.pprint('CYAN', 'Removing doxygen generated documentation...')
                 shutil.rmtree(html_build_dir)
                 Logs.pprint('CYAN', 'Removing doxygen generated documentation done.')
 
 
-from waflib import TaskGen
 @TaskGen.extension('.mm')
 def mm_hook(self, node):
     """Alias .mm files to be compiled the same as .cpp files, gcc will do the right thing."""


### PR DESCRIPTION
This fixes the Python syntax in all wscripts (excluding man/wscript, as it is fixed by #825). The fixes include:

* all wscripts are allowed a line length of 120 chars
* unused imports are removed
* moves file-wide imports to top of file
* general syntax fixes according to flake8 recommendations
* adds a flake8 configuration file and runs flake8 against all wscripts in CI
* allows for the IIO driver to be built (picks up source files correctly)

This allows for better readability and detection of errors. Running flake8 can be included in CI as well.
