### PR TITLE
fix: github workflow vulnerable to script injection

### DIFF
--- a/.github/workflows/irc.yml
+++ b/.github/workflows/irc.yml
@@ -2,6 +2,9 @@ name: irc
 
 on: [push]
 
+env:
+  COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
+
 jobs:
   notification:
     runs-on: ubuntu-latest
@@ -10,7 +13,7 @@ jobs:
       - name: Format message
         id: message
         run: |
-          message="${{ github.actor }} pushed $(echo '${{ github.event.commits[0].message }}' | head -n 1) ${{ github.event.commits[0].url }}"
+          message="${{ github.actor }} pushed $(echo '$COMMIT_MESSAGE' | head -n 1) ${{ github.event.commits[0].url }}"
           echo ::set-output name=message::"${message}"
       - name: IRC notification
         uses: Gottox/irc-message-action@v2


### PR DESCRIPTION
Hi! I'm Diogo from Google's Open Source Security Team([GOSST](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html)) and I'm dropping by to suggest this small change that will enhance the security of your repository by preventing script injection attacks through your GitHub workflows.

In the piece of code I changed, you were directly using the value of a variable that comes from a user's input, so a malicious user could exploit that input and use it to run arbitrary code. By using an intermediate environment variable, the value of the expression is stored in memory, used as a variable and doesn't interact with the script generation process. This mitigates the script injection risks and also keeps your workflow running exactly as before.

You can find more information about this on this [github documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) or in this [gitguardian blogpost](https://blog.gitguardian.com/github-actions-security-cheat-sheet/).

Cheers!