### PR TITLE
Fix build of jack-example-tools with waf autooptions

### DIFF
--- a/wscript
+++ b/wscript
@@ -300,7 +300,7 @@ def configure(conf):
         else:
             conf.env['SYSTEMD_USER_UNIT_DIR'] = None
 
-    if conf.env['HAVE_JACK_EXAMPLE_TOOLS']:
+    if conf.env['BUILD_JACK_EXAMPLE_TOOLS']:
         conf.recurse('example-clients')
         conf.recurse('tools')
 
@@ -806,14 +806,14 @@ def build(bld):
 
     build_drivers(bld)
 
-    if bld.env['HAVE_JACK_EXAMPLE_TOOLS']:
+    if bld.env['BUILD_JACK_EXAMPLE_TOOLS']:
         bld.recurse('example-clients')
         bld.recurse('tools')
 
     if bld.env['IS_LINUX'] or bld.env['IS_FREEBSD']:
         bld.recurse('man')
         bld.recurse('systemd')
-    if not bld.env['IS_WINDOWS'] and bld.env['HAVE_JACK_EXAMPLE_TOOLS']:
+    if not bld.env['IS_WINDOWS'] and bld.env['BUILD_JACK_EXAMPLE_TOOLS']:
         bld.recurse('tests')
     if bld.env['BUILD_JACKDBUS']:
         bld.recurse('dbus')


### PR DESCRIPTION
wscript:
In 61a708f2c6873881ae36fa2f01b38a15bfc3f681 a regression has been
introduced, that always leads to not building the jack-example-tools
(even if selected).
This has been introduced due to the use of the wrong configuration
environment `HAVE_JACK_EXAMPLE_TOOLS`, whereas it should have been
`BUILD_JACK_EXAMPLE_TOOLS`.

Related to #805 