### PR TITLE
Fix crash in midi_latency_test

### DIFF
--- a/example-clients/midi_latency_test.c
+++ b/example-clients/midi_latency_test.c
@@ -652,8 +652,7 @@ main(int argc, char **argv)
             break;
         default:
             {
-                char *s = "'- '";
-                s[2] = c;
+                signed char s[] = {'\'', '-', c, '\'', '\0'};
                 die(s, "invalid switch");
             }
         case -1:


### PR DESCRIPTION
`s` points to a constant string literal in the current code (which is in practice
just a pointer in some read-only memory). The next line `s[2] = c;` either
crashes or just gets completely removed by the compiler as it attempts to
write to read-only memory.