### PR TITLE
Remove register keyword which is deprecated in C++17

### DIFF
--- a/common/JackAudioPort.cpp
+++ b/common/JackAudioPort.cpp
@@ -64,14 +64,14 @@ static inline void MixAudioBuffer(jack_default_audio_sample_t* mixbuffer, jack_d
         buffer += 4;
         frames_group--;
     #else
-        register jack_default_audio_sample_t mixFloat1 = *mixbuffer;
-        register jack_default_audio_sample_t sourceFloat1 = *buffer;
-        register jack_default_audio_sample_t mixFloat2 = *(mixbuffer + 1);
-        register jack_default_audio_sample_t sourceFloat2 = *(buffer + 1);
-        register jack_default_audio_sample_t mixFloat3 = *(mixbuffer + 2);
-        register jack_default_audio_sample_t sourceFloat3 = *(buffer + 2);
-        register jack_default_audio_sample_t mixFloat4 = *(mixbuffer + 3);
-        register jack_default_audio_sample_t sourceFloat4 = *(buffer + 3);
+        jack_default_audio_sample_t mixFloat1 = *mixbuffer;
+        jack_default_audio_sample_t sourceFloat1 = *buffer;
+        jack_default_audio_sample_t mixFloat2 = *(mixbuffer + 1);
+        jack_default_audio_sample_t sourceFloat2 = *(buffer + 1);
+        jack_default_audio_sample_t mixFloat3 = *(mixbuffer + 2);
+        jack_default_audio_sample_t sourceFloat3 = *(buffer + 2);
+        jack_default_audio_sample_t mixFloat4 = *(mixbuffer + 3);
+        jack_default_audio_sample_t sourceFloat4 = *(buffer + 3);
 
         buffer += 4;
         frames_group--;
@@ -91,8 +91,8 @@ static inline void MixAudioBuffer(jack_default_audio_sample_t* mixbuffer, jack_d
     }
 
     while (frames > 0) {
-        register jack_default_audio_sample_t mixFloat1 = *mixbuffer;
-        register jack_default_audio_sample_t sourceFloat1 = *buffer;
+        jack_default_audio_sample_t mixFloat1 = *mixbuffer;
+        jack_default_audio_sample_t sourceFloat1 = *buffer;
         buffer++;
         frames--;
         mixFloat1 += sourceFloat1;

--- a/windows/JackAtomic_os.h
+++ b/windows/JackAtomic_os.h
@@ -38,7 +38,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 //----------------------------------------------------------------
 inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void * addr)
 {
-    register char c;
+    char c;
     __asm {
         push	ebx
         push	esi
@@ -59,7 +59,7 @@ inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void * addr)
 
 static inline char CAS(volatile UInt32 value, UInt32 newvalue, volatile void* addr)
 {
-    register char ret;
+    char ret;
     __asm__ __volatile__ (
         "# CAS \n\t"
         LOCK "cmpxchg %2, (%1) \n\t"


### PR DESCRIPTION
This fixes warnings with clang like this
warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]

According to https://en.cppreference.com/w/cpp/keyword/register
the keyword is unused and reserved.

Fixes https://github.com/jackaudio/jack2/issues/774