### PR TITLE
Fix alignas() on non-packed architectures (#839).

### DIFF
--- a/common/JackAtomicArrayState.h
+++ b/common/JackAtomicArrayState.h
@@ -122,7 +122,7 @@ class JackAtomicArrayState
         // fState[2] ==> request
 
         T fState[3];
-        alignas(UInt32) volatile AtomicArrayCounter fCounter;
+        alignas(UInt32) alignas(AtomicArrayCounter) volatile AtomicArrayCounter fCounter;
 
         UInt32 WriteNextStateStartAux(int state, bool* result)
         {

--- a/common/JackAtomicState.h
+++ b/common/JackAtomicState.h
@@ -94,7 +94,7 @@ class JackAtomicState
     protected:
 
         T fState[2];
-        alignas(UInt32) volatile AtomicCounter fCounter;
+        alignas(UInt32) alignas(AtomicCounter) volatile AtomicCounter fCounter;
         SInt32 fCallWriteCounter;
 
         UInt32 WriteNextStateStartAux()

--- a/common/JackConnectionManager.h
+++ b/common/JackConnectionManager.h
@@ -417,7 +417,7 @@ class SERVER_EXPORT JackConnectionManager
         JackFixedArray1<PORT_NUM_FOR_CLIENT> fInputPort[CLIENT_NUM];	/*! Table of input port per refnum : to find a refnum for a given port */
         JackFixedArray<PORT_NUM_FOR_CLIENT> fOutputPort[CLIENT_NUM];	/*! Table of output port per refnum : to find a refnum for a given port */
         JackFixedMatrix<CLIENT_NUM> fConnectionRef;						/*! Table of port connections by (refnum , refnum) */
-        alignas(UInt32) JackActivationCount fInputCounter[CLIENT_NUM];	/*! Activation counter per refnum */
+        alignas(UInt32) alignas(JackActivationCount) JackActivationCount fInputCounter[CLIENT_NUM];	/*! Activation counter per refnum */
         JackLoopFeedback<CONNECTION_NUM_FOR_PORT> fLoopFeedback;		/*! Loop feedback connections */
 
         bool IsLoopPathAux(int ref1, int ref2) const;

--- a/common/JackEngineControl.h
+++ b/common/JackEngineControl.h
@@ -64,7 +64,7 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     int fClientPriority;
     int fMaxClientPriority;
     char fServerName[JACK_SERVER_NAME_SIZE+1];
-    alignas(UInt32) JackTransportEngine fTransport;
+    alignas(UInt32) alignas(JackTransportEngine) JackTransportEngine fTransport;
     jack_timer_type_t fClockSource;
     int fDriverNum;
     bool fVerbose;
@@ -86,7 +86,7 @@ struct SERVER_EXPORT JackEngineControl : public JackShmMem
     UInt64 fConstraint;
 
     // Timer
-    alignas(UInt32) JackFrameTimer fFrameTimer;
+    alignas(UInt32) alignas(JackFrameTimer) JackFrameTimer fFrameTimer;
 
 #ifdef JACK_MONITOR
     JackEngineProfiling fProfiler;


### PR DESCRIPTION
Unbreak the build with Clang on architectures where JACK uses non-packed
data structures, like arm64 or powerpc. The alignment errors are exposed
there because:
 * The non-packed data structures require 8 byte alignment.
 * alignas() is not allowed to weaken alignment requirements to 4 bytes.
 * Clang enforces this according to standard, GCC ignores it.

Use an additional alignas() specifier to let the compiler choose between
minimum alignment (packed) and "natural" alignment (non-packed). This is
both standard c++11 and compatible with older GCC, which does not
propagate alignment requirements of packed substructures properly.

To the best of my knowledge, this does not change ABI on any platform.

Please note that JACK explicitly uses packed data structures on MacOS,
that's why it wasn't affected by this problem.