### PR TITLE
Fix build of jack-example-tools man pages

### DIFF
--- a/man/wscript
+++ b/man/wscript
@@ -5,6 +5,6 @@
 def build(bld):
     bld.exec_command('cd man ; sh fill_template {} {}'.format(
         bld.env['JACK_VERSION'],
-        bld.env['HAVE_JACK_EXAMPLE_TOOLS'])
+        bld.env['BUILD_JACK_EXAMPLE_TOOLS'])
     )
     bld.install_files(bld.env['MANDIR'], bld.path.ant_glob('*.1'))


### PR DESCRIPTION
Commit e8c0be1ce932bfb99fdd1a50e08fab187efed6ca changed the name
of the configuration environment to build the jack-example-tools,
but forgot to change it for man pages.