### PR TITLE
installer: add qwindowsvistastyle.dll for QJackCtl

### DIFF
--- a/windows/inno/win32.iss
+++ b/windows/inno/win32.iss
@@ -43,6 +43,7 @@ Source: "win32\lib\libjack.dll"; DestDir: "{win}"; Components: jackserver; Flags
 Source: "win32\bin\qjackctl.exe"; DestDir: "{app}\qjackctl"; Components: qjackctl; Flags: ignoreversion;
 Source: "Qt5*.dll"; DestDir: "{app}\qjackctl"; Components: qjackctl; Flags: ignoreversion;
 Source: "qwindows.dll"; DestDir: "{app}\qjackctl\platforms"; Components: qjackctl; Flags: ignoreversion;
+Source: "qwindowsvistastyle.dll"; DestDir: "{app}\qjackctl\styles"; Components: qjackctl; Flags: ignoreversion;
 ; dev
 Source: "win32\include\jack\*.h"; DestDir: "{app}\include\jack"; Components: dev; Flags: ignoreversion;
 Source: "win32\lib\*.a"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;

--- a/windows/inno/win64.iss
+++ b/windows/inno/win64.iss
@@ -45,6 +45,7 @@ Source: "win64\lib32\libjack.dll"; DestDir: "{win}"; Components: jackserver; Fla
 Source: "win64\bin\qjackctl.exe"; DestDir: "{app}\qjackctl"; Components: qjackctl; Flags: ignoreversion;
 Source: "Qt5*.dll"; DestDir: "{app}\qjackctl"; Components: qjackctl; Flags: ignoreversion;
 Source: "qwindows.dll"; DestDir: "{app}\qjackctl\platforms"; Components: qjackctl; Flags: ignoreversion;
+Source: "qwindowsvistastyle.dll"; DestDir: "{app}\qjackctl\styles"; Components: qjackctl; Flags: ignoreversion;
 ; dev
 Source: "win64\include\jack\*.h"; DestDir: "{app}\include\jack"; Components: dev; Flags: ignoreversion;
 Source: "win64\lib\*.a"; DestDir: "{app}\lib"; Components: dev; Flags: ignoreversion;


### PR DESCRIPTION
This DLL is required to have a proper Qt skin on Windows.

For a proper installer build using PawPaw, this PR requires https://github.com/DISTRHO/PawPaw/pull/25.