### PR TITLE
Change to JackTools::GetUID() on Windows that fixes metadata

### DIFF
--- a/common/JackTools.cpp
+++ b/common/JackTools.cpp
@@ -69,8 +69,19 @@ namespace Jack {
     int JackTools::GetUID()
     {
 #ifdef WIN32
-        return  _getpid();
-        //#error "No getuid function available"
+        HANDLE tokenHandle = nullptr;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &tokenHandle)) {
+            return 0;
+        }
+
+        TOKEN_STATISTICS tokenStats;
+        DWORD returnLength;
+        if (!GetTokenInformation(tokenHandle, TokenStatistics, &tokenStats, sizeof(tokenStats), &returnLength)) {
+            CloseHandle(tokenHandle);
+            return 0;
+        }
+
+        return(tokenStats.AuthenticationId.LowPart);
 #else
         return geteuid();
 #endif


### PR DESCRIPTION
Change to JackTools::GetUID() on Windows that fixes metadata creating a new BDB on every API call.

JackTools::GetUID() would return the PID of the calling process. (I think this was a stub because there is no Windows equivalent). The linux version appears to return a linux UID. This patch does something similar on Windows so as to create/open the same DB on Windows and metadata now works correctly.