### PR TITLE
JackPosixProcessSync: Fix mutex owner on TimedWait() timeout.

### DIFF
--- a/posix/JackPosixProcessSync.cpp
+++ b/posix/JackPosixProcessSync.cpp
@@ -122,7 +122,7 @@ bool JackPosixProcessSync::TimedWait(long usec)
     time.tv_nsec = (next_date_usec % 1000000) * 1000;
 
     res = pthread_cond_timedwait(&fCond, &fMutex, &time);
-    if (res != 0) {
+    if (res != 0 && res != ETIMEDOUT) {
         jack_error("JackPosixProcessSync::TimedWait error usec = %ld err = %s", usec, strerror(res));
     } else {
         fOwner = pthread_self();


### PR DESCRIPTION
Per POSIX definition, pthread_cond_timedwait() re-acquires the mutex when a timeout occurs and ETIMEDOUT is returned. In that case also mark the waiting thread as owner again, for consistency. Otherwise subsequent attempts to unlock the mutex will fail, leaving the mutex locked forever.

The return value of TimedWait() is still false on timeout, the same as for other platform's implementations.
But AFAICT, JackPosixProcessSync::TimedWait() is only used by my new FreeBSD OSS backend, see #943.