### PR TITLE
ADIT alsa improvement backports

### DIFF
--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -688,6 +688,17 @@ alsa_driver_configure_stream (alsa_driver_t *driver, char *device_name,
 	return 0;
 }
 
+static void
+alsa_driver_set_sample_bytes (alsa_driver_t *driver)
+{
+	driver->playback_sample_bytes =
+		snd_pcm_format_physical_width (driver->playback_sample_format)
+		/ 8;
+	driver->capture_sample_bytes =
+		snd_pcm_format_physical_width (driver->capture_sample_format)
+		/ 8;
+}
+
 static int
 alsa_driver_set_parameters (alsa_driver_t *driver,
 			    jack_nframes_t frames_per_cycle,
@@ -835,12 +846,7 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 		}
 	}
 
-	driver->playback_sample_bytes =
-		snd_pcm_format_physical_width (driver->playback_sample_format)
-		/ 8;
-	driver->capture_sample_bytes =
-		snd_pcm_format_physical_width (driver->capture_sample_format)
-		/ 8;
+	alsa_driver_set_sample_bytes(driver);
 
 	if (driver->playback_handle) {
 		switch (driver->playback_sample_format) {

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -1055,6 +1055,12 @@ alsa_driver_get_channel_addresses (alsa_driver_t *driver,
 	return 0;
 }
 
+static int
+alsa_driver_stream_start(snd_pcm_t *pcm, bool is_capture)
+{
+	return snd_pcm_start(pcm);
+}
+
 int
 alsa_driver_start (alsa_driver_t *driver)
 {
@@ -1161,7 +1167,7 @@ alsa_driver_start (alsa_driver_t *driver)
 				     driver->user_nperiods
 				     * driver->frames_per_cycle);
 
-		if ((err = snd_pcm_start (driver->playback_handle)) < 0) {
+		if ((err = alsa_driver_stream_start (driver->playback_handle, SND_PCM_STREAM_PLAYBACK)) < 0) {
 			jack_error ("ALSA: could not start playback (%s)",
 				    snd_strerror (err));
 			return -1;
@@ -1170,7 +1176,7 @@ alsa_driver_start (alsa_driver_t *driver)
 
 	if ((driver->capture_handle && driver->capture_and_playback_not_synced)
 	    || !driver->playback_handle) {
-		if ((err = snd_pcm_start (driver->capture_handle)) < 0) {
+		if ((err = alsa_driver_stream_start (driver->capture_handle, SND_PCM_STREAM_CAPTURE)) < 0) {
 			jack_error ("ALSA: could not start capture (%s)",
 				    snd_strerror (err));
 			return -1;
@@ -1352,6 +1358,18 @@ alsa_driver_set_clock_sync_status (alsa_driver_t *driver, channel_t chn,
 	alsa_driver_clock_sync_notify (driver, chn, status);
 }
 
+static int
+alsa_driver_poll_descriptors(snd_pcm_t *pcm, struct pollfd *pfds, unsigned int space, bool is_capture)
+{
+	return snd_pcm_poll_descriptors(pcm, pfds, space);
+}
+
+static snd_pcm_sframes_t
+alsa_driver_avail(alsa_driver_t *driver, snd_pcm_t *pcm, bool is_capture)
+{
+	return snd_pcm_avail_update(pcm);
+}
+
 static int under_gdb = FALSE;
 
 jack_nframes_t
@@ -1392,16 +1410,16 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 		nfds = 0;
 
 		if (need_playback) {
-			snd_pcm_poll_descriptors (driver->playback_handle,
+			alsa_driver_poll_descriptors (driver->playback_handle,
 						  &driver->pfd[0],
-						  driver->playback_nfds);
+						  driver->playback_nfds, SND_PCM_STREAM_PLAYBACK);
 			nfds += driver->playback_nfds;
 		}
 
 		if (need_capture) {
-			snd_pcm_poll_descriptors (driver->capture_handle,
+			alsa_driver_poll_descriptors (driver->capture_handle,
 						  &driver->pfd[nfds],
-						  driver->capture_nfds);
+						  driver->capture_nfds, SND_PCM_STREAM_CAPTURE);
 			ci = nfds;
 			nfds += driver->capture_nfds;
 		}
@@ -1578,8 +1596,8 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 	}
 
 	if (driver->capture_handle) {
-		if ((capture_avail = snd_pcm_avail_update (
-			     driver->capture_handle)) < 0) {
+		if ((capture_avail = alsa_driver_avail (driver,
+			     driver->capture_handle, SND_PCM_STREAM_CAPTURE)) < 0) {
 			if (capture_avail == -EPIPE) {
 				xrun_detected = TRUE;
 			} else {
@@ -1593,8 +1611,8 @@ alsa_driver_wait (alsa_driver_t *driver, int extra_fd, int *status, float
 	}
 
 	if (driver->playback_handle) {
-		if ((playback_avail = snd_pcm_avail_update (
-			     driver->playback_handle)) < 0) {
+		if ((playback_avail = alsa_driver_avail (driver,
+			     driver->playback_handle, SND_PCM_STREAM_PLAYBACK)) < 0) {
 			if (playback_avail == -EPIPE) {
 				xrun_detected = TRUE;
 			} else {

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -688,6 +688,28 @@ alsa_driver_configure_stream (alsa_driver_t *driver, char *device_name,
 	return 0;
 }
 
+static int
+alsa_driver_check_format (snd_pcm_format_t format)
+{
+	switch (format) {
+	case SND_PCM_FORMAT_FLOAT_LE:
+	case SND_PCM_FORMAT_S24_3LE:
+	case SND_PCM_FORMAT_S24_3BE:
+	case SND_PCM_FORMAT_S24_LE:
+	case SND_PCM_FORMAT_S24_BE:
+	case SND_PCM_FORMAT_S32_BE:
+	case SND_PCM_FORMAT_S16_BE:
+	case SND_PCM_FORMAT_S16_LE:
+	case SND_PCM_FORMAT_S32_LE:
+		break;
+	default:
+		jack_error ("format not supported %d", format);
+		return -1;
+	}
+
+	return 0;
+}
+
 static void
 alsa_driver_set_sample_bytes (alsa_driver_t *driver)
 {
@@ -849,42 +871,20 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 	alsa_driver_set_sample_bytes(driver);
 
 	if (driver->playback_handle) {
-		switch (driver->playback_sample_format) {
-        case SND_PCM_FORMAT_FLOAT_LE:
-		case SND_PCM_FORMAT_S32_LE:
-		case SND_PCM_FORMAT_S24_3LE:
-		case SND_PCM_FORMAT_S24_3BE:
-		case SND_PCM_FORMAT_S24_LE:
-		case SND_PCM_FORMAT_S24_BE:
-		case SND_PCM_FORMAT_S16_LE:
-		case SND_PCM_FORMAT_S32_BE:
-		case SND_PCM_FORMAT_S16_BE:
-			break;
-
-		default:
+		err = alsa_driver_check_format(driver->playback_sample_format);
+		if(err < 0) {
 			jack_error ("programming error: unhandled format "
 				    "type for playback");
-			exit (1);
+			return -1;
 		}
 	}
 
 	if (driver->capture_handle) {
-		switch (driver->capture_sample_format) {
-        case SND_PCM_FORMAT_FLOAT_LE:
-		case SND_PCM_FORMAT_S32_LE:
-		case SND_PCM_FORMAT_S24_3LE:
-		case SND_PCM_FORMAT_S24_3BE:
-		case SND_PCM_FORMAT_S24_LE:
-		case SND_PCM_FORMAT_S24_BE:
-		case SND_PCM_FORMAT_S16_LE:
-		case SND_PCM_FORMAT_S32_BE:
-		case SND_PCM_FORMAT_S16_BE:
-			break;
-
-		default:
+		err = alsa_driver_check_format(driver->capture_sample_format);
+		if(err < 0) {
 			jack_error ("programming error: unhandled format "
 				    "type for capture");
-			exit (1);
+			return -1;
 		}
 	}
 

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -318,10 +318,12 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 				{
 					case SND_PCM_FORMAT_S24_LE:
 					case SND_PCM_FORMAT_S24_BE:
-				driver->write_via_copy = driver->quirk_bswap?
-					sample_move_d32l24_sSs:
-					sample_move_d32l24_sS;
-				break;
+					{
+						driver->write_via_copy = driver->quirk_bswap?
+							sample_move_d32u24_sSs:
+							sample_move_d32u24_sS;
+						break;
+					}
 					case SND_PCM_FORMAT_S32_LE:
 					case SND_PCM_FORMAT_S32_BE:
 					{
@@ -382,10 +384,12 @@ alsa_driver_setup_io_function_pointers (alsa_driver_t *driver)
 				{
 					case SND_PCM_FORMAT_S24_LE:
 					case SND_PCM_FORMAT_S24_BE:
-				driver->read_via_copy = driver->quirk_bswap?
-					sample_move_dS_s32l24s:
-					sample_move_dS_s32l24;
-				break;
+					{
+						driver->read_via_copy = driver->quirk_bswap?
+							sample_move_dS_s32u24s:
+							sample_move_dS_s32u24;
+						break;
+					}
 					case SND_PCM_FORMAT_S32_LE:
 					case SND_PCM_FORMAT_S32_BE:
 					{

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -755,32 +755,34 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 		 rate, frames_per_cycle, (((float)frames_per_cycle / (float) rate) * 1000.0f), user_nperiods);
 
 	if (driver->capture_handle) {
-		if (alsa_driver_configure_stream (
-			    driver,
-			    driver->alsa_name_capture,
-			    "capture",
-			    driver->capture_handle,
-			    driver->capture_hw_params,
-			    driver->capture_sw_params,
-			    &driver->capture_nperiods,
-			    &driver->capture_nchannels,
-			    driver->capture_sample_bytes)) {
+		err = alsa_driver_configure_stream (
+		    driver,
+		    driver->alsa_name_capture,
+		    "capture",
+		    driver->capture_handle,
+		    driver->capture_hw_params,
+		    driver->capture_sw_params,
+		    &driver->capture_nperiods,
+		    &driver->capture_nchannels,
+		    driver->capture_sample_bytes);
+		if (err) {
 			jack_error ("ALSA: cannot configure capture channel");
 			return -1;
 		}
 	}
 
 	if (driver->playback_handle) {
-		if (alsa_driver_configure_stream (
-			    driver,
-			    driver->alsa_name_playback,
-			    "playback",
-			    driver->playback_handle,
-			    driver->playback_hw_params,
-			    driver->playback_sw_params,
-			    &driver->playback_nperiods,
-			    &driver->playback_nchannels,
-			    driver->playback_sample_bytes)) {
+		err = alsa_driver_configure_stream (
+		    driver,
+		    driver->alsa_name_playback,
+		    "playback",
+		    driver->playback_handle,
+		    driver->playback_hw_params,
+		    driver->playback_sw_params,
+		    &driver->playback_nperiods,
+		    &driver->playback_nchannels,
+		    driver->playback_sample_bytes);
+		if (err) {
 			jack_error ("ALSA: cannot configure playback channel");
 			return -1;
 		}
@@ -1230,7 +1232,8 @@ alsa_driver_stop (alsa_driver_t *driver)
     ClearOutput();
 
 	if (driver->playback_handle) {
-		if ((err = snd_pcm_drop (driver->playback_handle)) < 0) {
+		err = snd_pcm_drop (driver->playback_handle);
+		if (err < 0) {
 			jack_error ("ALSA: channel flush for playback "
 				    "failed (%s)", snd_strerror (err));
 			return -1;
@@ -1240,7 +1243,8 @@ alsa_driver_stop (alsa_driver_t *driver)
 	if (!driver->playback_handle
 	    || driver->capture_and_playback_not_synced) {
 		if (driver->capture_handle) {
-			if ((err = snd_pcm_drop (driver->capture_handle)) < 0) {
+			err = snd_pcm_drop (driver->capture_handle);
+			if (err < 0) {
 				jack_error ("ALSA: channel flush for "
 					    "capture failed (%s)",
 					    snd_strerror (err));

--- a/linux/alsa/alsa_driver.c
+++ b/linux/alsa/alsa_driver.c
@@ -1331,7 +1331,7 @@ alsa_driver_xrun_recovery (alsa_driver_t *driver, float *delayed_usecs)
 	return 0;
 }
 
-void
+static void
 alsa_driver_silence_untouched_channels (alsa_driver_t *driver,
 					jack_nframes_t nframes)
 {

--- a/linux/alsa/alsa_driver.h
+++ b/linux/alsa/alsa_driver.h
@@ -212,16 +212,6 @@ alsa_driver_write_to_channel (alsa_driver_t *driver,
 
 void  alsa_driver_silence_untouched_channels (alsa_driver_t *driver,
 					      jack_nframes_t nframes);
-void  alsa_driver_set_clock_sync_status (alsa_driver_t *driver, channel_t chn,
-					 ClockSyncStatus status);
-int   alsa_driver_listen_for_clock_sync_status (alsa_driver_t *,
-						ClockSyncListenerFunction,
-						void *arg);
-int   alsa_driver_stop_listen_for_clock_sync_status (alsa_driver_t *,
-						     unsigned int);
-void  alsa_driver_clock_sync_notify (alsa_driver_t *, channel_t chn,
-				     ClockSyncStatus);
-
 int
 alsa_driver_reset_parameters (alsa_driver_t *driver,
 			      jack_nframes_t frames_per_cycle,
@@ -267,8 +257,6 @@ alsa_driver_read (alsa_driver_t *driver, jack_nframes_t nframes);
 
 int
 alsa_driver_write (alsa_driver_t* driver, jack_nframes_t nframes);
-
-jack_time_t jack_get_microseconds(void);
 
 // Code implemented in JackAlsaDriver.cpp
 

--- a/linux/alsa/alsa_driver.h
+++ b/linux/alsa/alsa_driver.h
@@ -58,13 +58,19 @@ typedef struct _alsa_driver {
 
     JACK_DRIVER_NT_DECL
 
+    snd_pcm_format_t              playback_sample_format;
+    snd_pcm_format_t              capture_sample_format;
+    const snd_pcm_channel_area_t *capture_areas;
+    const snd_pcm_channel_area_t *playback_areas;
+    snd_pcm_hw_params_t          *playback_hw_params;
+    snd_pcm_sw_params_t          *playback_sw_params;
+    snd_pcm_hw_params_t          *capture_hw_params;
+    snd_pcm_sw_params_t          *capture_sw_params;
     int                           poll_timeout;
     jack_time_t                   poll_last;
     jack_time_t                   poll_next;
     char                        **playback_addr;
     char                        **capture_addr;
-    const snd_pcm_channel_area_t *capture_areas;
-    const snd_pcm_channel_area_t *playback_areas;
     struct pollfd                *pfd;
     unsigned int                  playback_nfds;
     unsigned int                  capture_nfds;
@@ -88,8 +94,6 @@ typedef struct _alsa_driver {
     char                         *alsa_driver;
     bitset_t			  channels_not_done;
     bitset_t			  channels_done;
-    snd_pcm_format_t              playback_sample_format;
-    snd_pcm_format_t              capture_sample_format;
     float                         max_sample_val;
     unsigned long                 user_nperiods;
     unsigned int                  playback_nperiods;
@@ -98,10 +102,6 @@ typedef struct _alsa_driver {
     snd_ctl_t                    *ctl_handle;
     snd_pcm_t                    *playback_handle;
     snd_pcm_t                    *capture_handle;
-    snd_pcm_hw_params_t          *playback_hw_params;
-    snd_pcm_sw_params_t          *playback_sw_params;
-    snd_pcm_hw_params_t          *capture_hw_params;
-    snd_pcm_sw_params_t          *capture_sw_params;
     jack_hardware_t              *hw;
     ClockSyncStatus              *clock_sync_data;
     jack_client_t                *client;

--- a/linux/alsa/alsa_driver.h
+++ b/linux/alsa/alsa_driver.h
@@ -210,8 +210,6 @@ alsa_driver_write_to_channel (alsa_driver_t *driver,
 	alsa_driver_mark_channel_done (driver, channel);
 }
 
-void  alsa_driver_silence_untouched_channels (alsa_driver_t *driver,
-					      jack_nframes_t nframes);
 int
 alsa_driver_reset_parameters (alsa_driver_t *driver,
 			      jack_nframes_t frames_per_cycle,


### PR DESCRIPTION
Hello,

please consider merging these changes developed internally at ADIT.

These changes are part of a larger effort by ADIT to port jack2 to QNX, improve responsiveness of jack2, improve error handling, hardening of jack2 and adding alsa multi device functionality and more.

This specific PR includes general refactoring and code improvements for the alsa driver. This is a precursor for further improvements like QNX port and 'alsa multi device feature' discussed in [PR-608](https://github.com/jackaudio/jack2/pull/608) 

Although QNX port is not going to be merged to upstream, as discussed in previous PRs, this PR is still needed for the [PR-608](https://github.com/jackaudio/jack2/pull/608)

If we can merge this I have prepared another PR that contains only the alsa multi dev feature patches.

The changed are used in production, but I had to backport them to newest master branch (it was a couple of years since I looked into this) and I have tested the PR on my laptop with a simple test:

```
jackd -r -d alsa -C hw:1 -P hw:1 -r 48000 -i 2 -o 2
jack_connect system:capture_1 system:playback_2
jack_connect system:capture_1 system:playback_2
```

Result: audio capture by card is audible on output

Please let me know what you think.

Best Regards,
Adam