### PR TITLE
Don't include headers within `extern "C"`

### DIFF
--- a/common/driver_interface.h
+++ b/common/driver_interface.h
@@ -21,16 +21,15 @@
 #ifndef __jack_driver_interface_h__
 #define __jack_driver_interface_h__
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <limits.h>
 #include "jslist.h"
 
 #include "JackCompilerDeps.h"
 #include "JackSystemDeps.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define JACK_DRIVER_NAME_MAX          15
 #define JACK_DRIVER_PARAM_NAME_MAX    15

--- a/common/jack/intclient.h
+++ b/common/jack/intclient.h
@@ -20,12 +20,12 @@
 #ifndef __jack_intclient_h__
 #define __jack_intclient_h__
 
+#include <jack/types.h>
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
-#include <jack/types.h>
 
 /**
  * Get an internal client's name.  This is useful when @ref

--- a/common/jack/jack.h
+++ b/common/jack/jack.h
@@ -21,14 +21,15 @@
 #ifndef __jack_h__
 #define __jack_h__
 
+#include <jack/systemdeps.h>
+#include <jack/types.h>
+#include <jack/transport.h>
+#include <jack/weakmacros.h>
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
-#include <jack/systemdeps.h>
-#include <jack/types.h>
-#include <jack/transport.h>
 
 /**
  * Note: More documentation can be found in jack/types.h.
@@ -45,8 +46,6 @@ extern "C"
      * use all JACK symbols with weak linkage, include
      * <jack/weakjack.h> before jack.h.
      *************************************************************/
-
-#include <jack/weakmacros.h>
 
 /**
  * Call this function to get version of the JACK, in form of several numbers

--- a/common/jack/midiport.h
+++ b/common/jack/midiport.h
@@ -21,14 +21,13 @@
 #ifndef __JACK_MIDIPORT_H
 #define __JACK_MIDIPORT_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <jack/weakmacros.h>
 #include <jack/types.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Type for raw event data contained in @ref jack_midi_event_t. */
 typedef unsigned char jack_midi_data_t;

--- a/common/jack/net.h
+++ b/common/jack/net.h
@@ -20,14 +20,13 @@
 #ifndef __net_h__
 #define __net_h__
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <jack/systemdeps.h>
 #include <jack/types.h>
 #include <jack/weakmacros.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define DEFAULT_MULTICAST_IP    "225.3.19.154"
 #define DEFAULT_PORT            19000

--- a/common/jack/ringbuffer.h
+++ b/common/jack/ringbuffer.h
@@ -21,12 +21,11 @@
 #ifndef _RINGBUFFER_H
 #define _RINGBUFFER_H
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @file ringbuffer.h
  *

--- a/common/jack/session.h
+++ b/common/jack/session.h
@@ -21,12 +21,12 @@
 #ifndef __jack_session_h__
 #define __jack_session_h__
 
+#include <jack/types.h>
+#include <jack/weakmacros.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <jack/types.h>
-#include <jack/weakmacros.h>
 
 /**
  * @defgroup SessionClientFunctions Session API for clients.

--- a/common/jack/statistics.h
+++ b/common/jack/statistics.h
@@ -21,12 +21,11 @@
 #ifndef __statistics_h__
 #define __statistics_h__
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <jack/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @return the maximum delay reported by the backend since

--- a/common/jack/thread.h
+++ b/common/jack/thread.h
@@ -20,13 +20,13 @@
 #ifndef __jack_thread_h__
 #define __jack_thread_h__
 
+#include <jack/systemdeps.h>
+#include <jack/weakmacros.h>
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
-#include <jack/systemdeps.h>
-#include <jack/weakmacros.h>
 
 /* use 512KB stack per thread - the default is way too high to be feasible
  * with mlockall() on many systems */

--- a/common/jack/transport.h
+++ b/common/jack/transport.h
@@ -21,12 +21,12 @@
 #ifndef __jack_transport_h__
 #define __jack_transport_h__
 
+#include <jack/types.h>
+#include <jack/weakmacros.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <jack/types.h>
-#include <jack/weakmacros.h>
 
 /**
  * @defgroup TransportControl Transport and Timebase control

--- a/common/netjack_packet.h
+++ b/common/netjack_packet.h
@@ -27,15 +27,14 @@
 #ifndef __JACK_NET_PACKET_H__
 #define __JACK_NET_PACKET_H__
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <jack/jack.h>
 #include <jack/types.h>
 #include <jack/jslist.h>
 #include <jack/midiport.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // The Packet Header.
 

--- a/tests/external_metro.h
+++ b/tests/external_metro.h
@@ -21,11 +21,6 @@
 #ifndef __external_metro__
 #define __external_metro__
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -35,6 +30,10 @@ extern "C"
 #include <string.h>
 #include <jack/jack.h>
 #include <jack/transport.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
     typedef jack_default_audio_sample_t sample_t;
 


### PR DESCRIPTION
Including C headers inside of extern "C" breaks use from C++. Hoist the includes of standard C headers above the block so we don't try to mangle the stdlib.

See https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2377 in PipeWire where they bundle some JACK headers, so came across this.