### PR TITLE
Fix CoreAudio device UID encoding: use kCFStringEncodingUTF8 

### DIFF
--- a/macosx/coreaudio/JackCoreAudioDriver.mm
+++ b/macosx/coreaudio/JackCoreAudioDriver.mm
@@ -225,7 +225,7 @@ static OSStatus DisplayDeviceNames()
         UIname = NULL;
         err = AudioDeviceGetProperty(devices[i], 0, false, kAudioDevicePropertyDeviceUID, &size, &UIname);
         if (err == noErr) {
-            CFStringGetCString(UIname, internal_name, 256, CFStringGetSystemEncoding());
+            CFStringGetCString(UIname, internal_name, 256, kCFStringEncodingUTF8);
         } else {
             goto error;
         }


### PR DESCRIPTION
Fixes https://github.com/jackaudio/jack2/issues/1017

## Change

In `DisplayDeviceNames()`, `macosx/coreaudio/JackCoreAudioDriver.mm` line 228:

```c
// Before:
CFStringGetCString(UIname, internal_name, 256, CFStringGetSystemEncoding());
// After:
CFStringGetCString(UIname, internal_name, 256, kCFStringEncodingUTF8);
```

## Rationale

CFStringGetSystemEncoding() returns kCFStringEncodingMacRoman on most
macOS systems. CoreAudio device UIDs are UTF-8 strings. When a UID contains
non-ASCII characters (e.g. RØDE AI-Micro — Ø = U+00D8, UTF-8 0xC3 0x98),
the bytes are misinterpreted as two separate MacRoman characters, producing
a corrupted internal name that no longer matches what the caller passes via
-C, -P or -d. Jack then silently falls back to the default device.

kCFStringEncodingUTF8 is what CoreAudio uses natively for device UIDs,
so this is the correct encoding to use here.

## Testing
The diagnosis is based on source code analysis and the solution has been validated indirectly: a workaround in
[JackMate](https://github.com/zinc75/JackMate) that re-injects the raw
MacRoman bytes extracted from jackd -d coreaudio -l confirms that the
encoding mismatch is the sole cause of the issue. See https://github.com/jackaudio/jack2/issues/1017
for full reproduction steps.