### PR TITLE
Remove unused JackArgParser::GetArgv

### DIFF
--- a/common/JackArgParser.cpp
+++ b/common/JackArgParser.cpp
@@ -121,26 +121,6 @@ namespace Jack {
         return 0;
     }
 
-    int JackArgParser::GetArgv ( char** argv )
-    {
-        //argv must be NULL
-        if ( argv )
-            return -1;
-        //else allocate and fill it
-        argv = (char**)calloc (fArgv.size(), sizeof(char*));
-        if (argv == NULL) 
-        {
-            return -1;
-        }
-        for ( unsigned int i = 0; i < fArgv.size(); i++ )
-        {
-            argv[i] = (char*)calloc(fArgv[i].length(), sizeof(char));
-            fill_n ( argv[i], fArgv[i].length() + 1, 0 );
-            fArgv[i].copy ( argv[i], fArgv[i].length() );
-        }
-        return 0;
-    }
-
     void JackArgParser::DeleteArgv ( const char** argv )
     {
         unsigned int i;

--- a/common/JackArgParser.h
+++ b/common/JackArgParser.h
@@ -50,7 +50,6 @@ namespace Jack
             int GetNumArgv();
             int GetArgc();
             int GetArgv ( std::vector<std::string>& argv );
-            int GetArgv ( char** argv );
             void DeleteArgv ( const char** argv );
             bool ParseParams ( jack_driver_desc_t* desc, JSList** param_list );
             void FreeParams ( JSList* param_list );


### PR DESCRIPTION
This is not called anywhere. Also this function doesn't do anything useful besides
leaking memory in its current form. I think the idea was to give this a
`char ***` (instead of `char **`) paramter that will be filled and then can
be used by the caller. But in its current form it just allocates a pointer
with the address being only used in the local variable (which then goes out
of scope and the memory is lost).