### PR TITLE
CI: Add FreeBSD builds through Cirrus CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,29 @@
+task:
+  freebsd_instance:
+    matrix:
+      - image_family: freebsd-12-3
+      - image_family: freebsd-13-0
+
+  environment:
+    CFLAGS: -O2 -pipe -fPIC -fstack-protector-strong -fno-strict-aliasing -I/usr/local/include
+    CPPFLAGS: -O2 -pipe -fPIC -fstack-protector-strong -fno-strict-aliasing -I/usr/local/include
+    LDFLAGS: -lreadline -L/usr/local/lib -fstack-protector-strong
+  prepare_script:
+    - mkdir ${HOME}/install
+
+  matrix:
+    - name: FreeBSD Minimal Build
+      dependencies_script:
+        - pkg install -y pkgconf python3 libsndfile libsamplerate libsysinfo readline expat
+      config_script:
+        - python3 ./waf configure --celt=no --sndfile=yes --samplerate=yes --alsa=no --classic --readline=yes --opus=no --example-tools=no --prefix ${HOME}/install
+    - name: FreeBSD All Options
+      dependencies_script:
+        - pkg install -y pkgconf python3 libsndfile libsamplerate libsysinfo readline alsa-lib dbus expat opus
+      config_script:
+        - python3 ./waf configure --celt=no --sndfile=yes --samplerate=yes --alsa=yes --dbus --classic --autostart=dbus --readline=yes --opus=yes --prefix ${HOME}/install
+
+  build_script:
+    - python3 ./waf
+  install_script:
+    - python3 ./waf install


### PR DESCRIPTION
When the github application Cirrus CI (https://cirrus-ci.org/) is
installed, this build description file adds FreeBSD build checks to
changes and PRs in github.

There are four build tasks currently, a minimal build and one with all
options enabled on two different FreeBSD versions.

Unfortunately I don't see any other option of adding FreeBSD CI builds. But Cirrus CI has been quite unintrusive to me.

You can install the Cirrus CI Application from the Marketplace - choose the _public repositories only_ option (free) and select the repositories that use it. That will add the FreeBSD CI build checks to every change and PR that has this description file.

As a demo you can see what it looks like in my private repo:
https://github.com/0EVSG/jack2/tree/feature/freebsd_cirrus