### PR TITLE
Use XDG_STATE_HOME for jackdbus logs

### DIFF
--- a/dbus/jackdbus.c
+++ b/dbus/jackdbus.c
@@ -694,7 +694,7 @@ pathname_cat(const char *pathname_a, const char *pathname_b)
 bool
 paths_init()
 {
-	const char *home_dir, *xdg_config_home, *xdg_state_home;
+    const char *home_dir;
     
     home_dir = getenv("HOME");
     if (home_dir == NULL)
@@ -703,30 +703,30 @@ paths_init()
         goto fail;
     }
 
-	xdg_config_home = getenv("XDG_CONFIG_HOME");
-	if (xdg_config_home == NULL)
-	{
-	    if (!(xdg_config_home = pathname_cat(home_dir, DEFAULT_XDG_CONFIG))) goto fail;
-	}
-
-    xdg_state_home = getenv("XDG_STATE_HOME");
-    if (xdg_state_home == NULL)
+    g_jackdbus_config_dir = getenv("XDG_CONFIG_HOME");
+    if (g_jackdbus_config_dir == NULL)
     {
-        if (!(xdg_state_home = pathname_cat(home_dir, DEFAULT_XDG_STATE))) goto fail;
+        if (!(g_jackdbus_config_dir = pathname_cat(home_dir, DEFAULT_XDG_CONFIG))) goto fail;
     }
 
-	if (!(g_jackdbus_config_dir = pathname_cat(xdg_config_home, JACKDBUS_DIR))) goto fail;
-	if (!(g_jackdbus_log_dir = pathname_cat(xdg_state_home, JACKDBUS_DIR))) goto fail;
+    g_jackdbus_log_dir = getenv("XDG_STATE_HOME");
+    if (g_jackdbus_log_dir == NULL)
+    {
+        if (!(g_jackdbus_log_dir = pathname_cat(home_dir, DEFAULT_XDG_STATE))) goto fail;
+    }
 
-    if (!ensure_dir_exist(xdg_config_home, 0700))
+
+    if (!ensure_dir_exist(g_jackdbus_config_dir, 0700))
     {
         goto fail;
     }
+    if (!(g_jackdbus_config_dir = pathname_cat(g_jackdbus_config_dir, JACKDBUS_DIR))) goto fail;
     
-    if (!ensure_dir_exist(xdg_state_home, 0700))
+    if (!ensure_dir_exist(g_jackdbus_log_dir, 0700))
     {
         goto fail;
     }
+    if (!(g_jackdbus_log_dir = pathname_cat(g_jackdbus_log_dir, JACKDBUS_DIR))) goto fail;
 
     if (!ensure_dir_exist(g_jackdbus_config_dir, 0700))
     {

--- a/dbus/jackdbus.c
+++ b/dbus/jackdbus.c
@@ -694,7 +694,7 @@ pathname_cat(const char *pathname_a, const char *pathname_b)
 bool
 paths_init()
 {
-	const char *home_dir, *xdg_config_home, *xdg_log_home;
+	const char *home_dir, *xdg_config_home, *xdg_state_home;
     
     home_dir = getenv("HOME");
     if (home_dir == NULL)
@@ -709,17 +709,21 @@ paths_init()
 	    if (!(xdg_config_home = pathname_cat(home_dir, DEFAULT_XDG_CONFIG))) goto fail;
 	}
 
-    if (!(xdg_log_home = pathname_cat(home_dir, DEFAULT_XDG_LOG))) goto fail;
+    xdg_state_home = getenv("XDG_STATE_HOME");
+    if (xdg_state_home == NULL)
+    {
+        if (!(xdg_state_home = pathname_cat(home_dir, DEFAULT_XDG_STATE))) goto fail;
+    }
 
 	if (!(g_jackdbus_config_dir = pathname_cat(xdg_config_home, JACKDBUS_DIR))) goto fail;
-	if (!(g_jackdbus_log_dir = pathname_cat(xdg_log_home, JACKDBUS_DIR))) goto fail;
+	if (!(g_jackdbus_log_dir = pathname_cat(xdg_state_home, JACKDBUS_DIR))) goto fail;
 
     if (!ensure_dir_exist(xdg_config_home, 0700))
     {
         goto fail;
     }
     
-    if (!ensure_dir_exist(xdg_log_home, 0700))
+    if (!ensure_dir_exist(xdg_state_home, 0700))
     {
         goto fail;
     }

--- a/dbus/jackdbus.h
+++ b/dbus/jackdbus.h
@@ -29,7 +29,7 @@
 //#define DISABLE_SIGNAL_MAGIC
 
 #define DEFAULT_XDG_CONFIG "/.config"
-#define DEFAULT_XDG_LOG "/.log"
+#define DEFAULT_XDG_STATE "/.local/state"
 #define JACKDBUS_DIR "/jack"
 #define JACKDBUS_LOG "/jackdbus.log"
 #define JACKDBUS_CONF "/conf.xml"


### PR DESCRIPTION
Fixes #402 

In that bug, it's mentioned that Debian has an $XDG_STATE_HOME extension for that purpose.  Well, it's been added to [version 0.8 of the specification](https://specifications.freedesktop.org/basedir-spec/0.8/) (8 May 2021) with the description:

> The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:
> *    actions history (logs, history, recently used files, …)
> *    current state of the application that can be reused on a restart (view, layout, open files, undo history, …)

It's been a part of the official specification for almost three years and other applications use it, so it should be safe to use it and not add unnecessary files and directories to $HOME.