### PR TITLE
FreeBSD: Add missing OSS option --excl to man page.

### DIFF
--- a/freebsd/oss/JackOSSDriver.cpp
+++ b/freebsd/oss/JackOSSDriver.cpp
@@ -1288,7 +1288,7 @@ SERVER_EXPORT jack_driver_desc_t* driver_get_descriptor()
     jack_driver_descriptor_add_parameter(desc, &filler, "outchannels", 'o', JackDriverParamUInt, &value, NULL, "Playback channels", NULL);
 
     value.i = false;
-    jack_driver_descriptor_add_parameter(desc, &filler, "excl", 'e', JackDriverParamBool, &value, NULL, "Exclusif (O_EXCL) access mode", NULL);
+    jack_driver_descriptor_add_parameter(desc, &filler, "excl", 'e', JackDriverParamBool, &value, NULL, "Exclusive and direct device access", NULL);
 
     strcpy(value.str, OSS_DRIVER_DEF_DEV);
     jack_driver_descriptor_add_parameter(desc, &filler, "capture", 'C', JackDriverParamString, &value, NULL, "Input device", NULL);

--- a/man/jackd.0
+++ b/man/jackd.0
@@ -583,6 +583,13 @@ Whether or not to ignore hardware period size.
 (default: false)
 
 .TP
+\fB\-e, \-\-excl \fIboolean\fR
+Request exclusive and direct access to the sound device.
+This avoids mixing and automatic audio conversion in the
+OSS driver, and the extra latency that comes with that.
+(default: false)
+
+.TP
 \fB\-I, \-\-input\-latency\fR
 Extra input latency (frames). 
 (default: 0)

--- a/solaris/oss/JackOSSDriver.cpp
+++ b/solaris/oss/JackOSSDriver.cpp
@@ -759,7 +759,7 @@ SERVER_EXPORT jack_driver_desc_t* driver_get_descriptor()
     jack_driver_descriptor_add_parameter(desc, &filler, "outchannels", 'o', JackDriverParamUInt, &value, NULL, "Playback channels", NULL);
 
     value.i = false;
-    jack_driver_descriptor_add_parameter(desc, &filler, "excl", 'e', JackDriverParamBool, &value, NULL, "Exclusif (O_EXCL) access mode", NULL);
+    jack_driver_descriptor_add_parameter(desc, &filler, "excl", 'e', JackDriverParamBool, &value, NULL, "Exclusive and direct device access", NULL);
 
     strcpy(value.str, OSS_DRIVER_DEF_DEV);
     jack_driver_descriptor_add_parameter(desc, &filler, "capture", 'C', JackDriverParamString, &value, NULL, "Input device", NULL);


### PR DESCRIPTION
Did a short check of the man page and saw that --excl was missing. The other options seem to be fine, I left out the --device option because it is redundant and its short version -d may be confused with the driver backend -d.

While there, also improve the short description of the excl option in the OSS backend part of usage help and jack_control.

The options of the FreeBSD and Solaris OSS backends are kept compatible, intentionally.

Is there anything more to man page QA, apart from spellcheck?