### PR TITLE
API: Export missing symbols to jack library.

### DIFF
--- a/common/JackError.cpp
+++ b/common/JackError.cpp
@@ -133,5 +133,5 @@ SERVER_EXPORT void silent_jack_error_callback(const char *desc)
 SERVER_EXPORT void silent_jack_info_callback(const char *desc)
 {}
 
-SERVER_EXPORT void (*jack_error_callback)(const char *desc) = &default_jack_error_callback;
-SERVER_EXPORT void (*jack_info_callback)(const char *desc) = &default_jack_info_callback;
+LIB_EXPORT void (*jack_error_callback)(const char *desc) = &default_jack_error_callback;
+LIB_EXPORT void (*jack_info_callback)(const char *desc) = &default_jack_info_callback;

--- a/common/JackError.h
+++ b/common/JackError.h
@@ -35,8 +35,8 @@ extern "C"
     SERVER_EXPORT void jack_info(const char *fmt, ...);
     SERVER_EXPORT void jack_log(const char *fmt, ...);
 
-    SERVER_EXPORT extern void (*jack_error_callback)(const char *desc);
-    SERVER_EXPORT extern void (*jack_info_callback)(const char *desc);
+    LIB_EXPORT extern void (*jack_error_callback)(const char *desc);
+    LIB_EXPORT extern void (*jack_info_callback)(const char *desc);
 
     SERVER_EXPORT extern void default_jack_error_callback(const char *desc);
     SERVER_EXPORT extern void default_jack_info_callback(const char *desc);


### PR DESCRIPTION
The function pointers `jack_error_callback` and `jack_info_callback` are
offered by the jack.h header as non-weak API members, but they were not
exported to the jack library, only to the jackserver library.

This broke the Jack backend of the OpenAl Soft library when switching
from Jack1 to Jack2.

Some archeological references: #226, kcat/openal-soft#138, kcat/openal-soft#139

Alternative solution: Mark `jack_error_callback` and `jack_info_callback` as deprecated and export them as weak symbols. OpenAl Soft library already handles `jack_error_callback` like a weak symbol, and I'm not aware of any other software that is affected.

@falkTX: Do we need some additional reviewers / opinions on that?