### PR TITLE
pkgconfig: Use predefined variables in Libs and Cflags

### DIFF
--- a/jack.pc.in
+++ b/jack.pc.in
@@ -8,5 +8,5 @@ jack_implementation=jack2
 Name: jack
 Description: the Jack Audio Connection Kit: a low-latency synchronous callback-based media server
 Version: @JACK_VERSION@
-Libs: -L@LIBDIR@ -l@CLIENTLIB@
-Cflags: -I@INCLUDEDIR@
+Libs: -L${libdir} -l@CLIENTLIB@
+Cflags: -I${includedir}


### PR DESCRIPTION
This fixes path relocation in mingw environment. Without this,
libdir and includedir are not shown in pkgconfig output. e.g.
* Without predefined variables:
  - pkgconf -cflags jack: No output
  - pkgconf -libs jack: -ljack64
* With predefined variables:
  - pkgconf -cflags jack: -IC:/msys64/mingw64/include
  - pkgconf -libs jack: -LC:/msys64/mingw64/lib -ljack64

Also official documentation suggests to use variables
https://people.freedesktop.org/~dbn/pkg-config-guide.html