### PR TITLE
Jack MIDI portnames (fixes #944)

### DIFF
--- a/linux/alsa/alsa_rawmidi.c
+++ b/linux/alsa/alsa_rawmidi.c
@@ -441,6 +441,7 @@ inline int midi_port_open_jack(alsa_rawmidi_t *midi, midi_port_t *port, int type
 		type | JackPortIsPhysical | JackPortIsTerminal, 0);
 
 	// Like in alsa_seqmidi.c, use the Jack1 port name as alias. -ag
+	const char *prefix = "alsa_midi:";
 	const char* device_name = port->device_name;
 	const char* port_name = port->subdev_name;
 	const char *type_name = (type & JackPortIsOutput) ? "out" : "in";
@@ -448,13 +449,15 @@ inline int midi_port_open_jack(alsa_rawmidi_t *midi, midi_port_t *port, int type
 	  /* entire client name is part of the port name so don't replicate it */
 	  snprintf (name,
 		    sizeof(name),
-		    "alsa_midi:%s (%s)",
+		    "%s%s (%s)",
+		    prefix,
 		    port_name,
 		    type_name);
 	} else {
 	  snprintf (name,
 		    sizeof(name),
-		    "alsa_midi:%s %s (%s)",
+		    "%s%s %s (%s)",
+		    prefix,
 		    device_name,
 		    port_name,
 		    type_name);
@@ -472,7 +475,8 @@ inline int midi_port_open_jack(alsa_rawmidi_t *midi, midi_port_t *port, int type
 		// we just ignore the given alias argument, and use the Jack1
 		// port name from above instead -ag
 		jack_port_set_alias(port->jack, name);
-		jack_port_set_default_metadata(port->jack, port->device_name);
+		// Pretty-name metadata is the same as alias without the prefix.
+		jack_port_set_default_metadata (port->jack, name+strlen(prefix));
 	}
 
 	return port->jack == NULL;

--- a/linux/alsa/alsa_seqmidi.c
+++ b/linux/alsa/alsa_seqmidi.c
@@ -147,13 +147,13 @@ static port_type_t port_type[2] = {
 	{
 		SND_SEQ_PORT_CAP_SUBS_READ,
 		JackPortIsOutput,
-		"playback",
+		"capture",
 		do_jack_input
 	},
 	{
 		SND_SEQ_PORT_CAP_SUBS_WRITE,
 		JackPortIsInput,
-		"capture",
+		"playback",
 		do_jack_output
 	}
 };
@@ -493,15 +493,6 @@ port_t* port_create(alsa_seqmidi_t *self, int type, snd_seq_addr_t addr, const s
 	snd_seq_client_info_alloca (&client_info);
 	snd_seq_get_any_client_info (self->seq, addr.client, client_info);
 
-	const char *device_name = snd_seq_client_info_get_name(client_info);
-	snprintf(port->name, sizeof(port->name), "alsa_pcm:%s/midi_%s_%d",
-		 device_name, port_type[type].name, addr.port+1);
-
-	// replace all offending characters by -
-	for (c = port->name; *c; ++c)
-		if (!isalnum(*c) && *c != '/' && *c != '_' && *c != ':' && *c != '(' && *c != ')')
-			*c = '-';
-
 	jack_caps = port_type[type].jack_caps;
 
 	/* mark anything that looks like a hardware port as physical&terminal */
@@ -520,18 +511,55 @@ port_t* port_create(alsa_seqmidi_t *self, int type, snd_seq_addr_t addr, const s
 	if (!port->jack_port)
 		goto failed;
 
+	// First alias: Jack1-compatible port name. -ag
+	const char *device_name = snd_seq_client_info_get_name(client_info);
+	const char* port_name = snd_seq_port_info_get_name (info);
+	const char* type_name = jack_caps & JackPortIsOutput ? "out" : "in";
+	// This code is pilfered from Jack1. -ag
+	if (strstr (port_name, device_name) == port_name) {
+	  /* entire client name is part of the port name so don't replicate it */
+	  snprintf (port->name,
+		    sizeof(port->name),
+		    "alsa_midi:%s (%s)",
+		    port_name,
+		    type_name);
+	} else {
+	  snprintf (port->name,
+		    sizeof(port->name),
+		    "alsa_midi:%s %s (%s)",
+		    device_name,
+		    port_name,
+		    type_name);
+	}
+
+	// replace all offending characters with ' '
+	for (c = port->name; *c; ++c) {
+		if (!isalnum(*c) && *c != ' ' && *c != '/' && *c != '_' && *c != ':' && *c != '(' && *c != ')') {
+			*c = ' ';
+		}
+	}
+
 	jack_port_set_alias (port->jack_port, port->name);
 	jack_port_set_default_metadata (port->jack_port, device_name);
 
-	/* generate an alias */
+	// Second alias: Strip the alsa_midi prefix, so that devices appear
+	// under their ALSA names. Use the ALSA port names (without device
+	// prefix) for the individual ports. -ag
+	if (strstr (port_name, device_name) == port_name) {
+	  // remove the device name prefix from the port name if present
+	  port_name += strlen(device_name);
+	  while (*port_name == ' ' || *port_name == '\t')
+	    port_name++;
+	}
+	snprintf(port->name, sizeof(port->name), "%s:%s (%s)",
+		 device_name, port_name, port_type[type].name);
 
-	snprintf(port->name, sizeof(port->name), "%s:midi/%s_%d",
-		 snd_seq_client_info_get_name (client_info), port_type[type].name, addr.port+1);
-
-	// replace all offending characters by -
-	for (c = port->name; *c; ++c)
-		if (!isalnum(*c) && *c != '/' && *c != '_' && *c != ':' && *c != '(' && *c != ')')
-			*c = '-';
+	// replace all offending characters with ' '
+	for (c = port->name; *c; ++c) {
+		if (!isalnum(*c) && *c != ' ' && *c != '/' && *c != '_' && *c != ':' && *c != '(' && *c != ')') {
+			*c = ' ';
+		}
+	}
 
 	jack_port_set_alias (port->jack_port, port->name);
 	jack_port_set_default_metadata (port->jack_port, device_name);


### PR DESCRIPTION
Fixes up the Jack MIDI port names along the lines of Jack1 and a2jmidid, as discussed in #944.

More precisely, here's a quick rundown of what this PR does in its final version:

- Jack MIDI port names are renamed, so that they match the ones from Jack1, for both -Xseq (rev. b17379ea31603263abc62b3b2e632ea31e339490) and -Xraw (rev. 0b38fa4fa2f311bde7d82afa5ac45a13ee08a631).
- The 1st seqmidi alias now uses alsa_midi (instead of the misnamed alsa_pcm) as prefix (this is in rev. b17379ea31603263abc62b3b2e632ea31e339490).
- The 1st rawmidi alias had no device prefix at all, which qjackctl doesn't like, thus I added the alsa_midi prefix there as well, so that the alias displays correctly in qjackctl (rev. cdaf88ced374f74958e710e03bc5b6f05b691a64).
- Both seqmidi aliases had the `capture` and `playback` labels in the port names the wrong way round, fixed by swapping them (rev. 3edde50da4892b2a21d70799dc034a1734b9d592).

So what this PR boils down to is to make the Jack MIDI port names compatible with Jack1 while keeping the existing aliases mostly intact (apart from some bugfixes).
