### PR TITLE
Fixes for selected problems found by llvm scan-build.

### DIFF
--- a/common/JackAPI.cpp
+++ b/common/JackAPI.cpp
@@ -510,7 +510,7 @@ LIB_EXPORT int jack_port_tie(jack_port_t* src, jack_port_t* dst)
         jack_error("jack_port_tie called with ports not belonging to the same client");
         return -1;
     } else {
-        return manager->GetPort(mydst)->Tie(mysrc);
+        return (manager ? manager->GetPort(mydst)->Tie(mysrc) : -1);
     }
 }
 

--- a/common/JackMidiAsyncQueue.cpp
+++ b/common/JackMidiAsyncQueue.cpp
@@ -38,7 +38,7 @@ JackMidiAsyncQueue::JackMidiAsyncQueue(size_t max_bytes, size_t max_messages)
         }
         jack_ringbuffer_free(byte_ring);
     }
-    delete data_buffer;
+    delete[] data_buffer;
     throw std::bad_alloc();
 }
 

--- a/example-clients/midi_latency_test.c
+++ b/example-clients/midi_latency_test.c
@@ -163,7 +163,7 @@ create_semaphore(int id)
         semaphore = NULL;
     }
 #else
-    semaphore = malloc(sizeof(semaphore_t));
+    semaphore = malloc(sizeof(sem_t));
     if (semaphore != NULL) {
         if (sem_init(semaphore, 0, 0)) {
             free(semaphore);


### PR DESCRIPTION
These problems were, amongst others, indicated by llvm scan-build (static analysis):

- Bad deallocation in JackMidiAsyncQueue. Should use delete[] for heap arrays.
- Bad semaphore allocation in midi_latency_test. Allocated pointer size instead of semaphore struct.
  - This should probably also go into jack-example-tools.
- Missing check for graph manager in JackAPI. Check GetGraphManager() for NULL there too.

Don't know if any of these affect real-life usage, but it's a good idea to fix them anyway.