### PR TITLE
Fix ringbuffer thread safety on ARM. Fix #715 #388

### DIFF
--- a/common/jack/ringbuffer.h
+++ b/common/jack/ringbuffer.h
@@ -50,8 +50,8 @@ jack_ringbuffer_data_t ;
 
 typedef struct {
     char	*buf;
-    volatile size_t write_ptr;
-    volatile size_t read_ptr;
+    size_t	write_ptr;
+    size_t	read_ptr;
     size_t	size;
     size_t	size_mask;
     int	mlocked;

--- a/common/ringbuffer.c
+++ b/common/ringbuffer.c
@@ -180,7 +180,8 @@ jack_ringbuffer_read_space (const jack_ringbuffer_t * rb)
 {
 	size_t w, r;
 
-	w = rb->write_ptr; JACK_ACQ_FENCE();
+	w = rb->write_ptr;
+	JACK_ACQ_FENCE();
 	r = rb->read_ptr;
 
 	return (w - r) & rb->size_mask;
@@ -196,7 +197,8 @@ jack_ringbuffer_write_space (const jack_ringbuffer_t * rb)
 	size_t w, r;
 
 	w = rb->write_ptr;
-	r = rb->read_ptr; JACK_ACQ_FENCE();
+	r = rb->read_ptr;
+	JACK_ACQ_FENCE();
 
 	return (r - w - 1) & rb->size_mask;
 }


### PR DESCRIPTION
This patch addresses the thread safety problem of `jack_ringbuffer_t`
mentioned in #715 and #388. The overbound read bug caused by this problem
is impossible to reproduce on x86 due to its strong memory ordering, but
it is a problem on ARM and other weakly ordered architectures.

Basically, the main problem is that, on a weakly ordered architecture,
it is possible that the pointer increment after `memcpy` becomes visible
to the other thread before `memcpy` finishes:

	memcpy (&(rb->buf[rb->write_ptr]), src, n1);
	// vvv can be visible to reading thread before memcpy finishes
	rb->write_ptr = (rb->write_ptr + n1) & rb->size_mask;

If this happens, the other thread can read the remaining garbage values
in `rb->buf` due to be overwritten by the unfinished `memcpy`.

To fix this, an explicit pair of [release/acquire memory fences][1] is
used to ensure the copy on the other thread *happens after* the `memcpy`
finishes so no garbage values can be read.

[1]: https://preshing.com/20130922/acquire-and-release-fences/